### PR TITLE
config(custodians): SUI-1713 - Update d02's artificial delay to be more obvious

### DIFF
--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -24,6 +24,10 @@ find_app_settings = {
 custodian_app_settings = {
   FindApi__BaseUrl = "https://s270d02func-ukw-find01.azurewebsites.net"
   StubCustodians__BaseUrl = "https://s270d02app-ukw-custodians01.azurewebsites.net"
+  RandomDelayMinSeconds = 1,
+  RandomDelayMaxSeconds = 5,
+  CustodianWorkerRandomIntervalMinSeconds = 3,
+  CustodianWorkerRandomIntervalMaxSeconds = 8
 }
 
 tags = {


### PR DESCRIPTION
## Summary

In order to improve the demos of the UI Test Harness, we are increasing the artificial delay to the custodian calls for the d02 environment.

## Changes

For the d02 environment only:
- Increase the delay range for fanout architecture to 1-5 seconds
- Increase the delay range for polling architecture to 3-8 seconds

## Validation

- Unit/integration/E2E tests run
- Plan on d01, validated no changes
- Plan/apply on d02, validated new config values are now present in app settings in azure

