### PR TITLE
feat: SUI-1671 - improve e2e test reliability immediately after deployment of the Stub Custodians

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -181,8 +181,8 @@ jobs:
             -e E2E__BaseUrl=http://localhost:7182/api/ \
             -e E2E__StubCustodiansBaseUrl=http://localhost:5193/api/ \
             -e E2E__SkipResetAzureTables=False \
-            -e E2E__UseExtendedFindApiHealthCheckTimeout=False \
-            -e E2E__CheckFindApiBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} # This threshold check is not necessary for ephemeral e2e tests, but is included to verify the threshold behaviour at pull request stage
+            -e E2E__UseExtendedHealthCheckTimeout=False \
+            -e E2E__CheckBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} # This threshold check is not necessary for ephemeral e2e tests, but is included to verify the threshold behaviour at pull request stage
 
       - name: Publish E2E test summary (ephemeral)
         if: always()
@@ -227,8 +227,8 @@ jobs:
             -e E2E__BaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}func-${{ steps.env_config.outputs.region_short }}-find01.azurewebsites.net/api/ \
             -e E2E__StubCustodiansBaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-custodians01.azurewebsites.net/api/ \
             -e E2E__SkipResetAzureTables=True \
-            -e E2E__UseExtendedFindApiHealthCheckTimeout=True \
-            -e E2E__CheckFindApiBuildTimestampThreshold=${{ github.event.workflow_run.run_started_at }} # We pass the run_started_at value so that we ensure the FindAPI has restarted with the latest version. Note that this will pass null if this pipeline was not trigerred by a workflow_run, but that is fine and desired in that case (because we only need the check when this pipeline is immediately trigerred by the workflow_run after deployment)
+            -e E2E__UseExtendedHealthCheckTimeout=True \
+            -e E2E__CheckBuildTimestampThreshold=${{ github.event.workflow_run.run_started_at }} # We pass the run_started_at value so that we ensure the FindAPI has restarted with the latest version. Note that this will pass null if this pipeline was not trigerred by a workflow_run, but that is fine and desired in that case (because we only need the check when this pipeline is immediately trigerred by the workflow_run after deployment)
 
       - name: Publish E2E test summary (dev)
         if: always()

--- a/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
@@ -18,7 +18,7 @@ public record Config
 
     public string? PreviousFindApiKey { get; init; }
 
-    public bool UseExtendedFindApiHealthCheckTimeout { get; init; } = false;
+    public bool UseExtendedHealthCheckTimeout { get; init; } = false;
 
-    public DateTimeOffset? CheckFindApiBuildTimestampThreshold { get; init; }
+    public DateTimeOffset? CheckBuildTimestampThreshold { get; init; }
 }

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -50,16 +50,17 @@ public class FunctionTestFixture : ICollectionFixture<FunctionTestFixture>, IDis
 
     private record HealthCheckResponse(string? Value, DateTimeOffset? BuildTimestamp);
 
+    private TimeSpan HealthCheckTimeout =>
+        Config.UseExtendedHealthCheckTimeout ? TimeSpan.FromMinutes(10) : TimeSpan.FromSeconds(60);
+
     public async Task EnsureFindApiIsUpAsync(ITestOutputHelper testOutputHelper)
     {
         await EnsureServiceIsUpAsync(
             "Find API",
             Client,
             testOutputHelper,
-            timeout: Config.UseExtendedFindApiHealthCheckTimeout
-                ? TimeSpan.FromMinutes(10)
-                : TimeSpan.FromSeconds(60),
-            checkBuildTimestampThreshold: Config.CheckFindApiBuildTimestampThreshold
+            timeout: HealthCheckTimeout,
+            checkBuildTimestampThreshold: Config.CheckBuildTimestampThreshold
         );
     }
 
@@ -69,7 +70,8 @@ public class FunctionTestFixture : ICollectionFixture<FunctionTestFixture>, IDis
             "StubCustodians API",
             StubCustodiansClient,
             testOutputHelper,
-            timeout: TimeSpan.FromSeconds(60)
+            timeout: HealthCheckTimeout,
+            checkBuildTimestampThreshold: Config.CheckBuildTimestampThreshold
         );
     }
 

--- a/Apps/StubCustodians/src/SUI.StubCustodians.API/Controllers/HealthController.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.API/Controllers/HealthController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using SUI.StubCustodians.API.Utility;
 
 namespace SUI.StubCustodians.API.Controllers;
 
