### PR TITLE
perf: SUI-1669 - remove duplicate build in e2e test ephemeral workflow

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -163,7 +163,7 @@ jobs:
              Apps/Find/src/SUI.Find.FindApi/local.settings.json
 
       - name: Start StubCustodians API
-        run: dotnet run --launch-profile http &
+        run: dotnet run --no-build --launch-profile http &
         working-directory: Apps/StubCustodians/src/SUI.StubCustodians.API
 
       - name: Start Find API


### PR DESCRIPTION
## Summary

Because the Stubs are built by the previous step, there's no need to rebuild them again here.  By removing the duplicate build there will be a small ~10 second performance improvement.

## Changes

- When launching the Stubs in the e2e test ephemeral workflow, pass `no-build` flag, because the Stubs have literally only just been built by the previous step.

## Validation

- Checked ephemeral e2e tests still pass in GitHub workflow.