### PR TITLE
Docs/githubpages 2

### DIFF
--- a/.github/workflows/deploy-github-documentation.yaml
+++ b/.github/workflows/deploy-github-documentation.yaml
@@ -23,3 +23,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: mkdocs.yml
+          REQUIREMENTS: folder/requirements.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Single unique identifier Documentation
+docs_dir: Docs/
 theme:
   name: material
   custom_dir: resources/tech_docs_template


### PR DESCRIPTION
fixes to github pages.

Added docs_dir: /Docs/ so that it knows where to look for docs. Without it, it looks at it's default which is 'docs/' lowercase and it is case sensitive