### PR TITLE
feat(find): SUI-1695 - Add backoff signalling to no work available responses

### DIFF
--- a/Apps/Find/src/SUI.Find.Application/Constants/ApplicationConstants.cs
+++ b/Apps/Find/src/SUI.Find.Application/Constants/ApplicationConstants.cs
@@ -50,6 +50,7 @@ public static class ApplicationConstants
 
     public static class Http
     {
+        public const string RetryAfterHeaderName = "Retry-After";
         public const string DefaultRetryAfterSeconds = "10";
     }
 }

--- a/Apps/Find/src/SUI.Find.Application/Constants/ApplicationConstants.cs
+++ b/Apps/Find/src/SUI.Find.Application/Constants/ApplicationConstants.cs
@@ -47,4 +47,9 @@ public static class ApplicationConstants
     {
         public const string QueueName = "search-requests-inbound";
     }
+
+    public static class Http
+    {
+        public const string DefaultRetryAfterSeconds = "10";
+    }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/ClaimJobFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/ClaimJobFunction.cs
@@ -84,7 +84,7 @@ public class ClaimJobFunction(ILogger<ClaimJobFunction> logger, IJobClaimService
         }
 
         var response = HttpResponseUtility.NoContentResponse(req);
-        response.Headers.Add("Retry-After", "10");
+        response.Headers.Add("Retry-After", ApplicationConstants.Http.DefaultRetryAfterSeconds);
         return response;
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/ClaimJobFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/ClaimJobFunction.cs
@@ -9,6 +9,7 @@ using SUI.Find.Application.Dtos;
 using SUI.Find.Application.Interfaces;
 using SUI.Find.FindApi.Attributes;
 using SUI.Find.FindApi.Models;
+using SUI.Find.FindApi.OpenApi;
 using SUI.Find.FindApi.Utility;
 
 namespace SUI.Find.FindApi.Functions.HttpFunctions;
@@ -28,7 +29,8 @@ public class ClaimJobFunction(ILogger<ClaimJobFunction> logger, IJobClaimService
     )]
     [OpenApiResponseWithoutBody(
         statusCode: HttpStatusCode.NoContent,
-        Summary = "There are no jobs waiting to be worked on."
+        Summary = "There are no jobs waiting to be worked on.",
+        CustomHeaderType = typeof(RetryAfterHeader)
     )]
     [RequiredScopes("work-item.write")]
     [Function(nameof(ClaimJob))]
@@ -81,6 +83,8 @@ public class ClaimJobFunction(ILogger<ClaimJobFunction> logger, IJobClaimService
             return await HttpResponseUtility.CreatedResponse(req, claimedJob, cancellationToken);
         }
 
-        return HttpResponseUtility.NoContentResponse(req);
+        var response = HttpResponseUtility.NoContentResponse(req);
+        response.Headers.Add("Retry-After", "10");
+        return response;
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/ClaimJobFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/ClaimJobFunction.cs
@@ -83,8 +83,6 @@ public class ClaimJobFunction(ILogger<ClaimJobFunction> logger, IJobClaimService
             return await HttpResponseUtility.CreatedResponse(req, claimedJob, cancellationToken);
         }
 
-        var response = HttpResponseUtility.NoContentResponse(req);
-        response.Headers.Add("Retry-After", ApplicationConstants.Http.DefaultRetryAfterSeconds);
-        return response;
+        return HttpResponseUtility.NoContentResponse(req).AddRetryAfterHeader();
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
@@ -8,6 +8,7 @@ using SUI.Find.Application.Constants;
 using SUI.Find.Application.Interfaces;
 using SUI.Find.FindApi.Attributes;
 using SUI.Find.FindApi.Models;
+using SUI.Find.FindApi.OpenApi;
 using SUI.Find.FindApi.Utility;
 
 namespace SUI.Find.FindApi.Functions.HttpFunctions;
