### PR TITLE
fix: SUI-1668 - use valid storage property names when marking job as completed

### DIFF
--- a/Apps/Find/src/SUI.Find.Infrastructure/Repositories/WorkItemJobCountRepository/WorkItemJobCountRepository.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Repositories/WorkItemJobCountRepository/WorkItemJobCountRepository.cs
@@ -15,7 +15,7 @@ public class WorkItemJobCountRepository : IWorkItemJobCountRepository, ITableSer
         .StorageTableWorkItemJobCountRepository
         .TableName;
 
-    private const string JobCompletedPrefix = "_job-completed-";
+    private const string JobCompletedPrefix = "__job_completed_";
 
     public WorkItemJobCountRepository(
         TableServiceClient client,
@@ -74,7 +74,7 @@ public class WorkItemJobCountRepository : IWorkItemJobCountRepository, ITableSer
 
         var entity = new TableEntity(partitionKey, rowKey)
         {
-            { $"{JobCompletedPrefix}{jobId}", DateTimeOffset.UtcNow },
+            { $"{JobCompletedPrefix}{jobId.Replace("-", "_")}", DateTimeOffset.UtcNow },
         };
 
         await Table.UpsertEntityAsync(entity, TableUpdateMode.Merge, cancellationToken);
@@ -112,7 +112,7 @@ public class WorkItemJobCountRepository : IWorkItemJobCountRepository, ITableSer
 
                 var completedJobIds = entity
                     .Keys.Where(key => key.StartsWith(JobCompletedPrefix))
-                    .Select(key => key[JobCompletedPrefix.Length..])
+                    .Select(key => key[JobCompletedPrefix.Length..].Replace("_", "-"))
                     .ToFrozenSet();
 
                 result = new WorkItemJobCount

--- a/Apps/Find/tests/SUI.Find.Infrastructure.IntegrationTests/Repositories/WorkItemJobCountRepositoryTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.IntegrationTests/Repositories/WorkItemJobCountRepositoryTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging.Abstractions;
 using SUI.Find.Application.Enums;
@@ -5,7 +6,7 @@ using SUI.Find.Infrastructure.Repositories.WorkItemJobCountRepository;
 
 namespace SUI.Find.Infrastructure.IntegrationTests.Repositories;
 
-public class WorkItemJobCountRepositoryTests : IAsyncLifetime
+public partial class WorkItemJobCountRepositoryTests : IAsyncLifetime
 {
     private readonly WorkItemJobCountRepository _sut = new(
         TableStorageFixture.Client,
@@ -253,5 +254,26 @@ public class WorkItemJobCountRepositoryTests : IAsyncLifetime
         result.WorkItemId.Should().Be(workItemId);
         result.CompletedJobIds.Should().HaveCount(100);
         result.CompletedJobIds.Should().BeEquivalentTo(testCompletedJobIds);
+
+        // Verify that all the properties of the storage entry have valid names
+        var partitionKey = WorkItemJobCountKeys.PartitionKey(workItemId);
+        var rowKey = WorkItemJobCountKeys.RowKey(jobType);
+        var tableClient = TableStorageFixture.Client.GetTableClient(
+            InfrastructureConstants.StorageTableWorkItemJobCountRepository.TableName
+        );
+        var stored = await tableClient.GetEntityAsync<TableEntity>(partitionKey, rowKey);
+
+        stored
+            .Value.Keys.Where(key => !key.StartsWith("odata"))
+            .Should()
+            .AllSatisfy(key =>
+                ValidIdentifierRegex()
+                    .IsMatch(key)
+                    .Should()
+                    .BeTrue($"the storage property name {key} should be a valid identifier")
+            );
     }
+
+    [GeneratedRegex(@"^[a-zA-Z_]\w+$")]
+    private static partial Regex ValidIdentifierRegex();
 }


### PR DESCRIPTION
Use valid Azure Table Storage property names when marking job as completed, fixes `PropertyNameInvalid` error in deployed environments (SUI-1668).