### PR TITLE
feat(find): sui-1694 - Include TraceParent in PEP auditing

### DIFF
--- a/Apps/Find/src/SUI.Find.Application/Services/PepFilterInput.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/PepFilterInput.cs
@@ -20,6 +20,7 @@ public record PepFilterInput<TItem>(
     IReadOnlyList<TItem> Items,
     DsaPolicyDefinition DsaPolicy,
     string Purpose,
-    string CorrelationId
+    string CorrelationId,
+    string? TraceParent
 )
     where TItem : IPepFilterable;

--- a/Apps/Find/src/SUI.Find.Application/Services/PepFilterInput.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/PepFilterInput.cs
@@ -13,6 +13,7 @@ namespace SUI.Find.Application.Services;
 /// <param name="DsaPolicy">The Data Sharing Agreement policy belonging to the Source Organization.</param>
 /// <param name="Purpose">The reason why the Searcher/Requestor requested the data, and why they need to see the data.</param>
 /// <param name="CorrelationId">ID used to correlate this action to the other steps in this search process.</param>
+/// <param name="TraceParent">Optional Trace Parent (W3C Trace Context) used for distributed tracing and correlation, to help with diagnosing problems.</param>
 public record PepFilterInput<TItem>(
     string SourceOrgId,
     string DestOrgId,

--- a/Apps/Find/src/SUI.Find.Application/Services/PolicyEnforcementService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/PolicyEnforcementService.cs
@@ -36,6 +36,7 @@ public class PolicyEnforcementService(
             input.DestOrgId,
             input.CorrelationId,
             input.Purpose,
+            input.TraceParent,
             cancellationToken
         );
 
@@ -47,6 +48,7 @@ public class PolicyEnforcementService(
         string destinationOrgId,
         string correlationId,
         string purpose,
+        string? traceParent,
         CancellationToken cancellationToken
     )
         where TItem : IPepFilterable
@@ -90,6 +92,7 @@ public class PolicyEnforcementService(
             Payload = JsonSerializer.SerializeToElement(payload),
             Timestamp = timeProvider.GetUtcNow().DateTime,
             CorrelationId = correlationId,
+            TraceParent = traceParent,
         };
 
         await auditQueueClient.SendAuditEventAsync(auditMessage, cancellationToken);

--- a/Apps/Find/src/SUI.Find.Domain/Events/Audit/AuditEvent.cs
+++ b/Apps/Find/src/SUI.Find.Domain/Events/Audit/AuditEvent.cs
@@ -11,4 +11,5 @@ public class AuditEvent
     public required JsonElement Payload { get; set; }
     public required DateTime Timestamp { get; set; } = DateTime.UtcNow;
     public required string CorrelationId { get; set; }
+    public string? TraceParent { get; set; }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/OrchestratorFunctions/SearchOrchestrator.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/OrchestratorFunctions/SearchOrchestrator.cs
@@ -124,7 +124,7 @@ public class SearchOrchestrator(ILogger<SearchOrchestrator> logger)
             provider.DsaPolicy,
             data.PolicyContext.Purpose,
             data.Metadata.InvocationId,
-            null
+            TraceParent: null
         );
 
         var pepResults = await context.CallActivityAsync<

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/OrchestratorFunctions/SearchOrchestrator.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/OrchestratorFunctions/SearchOrchestrator.cs
@@ -123,7 +123,8 @@ public class SearchOrchestrator(ILogger<SearchOrchestrator> logger)
             providerResults,
             provider.DsaPolicy,
             data.PolicyContext.Purpose,
-            data.Metadata.InvocationId
+            data.Metadata.InvocationId,
+            null
         );
 
         var pepResults = await context.CallActivityAsync<

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/QueueFunctions/QueueSearchJobTrigger.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/QueueFunctions/QueueSearchJobTrigger.cs
@@ -70,7 +70,8 @@ public class QueueSearchJobTrigger(
                         Items: [custodian],
                         DsaPolicy: custodian.DsaPolicy,
                         Purpose: "SAFEGUARDING",
-                        CorrelationId: searchRequestMessage.WorkItemId.ToString()
+                        CorrelationId: searchRequestMessage.WorkItemId.ToString(),
+                        searchRequestMessage.TraceParent
                     ),
                     token
                 )