@@ -28,7 +29,8 @@ public class WorkAvailableFunction(
     )]
     [OpenApiResponseWithoutBody(
         statusCode: HttpStatusCode.NoContent,
-        Summary = "No work available. There are no jobs waiting to be worked on."
+        Summary = "No work available. There are no jobs waiting to be worked on.",
+        CustomHeaderType = typeof(RetryAfterHeader)
     )]
     [RequiredScopes("work-item.read")]
     [Function(nameof(WorkAvailable))]
@@ -74,8 +76,13 @@ public class WorkAvailableFunction(
             cancellationToken
         );
 
-        return hasJobs
-            ? HttpResponseUtility.OkResponse(req)
-            : HttpResponseUtility.NoContentResponse(req);
+        if (hasJobs)
+        {
+            return HttpResponseUtility.OkResponse(req);
+        }
+
+        var response = HttpResponseUtility.NoContentResponse(req);
+        response.Headers.Add("Retry-After", "10");
+        return response;
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
@@ -81,8 +81,6 @@ public class WorkAvailableFunction(
             return HttpResponseUtility.OkResponse(req);
         }
 
-        var response = HttpResponseUtility.NoContentResponse(req);
-        response.Headers.Add("Retry-After", ApplicationConstants.Http.DefaultRetryAfterSeconds);
-        return response;
+        return HttpResponseUtility.NoContentResponse(req).AddRetryAfterHeader();
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
@@ -82,7 +82,7 @@ public class WorkAvailableFunction(
         }
 
         var response = HttpResponseUtility.NoContentResponse(req);
-        response.Headers.Add("Retry-After", "10");
+        response.Headers.Add("Retry-After", ApplicationConstants.Http.DefaultRetryAfterSeconds);
         return response;
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/OpenApi/RetryAfterHeader.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/OpenApi/RetryAfterHeader.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.OpenApi.Models;
+using SUI.Find.Application.Constants;
 
 namespace SUI.Find.FindApi.OpenApi;
 
@@ -11,7 +12,7 @@ public class RetryAfterHeader : IOpenApiCustomResponseHeader
         new()
         {
             {
-                "Retry-After",
+                ApplicationConstants.Http.RetryAfterHeaderName,
                 new OpenApiHeader
                 {
                     Description =

--- a/Apps/Find/src/SUI.Find.FindApi/OpenApi/RetryAfterHeader.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/OpenApi/RetryAfterHeader.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.OpenApi.Models;
+
+namespace SUI.Find.FindApi.OpenApi;
+
+[ExcludeFromCodeCoverage(Justification = "OpenAPI header does not contain any logic to be tested.")]
+public class RetryAfterHeader : IOpenApiCustomResponseHeader
+{
+    public Dictionary<string, OpenApiHeader> Headers { get; set; } =
+        new()
+        {
+            {
+                "Retry-After",
+                new OpenApiHeader
+                {
+                    Description =
+                        "The minimum number of seconds the client should wait before making a follow-up request.",
+                    Schema = new OpenApiSchema { Type = "integer" },
+                }
+            },
+        };
+}

--- a/Apps/Find/src/SUI.Find.FindApi/Utility/HttpResponseUtility.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Utility/HttpResponseUtility.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Azure.Functions.Worker.Http;
+using SUI.Find.Application.Constants;
 using SUI.Find.FindApi.Models;
 
 namespace SUI.Find.FindApi.Utility;
@@ -150,6 +151,15 @@ public static class HttpResponseUtility
         var res = req.CreateResponse(HttpStatusCode.NoContent);
         res.AddNoCacheHeaders();
         return res;
+    }
+
+    public static HttpResponseData AddRetryAfterHeader(this HttpResponseData response)
+    {
+        response.Headers.Add(
+            ApplicationConstants.Http.RetryAfterHeaderName,
+            ApplicationConstants.Http.DefaultRetryAfterSeconds
+        );
+        return response;
     }
 
     private static void AddNoCacheHeaders(this HttpResponseData response)

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
@@ -103,6 +103,10 @@ public class ClaimJobFunctionTests
 
         // Assert the response body
         result.Body.Length.ShouldBe(0);
+
+        var hasRetryHeader = result.Headers.TryGetValues("Retry-After", out var retryValues);
+        hasRetryHeader.ShouldBeTrue();
+        retryValues.ShouldHaveSingleItem().ShouldBe("10");
     }
 
     private static FunctionContext CreateContextWithAuth(string clientId)

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
@@ -106,7 +106,9 @@ public class ClaimJobFunctionTests
 
         var hasRetryHeader = result.Headers.TryGetValues("Retry-After", out var retryValues);
         hasRetryHeader.ShouldBeTrue();
-        retryValues.ShouldHaveSingleItem().ShouldBe("10");
+        retryValues
+            .ShouldHaveSingleItem()
+            .ShouldBe(ApplicationConstants.Http.DefaultRetryAfterSeconds);
     }
 
     private static FunctionContext CreateContextWithAuth(string clientId)

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
@@ -104,7 +104,10 @@ public class ClaimJobFunctionTests
         // Assert the response body
         result.Body.Length.ShouldBe(0);
 
