### PR TITLE
feat: SUI-1665: update UI Test Harness to use the auth-clients-inbound.json approach

### DIFF
--- a/.github/workflows/custodians-build-and-deploy.yml
+++ b/.github/workflows/custodians-build-and-deploy.yml
@@ -45,11 +45,13 @@ on:
       - main
     paths:
       - "Apps/StubCustodians/**"
+      - "Data/**"
   pull_request:
     branches:
       - main
     paths:
       - "Apps/StubCustodians/**"
+      - "Data/**"
 
 jobs:
   build-and-test-StubCustodians:

--- a/.github/workflows/find-build-and-deploy.yml
+++ b/.github/workflows/find-build-and-deploy.yml
@@ -45,11 +45,13 @@ on:
       - main
     paths:
       - "Apps/Find/**"
+      - "Data/**"
   pull_request:
     branches:
       - main
     paths:
       - "Apps/Find/**"
+      - "Data/**"
 
 jobs:
   build-and-test-Find:

--- a/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
@@ -128,7 +128,7 @@ public abstract class SearchTestsBase(
             {
                 EncryptedSui = "ZBLNLdIppgMge_MmzVImmA",
                 Sui = "9691292211",
-                TestClientId = "FAUX-01",
+                TestClientId = "NO-DSA-01",
                 Records = [],
             },
         ];

