### PR TITLE
fix: SUI-1671 - proactive fix to improve e2e test reliability for runs immediately after deployment of Find or Stubs

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -95,6 +95,7 @@ jobs:
 
           echo "---- GitHub Context Info: ----"
           echo "github.event_name: ${{ github.event_name || '(no value)' }}"
+          echo "github.event.workflow_run.name: ${{ github.event.workflow_run.name || '(no value)' }}"
           echo "github.event.workflow_run.event: ${{ github.event.workflow_run.event || '(no value)' }}"
           echo "github.event.workflow_run.conclusion: ${{ github.event.workflow_run.conclusion || '(no value)' }}"
           echo "github.event.workflow_run.head_branch: ${{ github.event.workflow_run.head_branch || '(no value)' }}"
@@ -181,8 +182,8 @@ jobs:
             -e E2E__BaseUrl=http://localhost:7182/api/ \
             -e E2E__StubCustodiansBaseUrl=http://localhost:5193/api/ \
             -e E2E__SkipResetAzureTables=False \
-            -e E2E__UseExtendedHealthCheckTimeout=False \
-            -e E2E__CheckBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} # This threshold check is not necessary for ephemeral e2e tests, but is included to verify the threshold behaviour at pull request stage
+            -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} \
+            -e E2E__CheckFindApiBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} # The threshold checks are not necessary for ephemeral e2e tests, but are included to verify the threshold behaviour at pull request stage
 
       - name: Publish E2E test summary (ephemeral)
         if: always()
@@ -227,8 +228,8 @@ jobs:
             -e E2E__BaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}func-${{ steps.env_config.outputs.region_short }}-find01.azurewebsites.net/api/ \
             -e E2E__StubCustodiansBaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-custodians01.azurewebsites.net/api/ \
             -e E2E__SkipResetAzureTables=True \
-            -e E2E__UseExtendedHealthCheckTimeout=True \
-            -e E2E__CheckBuildTimestampThreshold=${{ github.event.workflow_run.run_started_at }} # We pass the run_started_at value so that we ensure the FindAPI has restarted with the latest version. Note that this will pass null if this pipeline was not trigerred by a workflow_run, but that is fine and desired in that case (because we only need the check when this pipeline is immediately trigerred by the workflow_run after deployment)
+            -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Custodian') && github.event.workflow_run.run_started_at || '' }} \
+            -e E2E__CheckFindApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Find') && github.event.workflow_run.run_started_at || '' }} # We pass the run_started_at value(s) so that we ensure the relevant API has restarted with the latest version. Note that this will pass an empty value if this pipeline was not trigerred by a workflow_run for that specific API, but that is fine and desired in that case (because we only need the check when this pipeline is immediately trigerred by the workflow_run after deployment of that specific API)
 
       - name: Publish E2E test summary (dev)
         if: always()

--- a/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
@@ -18,7 +18,7 @@ public record Config
 
     public string? PreviousFindApiKey { get; init; }
 
-    public bool UseExtendedHealthCheckTimeout { get; init; } = false;
+    public DateTimeOffset? CheckFindApiBuildTimestampThreshold { get; init; }
 
-    public DateTimeOffset? CheckBuildTimestampThreshold { get; init; }
+    public DateTimeOffset? CheckStubCustodiansApiBuildTimestampThreshold { get; init; }
 }

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -50,17 +50,13 @@ public class FunctionTestFixture : ICollectionFixture<FunctionTestFixture>, IDis
 
     private record HealthCheckResponse(string? Value, DateTimeOffset? BuildTimestamp);
 
-    private TimeSpan HealthCheckTimeout =>
-        Config.UseExtendedHealthCheckTimeout ? TimeSpan.FromMinutes(10) : TimeSpan.FromSeconds(60);
-
     public async Task EnsureFindApiIsUpAsync(ITestOutputHelper testOutputHelper)
     {
         await EnsureServiceIsUpAsync(
             "Find API",
             Client,
             testOutputHelper,
-            timeout: HealthCheckTimeout,
-            checkBuildTimestampThreshold: Config.CheckBuildTimestampThreshold
+            checkBuildTimestampThreshold: Config.CheckFindApiBuildTimestampThreshold
         );
     }
 
@@ -70,8 +66,7 @@ public class FunctionTestFixture : ICollectionFixture<FunctionTestFixture>, IDis
             "StubCustodians API",
             StubCustodiansClient,
             testOutputHelper,
-            timeout: HealthCheckTimeout,
-            checkBuildTimestampThreshold: Config.CheckBuildTimestampThreshold
+            checkBuildTimestampThreshold: Config.CheckStubCustodiansApiBuildTimestampThreshold
         );
     }
 
@@ -87,7 +82,6 @@ public class FunctionTestFixture : ICollectionFixture<FunctionTestFixture>, IDis
         string serviceName,
         HttpClient client,
         ITestOutputHelper testOutputHelper,
-        TimeSpan timeout,
         DateTimeOffset? checkBuildTimestampThreshold = null
     )
     {
@@ -95,6 +89,9 @@ public class FunctionTestFixture : ICollectionFixture<FunctionTestFixture>, IDis
         var waitInterval = TimeSpan.FromSeconds(10);
 
         testOutputHelper.WriteLine($"Checking {serviceName} is up: {client.BaseAddress}{url}");
+
+        var useExtendedTimeout = checkBuildTimestampThreshold != null;
+        var timeout = useExtendedTimeout ? TimeSpan.FromMinutes(10) : TimeSpan.FromSeconds(60);
 
         // If health check does not indicate healthy, wait and then retry
         var retryCount = (int)Math.Round(timeout / waitInterval);


### PR DESCRIPTION
## Summary

The changes in this PR proactively fix an issue that would cause the e2e tests to fail falsely in the scenario where either the FindAPI or Stubs have changed, but not both.  In this scenario, which is the more common scenario, we should only check the build timestamp of the component that has changed, not both the timestamps.  Because the timestamp of the unchanged component will be correctly older than the threshold.

## Changes

- Separated the build timestamp threshold checks, and only check them if the corresponding component is the one that has changed
- Updated the timeout to be derived from whether a threshold check is required, rather than relying on the value being passed in

## Validation
- Unit, integration, E2E tests complete successfully locally
- E2E tests workflow passes against ephemeral environment, as part of PR
validation