-        var hasRetryHeader = result.Headers.TryGetValues("Retry-After", out var retryValues);
+        var hasRetryHeader = result.Headers.TryGetValues(
+            ApplicationConstants.Http.RetryAfterHeaderName,
+            out var retryValues
+        );
         hasRetryHeader.ShouldBeTrue();
         retryValues
             .ShouldHaveSingleItem()

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
@@ -1,20 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using SUI.Find.Application.Constants;
 using SUI.Find.Application.Interfaces;
-using SUI.Find.Application.Models;
 using SUI.Find.FindApi.Functions.HttpFunctions;
 using SUI.Find.FindApi.Models;
 using SUI.Find.FindApi.UnitTests.Mocks;
-using Xunit;
 
 namespace SUI.Find.FindApi.UnitTests.FunctionTests;
 
@@ -85,6 +77,12 @@ public class WorkAvailableFunctionTests
         await _jobClaimService
             .Received(1)
             .DoesCustodianHaveJobs("test-client", Arg.Any<CancellationToken>());
+
+        var hasRetryHeader = result.Headers.TryGetValues("Retry-After", out var retryValues);
+        Assert.True(hasRetryHeader, "Expected 'Retry-After' header to be present.");
+
+        var retryValue = Assert.Single(retryValues!);
+        Assert.Equal("10", retryValue);
     }
 
     private static FunctionContext CreateContextWithAuth(string clientId)

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
@@ -82,7 +82,7 @@ public class WorkAvailableFunctionTests
         Assert.True(hasRetryHeader, "Expected 'Retry-After' header to be present.");
 
         var retryValue = Assert.Single(retryValues!);
-        Assert.Equal("10", retryValue);
+        Assert.Equal(ApplicationConstants.Http.DefaultRetryAfterSeconds, retryValue);
     }
 
     private static FunctionContext CreateContextWithAuth(string clientId)

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
@@ -78,7 +78,10 @@ public class WorkAvailableFunctionTests
             .Received(1)
             .DoesCustodianHaveJobs("test-client", Arg.Any<CancellationToken>());
 
-        var hasRetryHeader = result.Headers.TryGetValues("Retry-After", out var retryValues);
+        var hasRetryHeader = result.Headers.TryGetValues(
+            ApplicationConstants.Http.RetryAfterHeaderName,
+            out var retryValues
+        );
         Assert.True(hasRetryHeader, "Expected 'Retry-After' header to be present.");
 
         var retryValue = Assert.Single(retryValues!);


### PR DESCRIPTION
## Summary

The ‘No work available' responses in the Polling implementation should include Backoff Signalling, so that load to the service can be dynamically managed in the future.

## Changes

In the 204 NoContent responses from both the ClaimJobFunction and the WorkAvailableFunction include a Retry-After response header, with a hardcoded value of 10 (seconds).

The generated OpenAPI schema is updated to indicate that the Retry-After response header will be included for 204 NoContent responses.

## Validation

Unit Tests with updates
