### PR TITLE
docs: started to capture notes for Productionisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ facilitating information sharing by providing systems, data storage and connecti
 | `PersonalDetailsRecord`          | personal.details           | https://schemas.example.gov.uk/sui/PersonalDetailsRecordV1.json           |
 
 
+## Productionisation
+
+Productionisation should include:
+
+* Review all occurrences of `#trivy:ignore`. They must be removed and resolved correctly, prior to handling any real data.
+
+
 ## Getting Started
 
 ### Prerequisites


### PR DESCRIPTION
This PR starts a section in the main readme where we can capture reminders and notes regarding steps that need to be completed  before this code can handle real data.