### PR TITLE
chore: SUI-1754 - Sprint 9 housekeeping

### DIFF
--- a/.github/workflows/ui-harness-build-and-deploy.yml
+++ b/.github/workflows/ui-harness-build-and-deploy.yml
@@ -45,11 +45,13 @@ on:
       - main
     paths:
       - "Apps/UIHarness/**"
+      - "Data/**"
   pull_request:
     branches:
       - main
     paths:
       - "Apps/UIHarness/**"
+      - "Data/**"
 
 jobs:
   build-and-test-UIHarness:

--- a/Apps/Find/src/SUI.Find.FindApi/example.local.settings.json
+++ b/Apps/Find/src/SUI.Find.FindApi/example.local.settings.json
@@ -14,10 +14,8 @@
     "OTEL_TRACES_SAMPLER": "always_on",
     "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=Development,service.namespace=SUI",
     "OTEL_SERVICE_NAME": "SUI.Find.FindApi",
-    "KeyVault:KeyVaultUri": "https://localdevtotallyrandomaddressbecauseitdoesntrunwiththestubauthtokenservice",
     "IdEncryption:EnablePersonIdEncryption": false,
     "MatchFunction:XApiKey": "local-dev-key-change-me",
-    "UseStubAuthTokenService": true,
     "StorageRetentionDays": 1
   }
 }

--- a/terraform/find/main.tf
+++ b/terraform/find/main.tf
@@ -218,7 +218,6 @@ module "function_app" {
       AuditProcessorConnectionString        = module.audit_processor_function_app.storage_connection_string
 
       IdEncryption__EnablePersonIdEncryption = false
-      UseStubAuthTokenService                = false
 
       StorageRetentionDays = "1"
 
@@ -226,11 +225,11 @@ module "function_app" {
         "https://${data.terraform_remote_state.stub_custodians[0].outputs.web_app_default_hostname}",
         null
       )
-      KeyVault__KeyVaultUri    = module.key_vault.vault_uri
-      "MatchFunction__XApiKey" = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.find_match_api_key.name}/)"
-      "NhsAuthConfig__NHS_DIGITAL_PRIVATE_KEY" = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_private_key.name}/)"
-      "NhsAuthConfig__NHS_DIGITAL_KID" = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_kid.name}/)"
-      "NhsAuthConfig__NHS_DIGITAL_CLIENT_ID" = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_client_id.name}/)"
+
+      MatchFunction__XApiKey                 = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.find_match_api_key.name}/)"
+      NhsAuthConfig__NHS_DIGITAL_PRIVATE_KEY = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_private_key.name}/)"
+      NhsAuthConfig__NHS_DIGITAL_KID         = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_kid.name}/)"
+      NhsAuthConfig__NHS_DIGITAL_CLIENT_ID   = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_client_id.name}/)"
     },
     var.find_app_settings
   )


### PR DESCRIPTION
## Summary

This PR tidies up some minor hangovers from recently completed work.

## Changes

- Removed the old `KeyVaultUri` and `UseStubAuthTokenService` config values, they are no longer used. (These values are no longer used now that the PDS FHIR secrets are always loaded from .NET config, and they are securely provided via Azure App Settings using Key Vault References in the infrastructure.)
- The UI Test Harness should include the Data folder in its workflow triggers, because it uses the shared Data to populate its list of Custodians, and get the Client Secrets to obtain auth tokens.

## Validation

- Manual checks & verification
- Planned the Terraform changes, to see that the only actual change is to remove the config values that are no longer used.
- Applied the Terraform changes to `d01` and `d02`