--- a/Apps/Find/src/SUI.Find.Infrastructure/Handlers/JobResultHandler.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Handlers/JobResultHandler.cs
@@ -85,6 +85,7 @@ public class JobResultHandler(
             records,
             context,
             message.WorkItemId,
+            message.JobTraceParent,
             cancellationToken
         );
 
@@ -225,6 +226,7 @@ public class JobResultHandler(
         IReadOnlyList<CustodianSearchResultItem> records,
         JobContext context,
         string workItemId,
+        string? traceParent,
         CancellationToken cancellationToken
     )
     {
@@ -238,7 +240,8 @@ public class JobResultHandler(
             records,
             context.Custodian.DsaPolicy,
             ApplicationConstants.PolicyEnforcementPurposes.Safeguarding,
-            workItemId
+            workItemId,
+            traceParent
         );
 
         var resultsWithDecision = await pepService.FilterItemsAndAuditAsync(

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/PolicyEnforcementServiceTests/EvaluateAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/PolicyEnforcementServiceTests/EvaluateAsyncTests.cs
@@ -6,6 +6,7 @@ using SUI.Find.Application.Enums;
 using SUI.Find.Application.Interfaces;
 using SUI.Find.Application.Models;
 using SUI.Find.Application.Services;
+using SUI.Find.Domain.Events.Audit;
 
 namespace SUI.Find.Application.UnitTests.Services.PolicyEnforcementServiceTests;
 
@@ -13,15 +14,16 @@ public class EvaluateAsyncTests
 {
     private readonly PolicyEnforcementService _sut;
     private readonly FakeTimeProvider _fakeTimeProvider = new();
+    private readonly IAuditQueueClient _queueClient;
 
     public EvaluateAsyncTests()
     {
         var logger = Substitute.For<ILogger<PolicyEnforcementService>>();
         logger.IsEnabled(LogLevel.Information).Returns(true);
 
-        var queueClient = Substitute.For<IAuditQueueClient>();
+        _queueClient = Substitute.For<IAuditQueueClient>();
         _fakeTimeProvider.SetUtcNow(DateTimeOffset.Parse("2026-01-01T00:00:00Z"));
-        _sut = new PolicyEnforcementService(queueClient, _fakeTimeProvider, logger);
+        _sut = new PolicyEnforcementService(_queueClient, _fakeTimeProvider, logger);
     }
 
     [Fact]
@@ -254,7 +256,8 @@ public class EvaluateAsyncTests
             searchResultItems,
             policy,
             Purpose: "SAFEGUARDING",
-            CorrelationId: "INV-ID-01"
+            CorrelationId: "INV-ID-01",
+            TraceParent: "test-trace-parent"
         );
 
         // Act
@@ -292,6 +295,13 @@ public class EvaluateAsyncTests
                     },
                 },
             ]);
+
+        await _queueClient
+            .Received(1)
+            .SendAuditEventAsync(
+                Arg.Is<AuditEvent>(e => e.TraceParent == "test-trace-parent"),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Fact]
@@ -341,7 +351,8 @@ public class EvaluateAsyncTests
             providerDefinitions,
             policy,
             Purpose: "SAFEGUARDING",
-            CorrelationId: "INV-ID-01"
+            CorrelationId: "INV-ID-01",
+            TraceParent: "test-trace-parent"
         );
 
         // Act
@@ -376,5 +387,12 @@ public class EvaluateAsyncTests
                     },
                 },
             ]);
