### PR TITLE
fix: SUI-1688 - added missing response bodies to generated OpenAPI spec

### DIFF
--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/RenewLeaseFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/RenewLeaseFunction.cs
@@ -25,6 +25,22 @@ public class RenewLeaseFunction(
         tags: ["Work"],
         Summary = "Renew the lease on a job"
     )]
+    [OpenApiResponseWithBody(
+        statusCode: HttpStatusCode.OK,
+        contentType: "application/json",
+        bodyType: typeof(RenewJobLeaseResponse),
+        Summary = "Lease was successfully extended."
+    )]
+    [OpenApiResponseWithoutBody(
+        statusCode: HttpStatusCode.NoContent,
+        Summary = "Lease was not extended. Either the job does not exist, or it is completed, or its lease has already expired, or the requested Lease ID did not match."
+    )]
+    [OpenApiResponseWithBody(
+        statusCode: HttpStatusCode.BadRequest,
+        contentType: "application/json",
+        bodyType: typeof(Problem),
+        Summary = "Invalid request. The request body is missing or malformed."
+    )]
     [RequiredScopes("work-item.write")]
     [Function(nameof(RenewLease))]
     public async Task<HttpResponseData> RenewLease(

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
@@ -22,6 +22,14 @@ public class WorkAvailableFunction(
         tags: ["Work"],
         Summary = "Check if work is available. Optional, the claim endpoint remains authoritative."
     )]
+    [OpenApiResponseWithoutBody(
+        statusCode: HttpStatusCode.OK,
+        Summary = "Work is available. There is at least one job waiting to be worked on."
+    )]
+    [OpenApiResponseWithoutBody(
+        statusCode: HttpStatusCode.NoContent,
+        Summary = "No work available. There are no jobs waiting to be worked on."
+    )]
     [RequiredScopes("work-item.read")]
     [Function(nameof(WorkAvailable))]
     public async Task<HttpResponseData> WorkAvailable(
@@ -61,12 +69,12 @@ public class WorkAvailableFunction(
             authContext.ClientId
         );
 
-        var result = await jobClaimService.DoesCustodianHaveJobs(
+        var hasJobs = await jobClaimService.DoesCustodianHaveJobs(
             authContext.ClientId,
             cancellationToken
         );
 
-        return result
+        return hasJobs
             ? HttpResponseUtility.OkResponse(req)
             : HttpResponseUtility.NoContentResponse(req);
     }


### PR DESCRIPTION
## Summary

Investigating how the DfE Find and Use an API (FaUAPI) service works identified some missing response bodies in our generated OpenAPI spec.

## Changes

- Added the response bodies to the applicable endpoints
- Minor change: renamed the boolean variable from `result` to `hasJobs`, to improve code readability.

## Validation

- Unit/integration/E2E tests run
- Generated OpenAPI spec manually uploaded to FaUAPI, and was successfully imported