### PR TITLE
feat(uiHarness): sui-1715 - Enable OTEL & App insights logging

### DIFF
--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/EnrolTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/EnrolTab.razor
@@ -124,6 +124,9 @@
     
     [Inject]
     public required IFindService FindService { get; set; }
+    
+    [Inject]
+    public required ILogger<EnrolTab> Logger { get; set; }
 
     protected override void OnParametersSet()
     {
@@ -136,6 +139,8 @@
         {
             return;
         }
+        
+        Logger.LogInformation("Enrol button clicked for organisation: {SelectedOrg}", SelectedOrg);
 
         _enrolledForOrg = null;
         EnrolProgress = 0;
@@ -156,6 +161,8 @@
     
     private async Task SetCurrentPerson(LocalPerson localPerson)
     {
+        Logger.LogInformation("Find Records button clicked for NHS Number: {NhsNumber}", localPerson.NhsNumber);
+        
         await CurrentPersonChanged.InvokeAsync(localPerson);
     }
 }

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
@@ -100,6 +100,9 @@
     
     [Inject]
     public required IFindService FindService { get; set; }
+    
+    [Inject]
+    public required ILogger<FindTab> Logger { get; set; }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -191,6 +194,12 @@
 
     private async Task SetCurrentRecord(LocalRecord localRecord)
     {
+        Logger.LogInformation(
+            "Fetch Record button clicked. Custodian: {CustodianName}, Record Type: {RecordType}, Record URL: {RecordUrl}", 
+            localRecord.CustodianName, 
+            localRecord.Type, 
+            localRecord.Url);
+        
         await CurrentRecordChanged.InvokeAsync(localRecord);
     }
 }

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/HostApplicationBuilderOpenTelemetryExtensions.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/HostApplicationBuilderOpenTelemetryExtensions.cs
@@ -1,0 +1,71 @@
+using Azure.Monitor.OpenTelemetry.Exporter;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace SUI.UIHarness.Web;
+
+public static class HostApplicationBuilderOpenTelemetryExtensions
+{
+    public static IHostApplicationBuilder UseOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        const string appInsightsConnectionStringKey = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+        const string otlpEndpointKey = "OTEL_EXPORTER_OTLP_ENDPOINT";
+        const string otelServiceNameKey = "OTEL_SERVICE_NAME";
+
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+            logging.ParseStateValues = true;
+        });
+
+        var appInsightsConnectionString = builder.Configuration[appInsightsConnectionStringKey];
+        var otlpEndpoint = builder.Configuration[otlpEndpointKey];
+        var configuredServiceName = builder.Configuration[otelServiceNameKey];
+
+        var openTelemetryBuilder = builder.Services.AddOpenTelemetry();
+
+        var serviceName = string.IsNullOrWhiteSpace(configuredServiceName)
+            ? builder.Environment.ApplicationName
+            : configuredServiceName;
+        if (!string.IsNullOrWhiteSpace(serviceName))
+        {
+            openTelemetryBuilder.ConfigureResource(resource => resource.AddService(serviceName));
+        }
+
+        openTelemetryBuilder
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddAspNetCoreInstrumentation(options => options.RecordException = true)
+                    .AddHttpClientInstrumentation(options => options.RecordException = true);
+            })
+            .WithMetrics(metrics =>
+                metrics
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation()
+                    .AddProcessInstrumentation()
+                    .AddMeter("System.Net.NameResolution")
+                    .AddMeter("System.Net.Security")
+                    .AddMeter("System.Net.Sockets")
+            );
+
+        var hasAppInsights = !string.IsNullOrWhiteSpace(appInsightsConnectionString);
+        var hasOtlpEndpoint = !string.IsNullOrWhiteSpace(otlpEndpoint);
+
+        if (hasAppInsights)
+        {
+            openTelemetryBuilder.UseAzureMonitorExporter();
+        }
+
+        if (hasOtlpEndpoint)
+        {
+            openTelemetryBuilder.UseOtlpExporter();
+        }
+
+        return builder;
+    }
+}

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
@@ -2,10 +2,13 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc;
+using SUI.UIHarness.Web;
 using SUI.UIHarness.Web.Components;
 using SUI.UIHarness.Web.Services;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.UseOpenTelemetry();
 
 // Add services to the container.
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
@@ -67,6 +70,7 @@ app.MapPost(
             [FromForm] string password,
             [FromForm] string architecture,
             [FromServices] IConfiguration configuration,
+            [FromServices] ILogger<Program> logger,
             HttpContext httpContext
         ) =>
         {
@@ -74,10 +78,18 @@ app.MapPost(
                 configuration.GetValue<string>("UI_TEST_HARNESS_PASSWORD") ?? "local-dev-only";
             if (password != expectedPassword)
             {
+                logger.LogInformation("Login failed for custodian: {CustodianName}", custodianName);
+
                 return Results.Redirect(
                     $"/login?error=invalid_password&custodianName={Uri.EscapeDataString(custodianName)}&architecture={Uri.EscapeDataString(architecture)}"
                 );
             }
+
+            logger.LogInformation(
+                "Login successful for custodian: {CustodianName} using architecture: {Architecture}",
+                custodianName,
+                architecture
+            );
 
             var claims = new List<Claim>
             {

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/SUI.UIHarness.Web.csproj
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/SUI.UIHarness.Web.csproj
@@ -11,4 +11,13 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+  </ItemGroup>
 </Project>

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.Development.json
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.Development.json
@@ -6,5 +6,11 @@
     }
   },
   "BaseUrl": "http://localhost:7182/",
-  "ArchitectureOptionHidden": false
+  "ArchitectureOptionHidden": false,
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+  "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+  "OTEL_LOGS_EXPORTER": "otlp",
+  "OTEL_TRACES_SAMPLER": "always_on",
+  "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=Development,service.namespace=SUI",
+  "OTEL_SERVICE_NAME": "SUI.UIHarness"
 }


### PR DESCRIPTION
## Summary

Enable OTEL & Application Insights for the UI Test Harness web app, so that the trace logs can be viewed to diagnose what the web app is doing when it is running locally or in the infrastructure

## Changes

OpenTelemetry packages are added to the UI Test Harness app

UseOpenTelemetry extension method is copied from the StubCustodians

The copied UseOpenTelemetry extension method is included in to the Program / web app builder code

Log information calls are added to:
- /api/auth/login endpoint (on failure and successful login)
- Enrol button click ('Enrol' Tab)
- Find Records button click (also on the ‘Enrol’ Tab), including the NHS Number
- Fetch Record button click ('Find Records' tab), including the Custodian, Record type and Record URL

Log messages can be seen in app insights when the Test Harness is used in the infrastructure

## Validation

Locally tested via the Aspire Dashboard