+
+        await _queueClient
+            .Received(1)
+            .SendAuditEventAsync(
+                Arg.Is<AuditEvent>(e => e.TraceParent == "test-trace-parent"),
+                Arg.Any<CancellationToken>()
+            );
     }
 }

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/QueueSearchJobTriggerTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/QueueSearchJobTriggerTests.cs
@@ -88,7 +88,9 @@ public class QueueSearchJobTriggerTests
 
         _mockPolicyEnforcementService
             .FilterItemsAndAuditAsync(
-                Arg.Any<PepFilterInput<ProviderDefinition>>(),
+                Arg.Is<PepFilterInput<ProviderDefinition>>(input =>
+                    input.TraceParent == requestMessage.TraceParent
+                ),
                 Arg.Any<CancellationToken>()
             )
             .Returns(callInfo =>
@@ -167,6 +169,7 @@ public class QueueSearchJobTriggerTests
             SearchingOrganisationId = "searching-custodian-id",
             TraceId = "test-trace-id",
             InvocationId = "test-invocation",
+            TraceParent = "original-search-request-trace-parent",
         };
 
         var custodians = new List<ProviderDefinition>
@@ -177,7 +180,9 @@ public class QueueSearchJobTriggerTests
         _mockCustodianService.GetCustodiansAsync().Returns(custodians);
         _mockPolicyEnforcementService
             .FilterItemsAndAuditAsync(
-                Arg.Any<PepFilterInput<ProviderDefinition>>(),
+                Arg.Is<PepFilterInput<ProviderDefinition>>(input =>
+                    input.TraceParent == requestMessage.TraceParent
+                ),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
@@ -237,7 +242,9 @@ public class QueueSearchJobTriggerTests
 
         _mockPolicyEnforcementService
             .FilterItemsAndAuditAsync(
-                Arg.Is<PepFilterInput<ProviderDefinition>>(req => req.SourceOrgId == "org1"),
+                Arg.Is<PepFilterInput<ProviderDefinition>>(req =>
+                    req.SourceOrgId == "org1" && req.TraceParent == requestMessage.TraceParent
+                ),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
@@ -248,7 +255,9 @@ public class QueueSearchJobTriggerTests
 
         _mockPolicyEnforcementService
             .FilterItemsAndAuditAsync(
-                Arg.Is<PepFilterInput<ProviderDefinition>>(req => req.SourceOrgId != "org1"),
+                Arg.Is<PepFilterInput<ProviderDefinition>>(req =>
+                    req.SourceOrgId != "org1" && req.TraceParent == requestMessage.TraceParent
+                ),
                 Arg.Any<CancellationToken>()
             )
             .Returns(callInfo =>

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Handlers/JobResultHandlerTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Handlers/JobResultHandlerTests.cs
@@ -89,6 +89,7 @@ public class JobResultHandlerTests
                     RecordUrl = $"url{i}",
                 })
                 .ToList(),
+            JobTraceParent = "test-job-trace-parent",
         };
     }
 
@@ -400,6 +401,7 @@ public class JobResultHandlerTests
                     && x.DestOrgType == searchingOrg.OrgType
                     && x.Purpose == ApplicationConstants.PolicyEnforcementPurposes.Safeguarding
                     && x.Items.Count == 2
+                    && x.TraceParent == message.JobTraceParent
                 ),
                 Arg.Any<CancellationToken>()
             );
@@ -542,6 +544,7 @@ public class JobResultHandlerTests
                     && x.DestOrgType == searchingOrg.OrgType
                     && x.Purpose == ApplicationConstants.PolicyEnforcementPurposes.Safeguarding
                     && x.Items.Count == 3
+                    && x.TraceParent == message.JobTraceParent
                 ),
                 Arg.Any<CancellationToken>()
             );


### PR DESCRIPTION
## Summary

Include TraceParent in PEP auditing

## Changes

-Optional TraceParent property is added to PepFilterInput and AuditEvent
  
- [x] PolicyEnforcementService is updated to pass along the TraceParent to the audit event

-Usages of FilterItemsAndAuditAsync in the Polling implementation are updated to pass along the TraceParent
  
- [x] QueueSearchJobTrigger uses searchRequestMessage.TraceParent
- [x]   JobResultHandler uses message.JobTraceParent

## Validation

-Unit Test runs