### PR TITLE
tests: SUI-1615 - E2E Test: Cross-organisation isolation for searches

### DIFF
--- a/Apps/Find/src/SUI.Find.Application/Models/CustomOneOf.cs
+++ b/Apps/Find/src/SUI.Find.Application/Models/CustomOneOf.cs
@@ -1,3 +1,5 @@
 namespace SUI.Find.Application.Models;
 
 public struct Unauthorized;
+
+public struct Forbidden;

--- a/Apps/Find/src/SUI.Find.Application/Services/SearchService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/SearchService.cs
@@ -26,21 +26,21 @@ public interface ISearchService
         CancellationToken cancellationToken
     );
 
-    Task<OneOf<SearchJobDto, NotFound, Unauthorized, Error>> CancelSearchAsync(
+    Task<OneOf<SearchJobDto, NotFound, Forbidden, Error>> CancelSearchAsync(
         string jobId,
         string clientId,
         DurableTaskClient client,
         CancellationToken cancellationToken
     );
 
-    Task<OneOf<SearchResultsDto, NotFound, Unauthorized, Error>> GetSearchResultsAsync(
+    Task<OneOf<SearchResultsDto, NotFound, Forbidden, Error>> GetSearchResultsAsync(
         string jobId,
         string clientId,
         DurableTaskClient client,
         CancellationToken cancellationToken
     );
 
-    Task<OneOf<SearchJobDto, Unauthorized, NotFound, Error>> GetSearchStatusAsync(
+    Task<OneOf<SearchJobDto, Forbidden, NotFound, Error>> GetSearchStatusAsync(
         string jobId,
         string clientId,
         DurableTaskClient client,
@@ -168,7 +168,7 @@ public class SearchService(
         return searchJob;
     }
 
-    public async Task<OneOf<SearchJobDto, NotFound, Unauthorized, Error>> CancelSearchAsync(
+    public async Task<OneOf<SearchJobDto, NotFound, Forbidden, Error>> CancelSearchAsync(
         string jobId,
         string clientId,
         DurableTaskClient client,
@@ -192,7 +192,7 @@ public class SearchService(
             var input = ReadOrchestratorInput<SearchOrchestratorInput>(metaData);
             if (input is null || input.PolicyContext.ClientId != clientId)
             {
-                return new Unauthorized();
+                return new Forbidden();
             }
 
             var canCancel =
@@ -228,7 +228,7 @@ public class SearchService(
         }
     }
 
-    public async Task<OneOf<SearchResultsDto, NotFound, Unauthorized, Error>> GetSearchResultsAsync(
+    public async Task<OneOf<SearchResultsDto, NotFound, Forbidden, Error>> GetSearchResultsAsync(
         string jobId,
         string clientId,
         DurableTaskClient client,
@@ -263,7 +263,7 @@ public class SearchService(
                     jobId,
                     clientId
                 );
-                return new Unauthorized();
+                return new Forbidden();
             }
 
             SearchResultItem[] finalItems;
@@ -324,7 +324,7 @@ public class SearchService(
         }
     }
 
-    public async Task<OneOf<SearchJobDto, Unauthorized, NotFound, Error>> GetSearchStatusAsync(
+    public async Task<OneOf<SearchJobDto, Forbidden, NotFound, Error>> GetSearchStatusAsync(
         string jobId,
         string clientId,
         DurableTaskClient client,
@@ -342,7 +342,7 @@ public class SearchService(
             var input = ReadOrchestratorInput<SearchOrchestratorInput>(jobStatus);
             if (input is null || input.PolicyContext.ClientId != clientId)
             {
-                return new Unauthorized();
+                return new Forbidden();
             }
 
             var dto = new SearchJobDto

--- a/Apps/Find/src/SUI.Find.Application/Services/SearchService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/SearchService.cs
@@ -177,7 +177,12 @@ public class SearchService(
     {
         try
         {
-            var metaData = await client.GetInstanceAsync(jobId, cancellation: cancellationToken);
+            var metaData = await client.GetInstanceAsync(
+                jobId,
+                getInputsAndOutputs: true,
+                cancellation: cancellationToken
+            );
+
             if (metaData is null)
             {
                 return new NotFound();

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/CancelSearchFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/CancelSearchFunction.cs
@@ -93,8 +93,8 @@ public class CancelSearchFunction(
                     context.InvocationId,
                     cancellationToken
                 ),
-            async unauthorized =>
-                await HttpResponseUtility.UnauthorizedResponse(
+            async forbidden =>
+                await HttpResponseUtility.ForbiddenResponse(
                     req,
                     context.InvocationId,
                     cancellationToken

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsFunction.cs
@@ -105,8 +105,8 @@ public class SearchResultsFunction(
                     context.InvocationId,
                     cancellationToken
                 ),
-            async unauthorized =>
-                await HttpResponseUtility.UnauthorizedResponse(
+            async forbidden =>
+                await HttpResponseUtility.ForbiddenResponse(
                     req,
                     context.InvocationId,
                     cancellationToken

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsV2Function.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsV2Function.cs
@@ -113,8 +113,8 @@ public class SearchResultsV2Function(
                     context.InvocationId,
                     cancellationToken
                 ),
-            async unauthorized =>
-                await HttpResponseUtility.UnauthorizedResponse(
+            async forbidden =>
+                await HttpResponseUtility.ForbiddenResponse(
                     req,
                     context.InvocationId,
                     cancellationToken

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchStatusFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchStatusFunction.cs
@@ -101,8 +101,8 @@ public class SearchStatusFunction(
                     SearchJob.FromDto(dto),
                     cancellationToken
                 ),
-            async unauthorized =>
-                await HttpResponseUtility.UnauthorizedResponse(
+            async forbidden =>
+                await HttpResponseUtility.ForbiddenResponse(
                     req,
                     context.InvocationId,
                     cancellationToken

--- a/Apps/Find/src/SUI.Find.FindApi/Utility/HttpResponseUtility.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Utility/HttpResponseUtility.cs
@@ -25,6 +25,24 @@ public static class HttpResponseUtility
         return res;
     }
 
+    public static async Task<HttpResponseData> ForbiddenResponse(
+        HttpRequestData req,
+        string traceId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var res = ProblemResponse(
+            req,
+            HttpStatusCode.Forbidden,
+            "Access Denied",
+            "No privileges to access resource.",
+            $"urn:trace::{traceId}",
+            cancellationToken
+        );
+
+        return await res;
+    }
+
     public static async Task<HttpResponseData> UnauthorizedResponse(
         HttpRequestData req,
         string traceId,

--- a/Apps/Find/src/SUI.Find.Infrastructure/Interfaces/IJobSearchService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Interfaces/IJobSearchService.cs
@@ -6,7 +6,7 @@ namespace SUI.Find.Infrastructure.Interfaces;
 
 public interface IJobSearchService
 {
-    Task<OneOf<SearchResultsV2Dto, NotFound, Unauthorized, Error>> GetSearchResultsAsync(
+    Task<OneOf<SearchResultsV2Dto, NotFound, Forbidden, Error>> GetSearchResultsAsync(
         string workItemId,
         string requestingOrganisationId,
         CancellationToken cancellationToken

--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/JobSearchService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/JobSearchService.cs
@@ -17,9 +17,7 @@ public class JobSearchService(
     ILogger<JobSearchService> logger
 ) : IJobSearchService
 {
-    public async Task<
-        OneOf<SearchResultsV2Dto, NotFound, Unauthorized, Error>
-    > GetSearchResultsAsync(
+    public async Task<OneOf<SearchResultsV2Dto, NotFound, Forbidden, Error>> GetSearchResultsAsync(
         string workItemId,
         string requestingOrganisationId,
         CancellationToken cancellationToken
@@ -47,7 +45,7 @@ public class JobSearchService(
                 workItemJobCountEntity.RequestingOrganisationId,
                 workItemId
             );
-            return new Unauthorized();
+            return new Forbidden();
         }
 
         var completedRecords = await searchResultsEntryRepository.GetByWorkItemIdAsync(

--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/UrlStorageTableService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/UrlStorageTableService.cs
@@ -1,3 +1,4 @@
+using Azure;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
 using OneOf;
@@ -81,6 +82,10 @@ public class UrlStorageTableService(
                 RequestingOrgId: res.Value.RequestingOrgId,
                 RecordType: res.Value.RecordType
             );
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return new NotFound();
         }
         catch (Exception ex)
         {

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/CancelSearchAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/CancelSearchAsyncTests.cs
@@ -138,7 +138,7 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
     }
 
     [Fact]
-    public async Task ShouldReturnUnauthorized_WhenClientIdDoesNotMatch()
+    public async Task ShouldReturnForbidden_WhenClientIdDoesNotMatch()
     {
         var meta = new OrchestrationMetadata("Orchestrator", "unauth-job")
         {
@@ -165,6 +165,6 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
             CancellationToken.None
         );
 
-        Assert.IsType<Unauthorized>(result.Value);
+        Assert.IsType<Forbidden>(result.Value);
     }
 }

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/CancelSearchAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/CancelSearchAsyncTests.cs
@@ -27,7 +27,11 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
     public async Task ShouldReturnNotFound_WhenJobDoesNotExist()
     {
         _client
-            .GetInstanceAsync("not-found-job", Arg.Any<CancellationToken>())
+            .GetInstanceAsync(
+                "not-found-job",
+                getInputsAndOutputs: true,
+                Arg.Any<CancellationToken>()
+            )
             .Returns((OrchestrationMetadata?)null);
 
         var result = await Sut.CancelSearchAsync(
@@ -47,7 +51,13 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
         {
             RuntimeStatus = OrchestrationRuntimeStatus.Completed,
         };
-        _client.GetInstanceAsync("completed-job", Arg.Any<CancellationToken>()).Returns(meta);
+        _client
+            .GetInstanceAsync(
+                "completed-job",
+                getInputsAndOutputs: true,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(meta);
 
         var result = await Sut.CancelSearchAsync(
             "completed-job",
@@ -67,7 +77,13 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
         {
             RuntimeStatus = OrchestrationRuntimeStatus.Suspended,
         };
-        _client.GetInstanceAsync("non-cancellable-job", Arg.Any<CancellationToken>()).Returns(meta);
+        _client
+            .GetInstanceAsync(
+                "non-cancellable-job",
+                getInputsAndOutputs: true,
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(meta);
 
         var result = await Sut.CancelSearchAsync(
             "non-cancellable-job",
@@ -88,7 +104,9 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
         {
             RuntimeStatus = OrchestrationRuntimeStatus.Running,
         };
-        _client.GetInstanceAsync("cancel-job", Arg.Any<CancellationToken>()).Returns(meta);
+        _client
+            .GetInstanceAsync("cancel-job", getInputsAndOutputs: true, Arg.Any<CancellationToken>())
+            .Returns(meta);
 
         var result = await Sut.CancelSearchAsync(
             "cancel-job",
@@ -106,7 +124,7 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
     public async Task ShouldReturnFailed_WhenExceptionIsThrown()
     {
         _client
-            .GetInstanceAsync("fail-job", Arg.Any<CancellationToken>())
+            .GetInstanceAsync("fail-job", getInputsAndOutputs: true, Arg.Any<CancellationToken>())
             .Throws(new Exception("fail"));
 
         var result = await Sut.CancelSearchAsync(
@@ -126,7 +144,9 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
         {
             RuntimeStatus = OrchestrationRuntimeStatus.Running,
         };
-        _client.GetInstanceAsync("unauth-job", Arg.Any<CancellationToken>()).Returns(meta);
+        _client
+            .GetInstanceAsync("unauth-job", getInputsAndOutputs: true, Arg.Any<CancellationToken>())
+            .Returns(meta);
 
         // Mock the ReadOrchestratorInput to return a different clientId
         var metaData = new SearchJobMetadata("test-person-id", DateTime.UtcNow, "invocation-id");

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/GetSearchResultsAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/GetSearchResultsAsyncTests.cs
@@ -32,7 +32,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
     }
 
     [Fact]
-    public async Task ShouldReturnUnauthorized_WhenClientIdDoesNotMatch()
+    public async Task ShouldReturnForbidden_WhenClientIdDoesNotMatch()
     {
         var meta = new OrchestrationMetadata("Orchestrator", "unauth-job")
         {
@@ -57,7 +57,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
             CancellationToken.None
         );
 
-        Assert.IsType<Unauthorized>(result.Value);
+        Assert.IsType<Forbidden>(result.Value);
     }
 
     [Fact]

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/GetSearchStatusAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/GetSearchStatusAsyncTests.cs
@@ -33,7 +33,7 @@ public class GetSearchStatusAsyncTests : BaseSearchServiceTests
     }
 
     [Fact]
-    public async Task ShouldReturnUnauthorized_WhenClientIdDoesNotMatch()
+    public async Task ShouldReturnForbidden_WhenClientIdDoesNotMatch()
     {
         var meta = new OrchestrationMetadata("Orchestrator", "unauth-job")
         {
@@ -57,7 +57,7 @@ public class GetSearchStatusAsyncTests : BaseSearchServiceTests
             CancellationToken.None
         );
 
-        Assert.IsType<Unauthorized>(result.Value);
+        Assert.IsType<Forbidden>(result.Value);
     }
 
     [Fact]

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
@@ -94,8 +94,7 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
 
         Assert.False(response.IsSuccessStatusCode);
         Assert.True(
-            response.StatusCode == expectedStatusCode
-                || response.StatusCode == HttpStatusCode.Unauthorized, // rs-todo: Unauthorized strictly isn't correct
+            response.StatusCode == expectedStatusCode,
             $"Expected {expectedStatusCode}, but got {response.StatusCode} for {method} {url}"
         );
     }

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using SUI.Find.Application.Models;
 using SUI.Find.FindApi.Models;
 
 namespace SUI.Find.E2ETests;
@@ -10,16 +11,6 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
     ITestOutputHelper testOutputHelper
 ) : SearchTestsBase(fixture, testOutputHelper)
 {
-    private const string TestClientSecret = "SUIProject";
-
-    private static readonly string[] TestScopes =
-    [
-        "find-record.write",
-        "find-record.read",
-        "fetch-record.write",
-        "fetch-record.read",
-    ];
-
     protected async Task RunIsolationTest(TestData testData)
     {
         var ownerToken = await GetAuthTokenAsync(
@@ -35,6 +26,7 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
 
         Assert.NotNull(ownerToken);
         Assert.NotNull(attackerToken);
+        Assert.NotEqual(ownerToken, attackerToken);
 
         var searchJobLinks = await RunAndAssertNewSearchEndpoint(
             Fixture.Config.UseEncryptedIds ? testData.EncryptedSui : testData.Sui,
@@ -48,20 +40,8 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
         Assert.True(hasResultsLink);
         var resultsUrl = RemoveLeadingSlashFromUrl(resultsLink!.Href);
 
-        if (!UsePolling && hasStatusLink)
-        {
-            var statusUrl = RemoveLeadingSlashFromUrl(statusLink!.Href);
-            await AssertForbidden(statusUrl, attackerToken, HttpMethod.Get);
-        }
-
-        await AssertForbidden(resultsUrl, attackerToken, HttpMethod.Get);
-
-        if (!UsePolling && hasCancelLink)
-        {
-            var cancelUrl = RemoveLeadingSlashFromUrl(cancelLink!.Href);
-            await AssertForbidden(cancelUrl, attackerToken, HttpMethod.Delete);
-        }
-
+        // First, run and wait for the search to complete
+        // We need to wait for at least the search to have started running, because some endpoints return not found until the queues have done their bit and eventual consistency has created things
         await RunAndAwaitAndAssertSearchStatusCompletion(
             statusLink?.Href ?? resultsLink.Href,
             resultsLink.Href,
@@ -69,22 +49,28 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
             ownerToken
         );
 
-        using var resultsRequest = new HttpRequestMessage(HttpMethod.Get, resultsUrl);
-        resultsRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", ownerToken);
-        using var resultsResponse = await Fixture.Client.SendAsync(resultsRequest);
-        var resultsContent = await resultsResponse.Content.ReadAsStringAsync();
-        var resultsTyped = JsonSerializer.Deserialize<SearchResultsBase>(resultsContent);
+        // Now the search has completed, verify that all the endpoints are not accessible to the attacker
+        if (!UsePolling)
+        {
+            Assert.True(hasStatusLink);
+            var statusUrl = RemoveLeadingSlashFromUrl(statusLink!.Href);
+            await AssertForbidden(statusUrl, attackerToken, HttpMethod.Get);
+        }
 
-        Assert.NotNull(resultsTyped);
-        if (resultsTyped.Items.Length > 0)
+        await AssertForbidden(resultsUrl, attackerToken, HttpMethod.Get);
+
+        if (!UsePolling)
         {
-            var recordUrl = RemoveLeadingSlashFromUrl(resultsTyped.Items[0].RecordUrl);
-            await AssertForbidden(recordUrl, attackerToken, HttpMethod.Get);
+            Assert.True(hasCancelLink);
+            var cancelUrl = RemoveLeadingSlashFromUrl(cancelLink!.Href);
+            await AssertForbidden(cancelUrl, attackerToken, HttpMethod.Delete);
         }
-        else
-        {
-            TestOutputHelper.WriteLine("Warning: No records found to test fetch isolation.");
-        }
+
+        var searchResultItems = await GetSearchResultItemsAsync(resultsUrl, ownerToken);
+
+        Assert.True(searchResultItems.Length > 0, "No records found to test fetch isolation");
+        var recordUrl = RemoveLeadingSlashFromUrl(searchResultItems.First().RecordUrl);
+        await AssertForbidden(recordUrl, attackerToken, HttpMethod.Get);
     }
 
     private async Task AssertForbidden(string url, string token, HttpMethod method)
@@ -97,9 +83,23 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
         Assert.True(
             response.StatusCode
                 is HttpStatusCode.Forbidden
-                    or HttpStatusCode.NotFound
-                    or HttpStatusCode.Unauthorized,
-            $"Expected Forbidden or NotFound, but got {response.StatusCode} for {method} {url}"
+                    or HttpStatusCode.NotFound // rs-todo: NotFound should only be for fetch
+                    or HttpStatusCode.Unauthorized, // rs-todo: Unauthorized strictly isn't correct
+            $"Expected Forbidden, but got {response.StatusCode} for {method} {url}"
         );
+    }
+
+    private async Task<SearchResultItem[]> GetSearchResultItemsAsync(
+        string resultsUrl,
+        string authToken
+    )
+    {
+        using var resultsRequest = new HttpRequestMessage(HttpMethod.Get, resultsUrl);
+        resultsRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+        using var resultsResponse = await Fixture.Client.SendAsync(resultsRequest);
+        var resultsContent = await resultsResponse.Content.ReadAsStringAsync();
+        var resultsTyped = JsonSerializer.Deserialize<SearchResultsBase>(resultsContent);
+        Assert.NotNull(resultsTyped);
+        return resultsTyped.Items;
     }
 }

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using SUI.Find.FindApi.Models;
+
+namespace SUI.Find.E2ETests;
+
+public abstract class CrossOrganisationIsolationSearchTestsBase(
+    FunctionTestFixture fixture,
+    ITestOutputHelper testOutputHelper
+) : SearchTestsBase(fixture, testOutputHelper)
+{
+    private const string TestClientSecret = "SUIProject";
+
+    private static readonly string[] TestScopes =
+    [
+        "find-record.write",
+        "find-record.read",
+        "fetch-record.write",
+        "fetch-record.read",
+    ];
+
+    protected async Task RunIsolationTest(TestData testData)
+    {
+        var ownerToken = await GetAuthTokenAsync(
+            testData.TestClientId,
+            TestClientSecret,
+            TestScopes
+        );
+
+        var attackerClientId =
+            testData.TestClientId == "LOCAL-AUTHORITY-01" ? "EDUCATION-01" : "LOCAL-AUTHORITY-01";
+
+        var attackerToken = await GetAuthTokenAsync(attackerClientId, TestClientSecret, TestScopes);
+
+        Assert.NotNull(ownerToken);
+        Assert.NotNull(attackerToken);
+
+        var searchJobLinks = await RunAndAssertNewSearchEndpoint(
+            Fixture.Config.UseEncryptedIds ? testData.EncryptedSui : testData.Sui,
+            ownerToken
+        );
+
+        var hasStatusLink = searchJobLinks.TryGetValue("status", out var statusLink);
+        var hasResultsLink = searchJobLinks.TryGetValue("results", out var resultsLink);
+        var hasCancelLink = searchJobLinks.TryGetValue("cancel", out var cancelLink);
+
+        Assert.True(hasResultsLink);
+        var resultsUrl = RemoveLeadingSlashFromUrl(resultsLink!.Href);
+
+        if (!UsePolling && hasStatusLink)
+        {
+            var statusUrl = RemoveLeadingSlashFromUrl(statusLink!.Href);
+            await AssertForbidden(statusUrl, attackerToken, HttpMethod.Get);
+        }
+
+        await AssertForbidden(resultsUrl, attackerToken, HttpMethod.Get);
+
+        if (!UsePolling && hasCancelLink)
+        {
+            var cancelUrl = RemoveLeadingSlashFromUrl(cancelLink!.Href);
+            await AssertForbidden(cancelUrl, attackerToken, HttpMethod.Delete);
+        }
+
+        await RunAndAwaitAndAssertSearchStatusCompletion(
+            statusLink?.Href ?? resultsLink.Href,
+            resultsLink.Href,
+            testData,
+            ownerToken
+        );
+
+        using var resultsRequest = new HttpRequestMessage(HttpMethod.Get, resultsUrl);
+        resultsRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", ownerToken);
+        using var resultsResponse = await Fixture.Client.SendAsync(resultsRequest);
+        var resultsContent = await resultsResponse.Content.ReadAsStringAsync();
+        var resultsTyped = JsonSerializer.Deserialize<SearchResultsBase>(resultsContent);
+
+        Assert.NotNull(resultsTyped);
+        if (resultsTyped.Items.Length > 0)
+        {
+            var recordUrl = RemoveLeadingSlashFromUrl(resultsTyped.Items[0].RecordUrl);
+            await AssertForbidden(recordUrl, attackerToken, HttpMethod.Get);
+        }
+        else
+        {
+            TestOutputHelper.WriteLine("Warning: No records found to test fetch isolation.");
+        }
+    }
+
+    private async Task AssertForbidden(string url, string token, HttpMethod method)
+    {
+        TestOutputHelper.WriteLine($"Asserting {method} {url} is forbidden for attacker");
+        using var request = new HttpRequestMessage(method, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        using var response = await Fixture.Client.SendAsync(request);
+
+        Assert.True(
+            response.StatusCode
+                is HttpStatusCode.Forbidden
+                    or HttpStatusCode.NotFound
+                    or HttpStatusCode.Unauthorized,
+            $"Expected Forbidden or NotFound, but got {response.StatusCode} for {method} {url}"
+        );
+    }
+}

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
@@ -54,38 +54,49 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
         {
             Assert.True(hasStatusLink);
             var statusUrl = RemoveLeadingSlashFromUrl(statusLink!.Href);
-            await AssertForbidden(statusUrl, attackerToken, HttpMethod.Get);
+            await AssertAttackingRequestFails(statusUrl, attackerToken, HttpMethod.Get);
         }
 
-        await AssertForbidden(resultsUrl, attackerToken, HttpMethod.Get);
+        await AssertAttackingRequestFails(resultsUrl, attackerToken, HttpMethod.Get);
 
         if (!UsePolling)
         {
             Assert.True(hasCancelLink);
             var cancelUrl = RemoveLeadingSlashFromUrl(cancelLink!.Href);
-            await AssertForbidden(cancelUrl, attackerToken, HttpMethod.Delete);
+            await AssertAttackingRequestFails(cancelUrl, attackerToken, HttpMethod.Delete);
         }
 
         var searchResultItems = await GetSearchResultItemsAsync(resultsUrl, ownerToken);
 
         Assert.True(searchResultItems.Length > 0, "No records found to test fetch isolation");
         var recordUrl = RemoveLeadingSlashFromUrl(searchResultItems.First().RecordUrl);
-        await AssertForbidden(recordUrl, attackerToken, HttpMethod.Get);
+        await AssertAttackingRequestFails(
+            recordUrl,
+            attackerToken,
+            HttpMethod.Get,
+            HttpStatusCode.NotFound
+        );
     }
 
-    private async Task AssertForbidden(string url, string token, HttpMethod method)
+    private async Task AssertAttackingRequestFails(
+        string url,
+        string token,
+        HttpMethod method,
+        HttpStatusCode expectedStatusCode = HttpStatusCode.Forbidden
+    )
     {
-        TestOutputHelper.WriteLine($"Asserting {method} {url} is forbidden for attacker");
+        TestOutputHelper.WriteLine(
+            $"Asserting {method} {url} is {expectedStatusCode} for attacker"
+        );
         using var request = new HttpRequestMessage(method, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         using var response = await Fixture.Client.SendAsync(request);
 
+        Assert.False(response.IsSuccessStatusCode);
         Assert.True(
-            response.StatusCode
-                is HttpStatusCode.Forbidden
-                    or HttpStatusCode.NotFound // rs-todo: NotFound should only be for fetch
-                    or HttpStatusCode.Unauthorized, // rs-todo: Unauthorized strictly isn't correct
-            $"Expected Forbidden, but got {response.StatusCode} for {method} {url}"
+            response.StatusCode == expectedStatusCode
+                || response.StatusCode == HttpStatusCode.Unauthorized, // rs-todo: Unauthorized strictly isn't correct
+            $"Expected {expectedStatusCode}, but got {response.StatusCode} for {method} {url}"
         );
     }
 

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsV1.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsV1.cs
@@ -1,5 +1,6 @@
 namespace SUI.Find.E2ETests;
 
+[Collection(StartANewSearchTestsV1.StartANewSearchTestsV1CollectionId)]
 public class CrossOrganisationIsolationSearchTestsV1(
     FunctionTestFixture fixture,
     ITestOutputHelper output

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsV1.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsV1.cs
@@ -1,0 +1,16 @@
+namespace SUI.Find.E2ETests;
+
+public class CrossOrganisationIsolationSearchTestsV1(
+    FunctionTestFixture fixture,
+    ITestOutputHelper output
+) : CrossOrganisationIsolationSearchTestsBase(fixture, output)
+{
+    protected override bool UsePolling => false;
+
+    [Theory]
+    [MemberData(nameof(HappyPathTestData), MemberType = typeof(SearchTestsBase))]
+    public async Task Search_IsIsolatedByOrganisation(TestData testData)
+    {
+        await RunIsolationTest(testData);
+    }
+}

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsV2.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsV2.cs
@@ -1,0 +1,16 @@
+namespace SUI.Find.E2ETests;
+
+public class CrossOrganisationIsolationSearchTestsV2(
+    FunctionTestFixture fixture,
+    ITestOutputHelper output
+) : CrossOrganisationIsolationSearchTestsBase(fixture, output)
+{
+    protected override bool UsePolling => true;
+
+    [Theory]
+    [MemberData(nameof(HappyPathTestData), MemberType = typeof(SearchTestsBase))]
+    public async Task Search_IsIsolatedByOrganisation(TestData testData)
+    {
+        await RunIsolationTest(testData);
+    }
+}

--- a/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
@@ -24,8 +24,9 @@ public abstract class SearchTestsBase(
 {
     protected abstract bool UsePolling { get; }
 
-    private const string TestClientSecret = "SUIProject";
-    private static readonly string[] TestScopes =
+    protected const string TestClientSecret = "SUIProject";
+
+    protected static readonly string[] TestScopes =
     [
         "find-record.write",
         "find-record.read",

--- a/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
@@ -175,7 +175,7 @@ public abstract class SearchTestsBase(
         // Fin
     }
 
-    private async Task<Dictionary<string, HalLink>> RunAndAssertNewSearchEndpoint(
+    protected async Task<Dictionary<string, HalLink>> RunAndAssertNewSearchEndpoint(
         string suid,
         string authToken
     )
@@ -255,7 +255,7 @@ public abstract class SearchTestsBase(
         return links;
     }
 
-    private async Task RunAndAssertPartialSearchResults(
+    protected async Task RunAndAssertPartialSearchResults(
         string url,
         TestData testData,
         string authToken
@@ -296,7 +296,7 @@ public abstract class SearchTestsBase(
         Assert.Empty(invalidRecordTypes);
     }
 
-    private async Task RunAndAssertFetchEndpoints(string url, TestData testData, string authToken)
+    protected async Task RunAndAssertFetchEndpoints(string url, TestData testData, string authToken)
     {
         url = RemoveLeadingSlashFromUrl(url);
 
@@ -401,7 +401,7 @@ public abstract class SearchTestsBase(
     /// <param name="resultsUrl">URL of the Search Results endpoint</param>
     /// <param name="testData">The test data for this search run</param>
     /// <param name="authToken">AuthToken for this search run</param>
-    private async Task RunAndAwaitAndAssertSearchStatusCompletion(
+    protected async Task RunAndAwaitAndAssertSearchStatusCompletion(
         string statusUrl,
         string resultsUrl,
         TestData testData,
@@ -491,7 +491,7 @@ public abstract class SearchTestsBase(
         Assert.NotNull(typedResult);
     }
 
-    private static string RemoveLeadingSlashFromUrl(string url) =>
+    protected static string RemoveLeadingSlashFromUrl(string url) =>
         url.StartsWith('/') ? url[1..] : url;
 
     private static string GenerateAppInsightsLink(string traceId)

--- a/Apps/Find/tests/SUI.Find.E2ETests/StartANewSearchTestsV1.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/StartANewSearchTestsV1.cs
@@ -1,7 +1,14 @@
 namespace SUI.Find.E2ETests;
 
+[Collection(StartANewSearchTestsV1CollectionId)]
 public class StartANewSearchTestsV1(FunctionTestFixture fixture, ITestOutputHelper output)
     : StartANewSearchTestsBase(fixture, output)
 {
     protected override bool UsePolling => false;
+
+    /// <summary>
+    /// Because jobs in version are not distinct, they are keyed on NHS Number + Organisation ID,
+    /// version 1 searches cannot be run in parallel if they use the same test data.
+    /// </summary>
+    public const string StartANewSearchTestsV1CollectionId = "StartANewSearchTestsV1";
 }

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/CancelSearchFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/CancelSearchFunctionTests.cs
@@ -191,7 +191,7 @@ public class CancelSearchFunctionTests
     }
 
     [Fact]
-    public async Task ShouldThrowUnauthorizedResponse_WhenUserIsNotAuthorizedToCancelSearch()
+    public async Task ShouldThrowForbiddenResponse_WhenUserDoesHaveAccessTo_CancelSearch()
     {
         // Arrange
         var httpRequestData = MockHttpRequestData.Create(
@@ -199,7 +199,7 @@ public class CancelSearchFunctionTests
         );
         _searchService
             .CancelSearchAsync(JobId, ClientId, _client, CancellationToken.None)
-            .Returns(new Unauthorized());
+            .Returns(new Forbidden());
 
         // Act
         var result = await _sut.CancelSearch(
@@ -210,9 +210,9 @@ public class CancelSearchFunctionTests
             CancellationToken.None
         );
 
-        Assert.Equal(System.Net.HttpStatusCode.Unauthorized, result.StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.Forbidden, result.StatusCode);
         result.Body.Position = 0;
         var problemResponse = await JsonSerializer.DeserializeAsync<Problem>(result.Body);
-        Assert.Equal((int)System.Net.HttpStatusCode.Unauthorized, problemResponse!.Status);
+        Assert.Equal((int)System.Net.HttpStatusCode.Forbidden, problemResponse!.Status);
     }
 }

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsFunctionTests.cs
@@ -108,11 +108,11 @@ public class SearchResultsFunctionTests
     }
 
     [Fact]
-    public async Task ReturnsUnauthorized_WhenUnauthorized()
+    public async Task ReturnsForbidden_WhenUserDoesNotHaveAccessTo_SearchResults()
     {
         _searchService
             .GetSearchResultsAsync("job-3", "test-client-id", _client, Arg.Any<CancellationToken>())
-            .Returns(new Unauthorized());
+            .Returns(new Forbidden());
 
         var response = await _sut.SearchResultsTrigger(
             _httpRequestData,
@@ -122,7 +122,7 @@ public class SearchResultsFunctionTests
             CancellationToken.None
         );
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
     [Fact]

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsV2FunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsV2FunctionTests.cs
@@ -143,7 +143,7 @@ public class SearchResultsV2FunctionTests
     }
 
     [Fact]
-    public async Task ReturnsUnauthorized_WhenUnauthorized()
+    public async Task ReturnsForbidden_WhenUserDoesNotHaveAccessTo_SearchResults()
     {
         _jobSearchService
             .GetSearchResultsAsync(
@@ -151,7 +151,7 @@ public class SearchResultsV2FunctionTests
                 Arg.Any<string>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(new Unauthorized());
+            .Returns(new Forbidden());
 
         var response = await _sut.SearchResultsV2Trigger(
             _httpRequestData,
@@ -161,7 +161,7 @@ public class SearchResultsV2FunctionTests
             CancellationToken.None
         );
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         Assert.Equal("no-cache", response.Headers.GetValues("Pragma").Single());
         Assert.Equal(
             DateTimeOffset.UnixEpoch.ToString("R"),

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchStatusFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchStatusFunctionTests.cs
@@ -113,14 +113,14 @@ public class SearchStatusFunctionTests
     }
 
     [Fact]
-    public async Task ShouldReturnUnauthorized_WhenServiceReturnsUnauthorized()
+    public async Task ShouldReturnForbidden_WhenUserDoesNotHaveAccessTo_SearchStatus()
     {
         // Arrange
         var context = CreateContextWithAuth();
         var req = MockHttpRequestData.Create();
         _searchService
             .GetSearchStatusAsync("job-4", "test-client-id", _client, Arg.Any<CancellationToken>())
-            .Returns(new Unauthorized());
+            .Returns(new Forbidden());
 
         // Act
         var response = await _sut.SearchJobTrigger(
@@ -132,7 +132,7 @@ public class SearchStatusFunctionTests
         );
 
         // Assert
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
     [Fact]

--- a/Apps/Find/tests/SUI.Find.Infrastructure.IntegrationTests/Services/UrlStorageTableServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.IntegrationTests/Services/UrlStorageTableServiceTests.cs
@@ -150,7 +150,7 @@ public class UrlStorageTableServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetAsync_ReturnsError_WhenEntityMissing()
+    public async Task GetAsync_ReturnsNotFound_WhenEntityMissing()
     {
         // ACT
         var result = await _sut.GetAsync(
@@ -160,7 +160,7 @@ public class UrlStorageTableServiceTests : IAsyncLifetime
         );
 
         // ASSERT
-        result.IsT3.Should().BeTrue(); // Error
+        result.IsT1.Should().BeTrue(); // NotFound
     }
 
     [Fact]

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/JobSearchServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/JobSearchServiceTests.cs
@@ -116,7 +116,7 @@ public class JobSearchServiceTests
     }
 
     [Fact]
-    public async Task GetSearchResults_ReturnsUnauthorised_WhenRequestingOrganisationIdIsWrong()
+    public async Task GetSearchResults_ReturnsForbidden_WhenRequestingOrganisationIdIsWrong()
     {
         var workItemId = "WID-1";
         var requestingOrganisationId = "ROID-1";
@@ -148,7 +148,7 @@ public class JobSearchServiceTests
         );
 
         // ASSERT
-        Assert.IsType<Unauthorized>(result.Value);
+        Assert.IsType<Forbidden>(result.Value);
         _logger
             .Received(1)
             .Log(


### PR DESCRIPTION
## Summary

Adds a set of E2E tests to verify that an Organisation cannot access other Organisation’s searches.

## Changes

- Added new E2E test, using existing pattern, that starts a search as one client, then proves another client cannot read status, results, fetch the returned records, or cancel the job.
    - Also includes E2E test change that only effects the version 1 "start a new search tests": now that there are two sets of version 1 "start a new search tests", they need to be put in to the same collection, because they cannot reliably run in parallel because of the shared job issue in version 1.

- Updated all HTTP endpoints in FindAPI to standardise on using `Forbidden`, rather than `Unauthorized`, when the request doesn't have access to the resource.

- Fixes to existing issues that were uncovered by these tests:
    - Fixed issue where by Fetch Record would incorrectly return a 500 server error rather than return 404 Not Found, when the record does not exist.
    - Fixed issue whereby v1 Jobs could never be cancelled, instead it always incorrectly threw the error: "The ReadInputAs method can only be used on OrchestrationMetadata objects that are fetched with the option to include input data."

## Validation

- E2E tests runs locally and ephemeral runs in GitHub