### PR TITLE
chore(workflows): minor naming improvement to app restart part of key rotation workflow

### DIFF
--- a/.github/workflows/rotate-keyvault-secret.yml
+++ b/.github/workflows/rotate-keyvault-secret.yml
@@ -276,7 +276,7 @@ jobs:
       restart_dependant_webapp: ${{ steps.context.outputs.restart_dependant_webapp }}
 
   restart-dependant-webapp:
-    name: Restart dependant web app if applicable
+    name: ${{ format('Restart {0}', needs.rotate.outputs.restart_dependant_webapp || 'dependant web app not applicable') }}
     needs: [prepare, rotate]
     if: needs.rotate.outputs.restart_dependant_webapp != ''
     uses: ./.github/workflows/restart-webapp.yml


### PR DESCRIPTION
## Summary

This PR makes a minor improvement to the key rotation workflow to display the name of the app that gets restarted, so sanity checking its workflow runs is quick.

## Changes

- Updated the key rotation workflow to display name of the app that gets restarted at the end, when applicable

## Validation

- IDE linting verifications
- Manual run of `Rotate Key Vault Secret` workflow against `d01`, checked name changes were as expected