### PR TITLE
feat: SUI-1708 - initial thinking for workflow to restart webapps

### DIFF
--- a/.github/workflows/restart-webapp.yml
+++ b/.github/workflows/restart-webapp.yml
@@ -1,0 +1,73 @@
+name: Restart Azure Web App
+run-name: >-
+  ${{
+    format(
+      'Restart Azure Web App - {0} in {1}',
+      inputs.web_app_descriptor,
+      inputs.environment
+    )
+  }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        required: true
+        default: d01
+        type: choice
+        options:
+          - d01
+          - d02
+      web_app_descriptor:
+        description: App to restart
+        required: true
+        default: custodians01
+        type: choice
+        options:
+          - custodians01
+          - uiharness01
+
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      web_app_descriptor:
+        required: true
+        type: string
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+
+jobs:
+  restart:
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-latest"]') }}
+    environment: ${{ inputs.environment }}
+    env:
+      RESOURCE_GROUP_NAME: ${{ format('{0}{1}rg-{2}-{3}', github.env.AZURE_SUBSCRIPTION_PREFIX, inputs.environment, github.env.AZURE_REGION_SHORT, github.env.AZURE_ENV_DESCRIPTOR) }}
+      WEB_APP_NAME: ${{ format('{0}{1}app-{2}-{3}', github.env.AZURE_SUBSCRIPTION_PREFIX, inputs.environment, github.env.AZURE_REGION_SHORT, inputs.web_app_descriptor) }}
+    steps:
+      - name: Azure login with OIDC for ${{ inputs.environment }}
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Display Workflow Setup
+        run: |
+          echo
+          echo "---- Workflow Setup: ----"
+          echo "RESOURCE_GROUP_NAME: $RESOURCE_GROUP_NAME"
+          echo "WEB_APP_NAME: $WEB_APP_NAME"
+
+      #- name: Restart Azure Web App
+      #  run: |
+      #    az webapp restart \
+      #      --name $WEB_APP_NAME \
+      #      --resource-group $RESOURCE_GROUP_NAME


### PR DESCRIPTION
## Summary

This is an interim PR workings towards a workflow to restart webapps.  This will eventually enable us to automatically restart the (soon to be deployed) UI Test Harness webapp when the Match API Key is rotated, ultimately so that the UI Test Harness picks up the new key.

This interim PR contains only a placeholder 'restart webapp' workflow.  It is necessary so that the full workflow can be tested in the branch before merging to main.  Currently no testing can be completed because workflows do not appear in GitHub until its been merged to the default branch.

## Changes

- Added placeholder 'restart webapp' workflow

## Validation

- Not possible yet, except for linting locally in IDE