--- a/Apps/StubCustodians/src/SUI.StubCustodians.API/Data/no-dsa-01.custodian.json
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.API/Data/no-dsa-01.custodian.json
@@ -1,5 +1,5 @@
 {
-  "orgId": "FAUX-01",
+  "orgId": "NO-DSA-01",
   "orgName": "Faux Organisation for Negative Testing",
   "orgType": "FAUX",
   "records": []

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/EnrolTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/EnrolTab.razor
@@ -14,8 +14,9 @@
     @if (ShowEnrolProgress)
     {
         <div id="enrolProgressWrap" class="mb-3">
-            <div class="d-flex justify-content-between align-items-center mb-1">
-                <span class="text-muted">Processing</span>
+            <div class="d-flex justify-content-start align-items-center mb-1">
+                <div class="spinner-border spinner-border-sm text-primary me-1" role="status"></div>
+                <span class="text-muted">Enrolling...</span>
                 <span id="enrolProgressText" class="text-muted"></span>
             </div>
             <div class="progress" role="progressbar" aria-label="Enrolment progress">

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FetchTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FetchTab.razor
@@ -13,8 +13,9 @@
 @if (_showFetchProgress)
 {
     <div id="fetchProgressWrap" class="mb-3">
-        <div class="d-flex justify-content-between align-items-center mb-1">
-            <span class="text-muted">Retrieving record</span>
+        <div class="d-flex justify-content-start align-items-center mb-1">
+            <div class="spinner-border spinner-border-sm text-primary me-1" role="status"></div>
+            <span class="text-muted">Retrieving record...</span>
             <span id="fetchProgressText" class="text-muted"></span>
         </div>
         <div class="progress" role="progressbar" aria-label="Fetch record progress">

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
@@ -114,12 +114,20 @@
         _foundRecordsFor = null;
         _findProgressPercentage = 0;
         _showFindProgress = true;
+        var currentNhsNumber = CurrentPerson.NhsNumber;
         var usePolling = Architecture == "Polling";
         var searchJob = await FindService.StartSearch(SelectedOrg, CurrentPerson.NhsNumber, usePolling);
         var keepPolling = true;
         const int percentToAdd = 10;
+        while (keepPolling && !HasCurrentNhsNumberChanged())
         {
             var result = await FindService.FindRecords(SelectedOrg, searchJob, usePolling);
+
+            if (HasCurrentNhsNumberChanged())
+            {
+                break;
+            }
+
             if (usePolling)
             {
                 _findProgressPercentage = result.CompletenessPercentage;
@@ -156,6 +164,9 @@
         }
 
         _showFindProgress = false;
+        return;
+
+        bool HasCurrentNhsNumberChanged() => currentNhsNumber != CurrentPerson?.NhsNumber;
     }
 
     private async Task SetCurrentRecord(LocalRecord localRecord)

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
@@ -28,7 +28,7 @@
             <span id="findRecordsProgressText" class="text-muted"></span>
         </div>
         <div class="progress" role="progressbar" aria-label="Find records progress">
-            <div id="findRecordsProgressBar" class="progress-bar progress-bar-striped progress-bar-animated" style="width:@(_findProgress)%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+            <div id="findRecordsProgressBar" class="progress-bar progress-bar-striped progress-bar-animated" style="width:@(_findProgressPercentage)%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
         </div>
     </div>
 }
@@ -96,7 +96,7 @@
     public EventCallback<LocalRecord> CurrentRecordChanged { get; set; }
 
     private bool _showFindProgress;
-    private int _findProgress;
+    private int _findProgressPercentage;
     private readonly List<LocalRecord> _foundRecords = [];
     private (string? Org, string? NhsNumber)? _foundRecordsFor;
     
@@ -109,26 +109,24 @@
         {
             return;
         }
-        
+
         _foundRecords.Clear();
         _foundRecordsFor = null;
-        _findProgress = 0;
+        _findProgressPercentage = 0;
         _showFindProgress = true;
         var usePolling = Architecture == "Polling";
         var searchJob = await FindService.StartSearch(SelectedOrg, CurrentPerson.NhsNumber, usePolling);
         var keepPolling = true;
-        var pollingCount = 1;
-        var percentToAdd = 10;
-        while (keepPolling)
+        const int percentToAdd = 10;
         {
             var result = await FindService.FindRecords(SelectedOrg, searchJob, usePolling);
             if (usePolling)
             {
-                _findProgress = result.CompletenessPercentage;
+                _findProgressPercentage = result.CompletenessPercentage;
             }
             else
             {
-                _findProgress += percentToAdd;
+                _findProgressPercentage += percentToAdd;
             }
 
             StateHasChanged();
@@ -147,13 +145,14 @@
                 StateHasChanged();
             }
             
-            pollingCount++;
-            if (pollingCount >= 10 || result.Status == FindSearchStatus.Completed)
+            if (_findProgressPercentage >= 100 || result.Status == FindSearchStatus.Completed)
             {
                 keepPolling = false;
             }
-            
-            await Task.Delay(2000);
+            else
+            {
+                await Task.Delay(2000);
+            }
         }
 
         _showFindProgress = false;

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
@@ -22,8 +22,9 @@
 @if (_showFindProgress)
 {
     <div id="findRecordsProgressWrap" class="mb-3">
-        <div class="d-flex justify-content-between align-items-center mb-1">
-            <span class="text-muted">Searching custodians</span>
+        <div class="d-flex justify-content-start align-items-center mb-1">
+            <div class="spinner-border spinner-border-sm text-primary me-1" role="status"></div>
+            <span class="text-muted">Searching custodians...</span>
             <span id="findRecordsProgressText" class="text-muted"></span>
         </div>
         <div class="progress" role="progressbar" aria-label="Find records progress">

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Pages/Login.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Pages/Login.razor
@@ -1,4 +1,6 @@
 @page "/login"
+@using SUI.UIHarness.Web.Services
+@inject IFindApiAuthClientProvider FindApiAuthClientProvider
 
 <PageTitle>Login</PageTitle>
 
@@ -12,11 +14,10 @@
                     <label for="custodianName" class="form-label">Custodian Name</label>
                     <select id="custodianName" name="custodianName" class="form-select" required>
                         <option value="">Select...</option>
-                        <option value="LOCAL-AUTHORITY-01">LOCAL-AUTHORITY-01</option>
-                        <option value="EDUCATION-01">EDUCATION-01</option>
-                        <option value="HEALTH-01">HEALTH-01</option>
-                        <option value="POLICE-01">POLICE-01</option>
-                        <option value="HOUSING-01">HOUSING-01</option>
+                        @foreach (var authClient in FindApiAuthClientProvider.GetAuthClients().Where(x => x.Enabled))
+                        {
+                            <option key="@authClient.ClientId" value="@authClient.ClientId">@authClient.ClientId</option>
+                        }
                     </select>
                 </div>
                 <div class="mb-3">

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Models/AuthClient.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Models/AuthClient.cs
@@ -1,0 +1,3 @@
+﻿namespace SUI.UIHarness.Web.Models;
+
+public record AuthClient(string ClientId, string ClientSecret, bool Enabled);

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddHttpClient(
     client => client.BaseAddress = new Uri(builder.Configuration["BaseUrl"] + "api/")
 );
 builder.Services.AddScoped<IFindService, FindService>();
+builder.Services.AddScoped<IFindApiAuthClientProvider, FindApiAuthClientProvider>();
 
 var app = builder.Build();
 

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/SUI.UIHarness.Web.csproj
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/SUI.UIHarness.Web.csproj
@@ -5,4 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\..\..\Data\auth-clients-inbound.json">
+      <Link>Data\auth-clients-inbound.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindApiAuthClientProvider.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindApiAuthClientProvider.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json;
+using SUI.UIHarness.Web.Models;
+
+namespace SUI.UIHarness.Web.Services;
+
+public class FindApiAuthClientProvider : IFindApiAuthClientProvider
+{
+    private readonly Lazy<IReadOnlyList<AuthClient>> _authClients = new(Load);
+
+    public IReadOnlyList<AuthClient> GetAuthClients() => _authClients.Value;
+
+    private static AuthClient[] Load()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Data", "auth-clients-inbound.json");
+
+        if (!File.Exists(path))
+        {
+            throw new InvalidOperationException($"auth-clients-inbound.json not found: {path}");
+        }
+
+        var json = File.ReadAllText(path);
+
+        var data =
+            JsonSerializer.Deserialize<AuthStore>(json, JsonSerializerOptions.Web)
+            ?? throw new InvalidOperationException("Invalid auth-clients-inbound.json");
+
+        return data.Clients ?? [];
+    }
+
+    private record AuthStore(AuthClient[]? Clients);
+}

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindService.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindService.cs
@@ -9,9 +9,9 @@ public class FindService : IFindService
 {
     private readonly JsonSerializerOptions _serializerSettings = new(JsonSerializerDefaults.Web);
     private readonly HttpClient _httpClient;
+    private readonly IFindApiAuthClientProvider _authClientProvider;
     private readonly ILogger<FindService> _logger;
     private const string? FindApiKey = "local-dev-key-change-me";
-    private const string TestClientSecret = "SUIProject";
     private static readonly string[] Scopes =
     [
         "match-record.read",
@@ -21,15 +21,20 @@ public class FindService : IFindService
         "fetch-record.read",
     ];
 
-    public FindService(IHttpClientFactory httpClientFactory, ILogger<FindService> logger)
+    public FindService(
+        IHttpClientFactory httpClientFactory,
+        IFindApiAuthClientProvider authClientProvider,
+        ILogger<FindService> logger
+    )
     {
         _httpClient = httpClientFactory.CreateClient(nameof(FindService));
+        _authClientProvider = authClientProvider;
         _logger = logger;
     }
 
     public async Task<FindMatchResult> MatchRecord(LocalPerson person, string clientId)
     {
-        await GetAuthTokenAsync(clientId, TestClientSecret, Scopes);
+        await GetAuthTokenAsync(clientId, Scopes);
         var request = new FindMatchRequest
         {
             Metadata = [],
@@ -57,7 +62,7 @@ public class FindService : IFindService
         }
         catch (Exception exception)
         {
-            _logger.LogError(exception, exception.Message);
+            _logger.LogError(exception, "MatchRecord failed: {Message}", exception.Message);
         }
 
         return new FindMatchResult("Not Found");
@@ -65,7 +70,7 @@ public class FindService : IFindService
 
     public async Task<string> StartSearch(string clientId, string suid, bool usePolling)
     {
-        await GetAuthTokenAsync(clientId, TestClientSecret, Scopes);
+        await GetAuthTokenAsync(clientId, Scopes);
 
         try
         {
@@ -98,7 +103,7 @@ public class FindService : IFindService
         }
         catch (Exception exception)
         {
-            _logger.LogError(exception, exception.Message);
+            _logger.LogError(exception, "StartSearch failed: {Message}", exception.Message);
         }
 
         return string.Empty;
@@ -106,7 +111,7 @@ public class FindService : IFindService
 
     public async Task<SearchResultsDto> FindRecords(string clientId, string jobId, bool usePolling)
     {
-        await GetAuthTokenAsync(clientId, TestClientSecret, Scopes);
+        await GetAuthTokenAsync(clientId, Scopes);
 
         try
         {
@@ -145,15 +150,15 @@ public class FindService : IFindService
         }
         catch (Exception exception)
         {
-            _logger.LogError(exception, exception.Message);
+            _logger.LogError(exception, "FindRecords failed: {Message}", exception.Message);
         }
 
-        return null;
+        return new SearchResultsDto("FindRecords failed", FindSearchStatus.Failed, [], 0);
     }
 
     public async Task<FindCustodianRecord?> FetchRecord(string clientId, string recordId)
     {
-        await GetAuthTokenAsync(clientId, TestClientSecret, Scopes);
+        await GetAuthTokenAsync(clientId, Scopes);
 
         try
         {
@@ -169,13 +174,13 @@ public class FindService : IFindService
         }
         catch (Exception exception)
         {
-            _logger.LogError(exception, exception.Message);
+            _logger.LogError(exception, "FetchRecord failed: {Message}", exception.Message);
         }
 
         return null;
     }
 
-    private async Task GetAuthTokenAsync(string clientId, string clientSecret, string[] scopes)
+    private async Task GetAuthTokenAsync(string clientId, string[] scopes)
     {
         var formData = new Dictionary<string, string>
         {
@@ -189,6 +194,11 @@ public class FindService : IFindService
         {
             Content = content,
         };
+
+        var clientSecret = _authClientProvider
+            .GetAuthClients()
+            .First(x => x.ClientId == clientId)
+            .ClientSecret;
 
         var authString = $"{clientId}:{clientSecret}";
         var base64Auth = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(authString));

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Services/IFindApiAuthClientProvider.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Services/IFindApiAuthClientProvider.cs
@@ -1,0 +1,8 @@
+﻿using SUI.UIHarness.Web.Models;
+
+namespace SUI.UIHarness.Web.Services;
+
+public interface IFindApiAuthClientProvider
+{
+    IReadOnlyList<AuthClient> GetAuthClients();
+}

--- a/Data/auth-clients-inbound.json
+++ b/Data/auth-clients-inbound.json
@@ -76,7 +76,7 @@
     },
     {
       "enabled": true,
-      "clientId": "FAUX-01",
+      "clientId": "NO-DSA-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
         "match-record.read",

--- a/Data/org-directory.json
+++ b/Data/org-directory.json
@@ -270,7 +270,7 @@
     },
 
     {
-      "orgId": "FAUX-01",
+      "orgId": "NO-DSA-01",
       "orgName": "Faux Organisation for Negative Testing",
       "orgType": "FAUX",
       "records": [
@@ -278,7 +278,7 @@
           "recordType": "personal.details",
           "connection": {
             "method": "GET",
-            "url": "{StubCustodiansBaseUrl}/api/v1/find/faux-01/{personId}?recordType=personal.details",
+            "url": "{StubCustodiansBaseUrl}/api/v1/find/no-dsa-01/{personId}?recordType=personal.details",
             "personIdPosition": "path",
             "auth": {
               "type": "oauth2_client_credentials",
@@ -297,7 +297,7 @@
       },
       "encryption": {
         "algorithm": "AES-256-CBC",
-        "keyId": "FAUX-01-KEY-1",
+        "keyId": "NO-DSA-01-KEY-1",
         "key": "bUdQfUlY7h81Pn8+TOSGCBkAXgxgVUOaLU1lka3leQM="
       }
     }


### PR DESCRIPTION
## Summary

Updates the UI Test Harness to dynamically include the registered Custodians, and their authentication details; so that there are less hard coded places to update, and to ease migration to a more production ready Authentication approach.  Relates to SUI-1665.

## Changes

- Updated to use the `Data/auth-clients-inbound.json` file and approach, like is done already in the `StubCustodians`.
- Updated the UI Test Harness’ list of “Custodians to simulate” so that it is populated from the data file.
- Updated the UI Test Harness’ token generation ultimately uses the credentials from the data file.
- Updated relevant GitHub workflows to be triggered on the `Data` directory too.

Also includes related fixes/improvements:
* Updated UI Test Harness to include loading spinners, to indicate work is being done (the progress bar can stay at 0% for a while, especially when using the Polling architecture, so the spinner provides more confidence that something is being done).
* Fixed the UI Test Harness' Find exit condition to stop when the percentage reaches 100% or the job becomes completed, rather than being capped at 10 steps.  Fixes issue whereby using the Polling Architecture would not correctly find all the expected records, because it usually takes longer than 10 steps.
* Fixed the UI Test Harness's Find Records process so that it breaks out if the NHS number changes.  Fixes issues whereby the background async process keeps running even if the user switches tab and chooses a different person, which would previously incorrectly cause records from the old process to be added to the new process.

## Validation

- Manual UI validation and testing.