@@ -24,6 +25,7 @@ public class HealthController(IHostEnvironment env, ILogger<AuthController> logg
             env.EnvironmentName,
             nowUtc = DateTimeOffset.UtcNow,
             nowLocal = DateTimeOffset.Now,
+            BuildTimestampUtility.BuildTimestamp,
         };
     }
 }

--- a/Apps/StubCustodians/src/SUI.StubCustodians.API/SUI.StubCustodians.API.csproj
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.API/SUI.StubCustodians.API.csproj
@@ -25,4 +25,7 @@
     <ProjectReference Include="..\SUI.Custodians.Domain\SUI.Custodians.Domain.csproj" />
     <ProjectReference Include="..\SUI.StubCustodians.Infrastructure\SUI.StubCustodians.Infrastructure.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <SourceRevisionId>timestamp_$([System.DateTimeOffset]::UtcNow.ToString("O"))</SourceRevisionId>
+  </PropertyGroup>
 </Project>

--- a/Apps/StubCustodians/src/SUI.StubCustodians.API/Utility/BuildTimestampUtility.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.API/Utility/BuildTimestampUtility.cs
@@ -1,0 +1,32 @@
+﻿using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace SUI.StubCustodians.API.Utility;
+
+public static partial class BuildTimestampUtility
+{
+    public static DateTimeOffset BuildTimestamp { get; } = ExtractBuildTimestampFromAssembly();
+
+    private static DateTimeOffset ExtractBuildTimestampFromAssembly()
+    {
+        // Note: `SourceRevisionId` must be set as expected in assembly's project file
+        var match = ExtractBuildTimestampRegex()
+            .Match(
+                typeof(BuildTimestampUtility)
+                    .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion
+                    ?? ""
+            );
+
+        return DateTimeOffset.ParseExact(
+            match.Groups["timestamp"].Value,
+            "O",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal
+        );
+    }
+
+    [GeneratedRegex(@"\+timestamp_(?<timestamp>.+)")]
+    private static partial Regex ExtractBuildTimestampRegex();
+}

--- a/Apps/StubCustodians/tests/SUI.StubCustodians.API.Unit.Tests/SUI.StubCustodians.API.Unit.Tests.csproj
+++ b/Apps/StubCustodians/tests/SUI.StubCustodians.API.Unit.Tests/SUI.StubCustodians.API.Unit.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/Apps/StubCustodians/tests/SUI.StubCustodians.API.Unit.Tests/Utility/BuildTimestampUtilityTests.cs
+++ b/Apps/StubCustodians/tests/SUI.StubCustodians.API.Unit.Tests/Utility/BuildTimestampUtilityTests.cs
@@ -1,0 +1,17 @@
+﻿using Shouldly;
+using SUI.StubCustodians.API.Utility;
+using Xunit.Abstractions;
+
+namespace SUI.StubCustodians.API.Unit.Tests.Utility;
+
+public class BuildTimestampUtilityTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void BuildTimestamp_Should_BeAGeneratedDateTime()
+    {
+        testOutputHelper.WriteLine($"BuildTimestamp: {BuildTimestampUtility.BuildTimestamp:O}");
+
+        BuildTimestampUtility.BuildTimestamp.ShouldBeGreaterThan(DateTimeOffset.MinValue);
+        BuildTimestampUtility.BuildTimestamp.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
+    }
+}


### PR DESCRIPTION
## Summary
This is the same change as commit 0a5599a1470f39169bd904a03808f128c3c55a04, but just for the Stubs rather than Find.  It updates the e2e tests to wait for the latest version of the Stubs to be deployed and started before the tests commence.

## Changes
The changes in this PR ensure that the e2e tests wait for the new version of the Stubs to be deployed and up and running.  Rather than wait for an arbitrary period of time (which could wait for too long unnecessarily), it waits until the API responds with a build timestamp which is on or after a known point in time that confirms the latest version is in use.

### Context and background info:
The e2e tests falsely fail when they are automatically ran after deployment of the Stubs.  They fail because the e2e tests run immediately after deployment, at which point the previously deployed version of the Stubs reports that is is up and healthy because the new deployment hasn’t started yet.  Once the new version of the Stubs is deployed and restarts, the API then temporarily times-out, and after a non-determinate period of time the new version of the app is up and healthy.   By waiting for this new version to be up before running the e2e tests, we ensure we are running against the latest version and that we won't get false failures from temporary timeouts caused by the deployment.

## Validation
- Unit, integration, E2E tests complete successfully locally
- E2E tests workflow passes against ephemeral environment, as part of PR validation