### PR TITLE
ops: sui-1746 - Create separate "Auxiliary" service plan for stubs and non-prod apps

### DIFF
--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -27,6 +27,12 @@ locals {
     var.environment_id,
     var.region_short
   )
+  aux_asp_name = format(
+    "%s%sasp-%s-auxsvcs01",
+    var.subscription_prefix,
+    var.environment_id,
+    var.region_short
+  )
   function_app_integration_vnet_name = format(
     "%s%svnet-%s-funcint01",
     var.subscription_prefix,
@@ -63,6 +69,19 @@ resource "azurerm_service_plan" "shared" {
   os_type             = var.app_service_plan_os_type
   sku_name            = var.app_service_plan_sku
   worker_count        = var.app_service_plan_worker_count
+
+  tags = local.base_tags
+}
+
+resource "azurerm_service_plan" "auxiliary" {
+  count               = var.use_auxiliary_asp ? 1 : 0
+
+  name                = local.aux_asp_name
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  os_type             = var.auxiliary_app_service_plan_os_type
+  sku_name            = var.auxiliary_app_service_plan_sku
+  worker_count        = var.auxiliary_app_service_plan_worker_count
 
   tags = local.base_tags
 }

--- a/terraform/core/outputs.tf
+++ b/terraform/core/outputs.tf
@@ -43,3 +43,8 @@ output "app_insights_connection_string" {
   description = "Connection string for the shared Application Insights instance."
   sensitive   = true
 }
+
+output "auxiliary_app_service_plan_id" {
+  value       = one(azurerm_service_plan.auxiliary[*].id)
+  description = "ID of the auxiliary App Service plan, if created."
+}

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -84,3 +84,27 @@ variable "function_app_integration_subnet_address_prefixes" {
   type        = list(string)
   default     = ["10.250.0.0/26"]
 }
+
+variable "use_auxiliary_asp" {
+  description = "Controls whether an auxiliary App Service Plan is created for stubs and non-prod apps."
+  type        = bool
+  default     = false
+}
+
+variable "auxiliary_app_service_plan_sku" {
+  description = "SKU name for the auxiliary App Service plan."
+  type        = string
+  default     = "B1"
+}
+
+variable "auxiliary_app_service_plan_os_type" {
+  description = "OS type for the auxiliary App Service plan."
+  type        = string
+  default     = "Linux"
+}
+
+variable "auxiliary_app_service_plan_worker_count" {
+  description = "Number of workers for the auxiliary App Service plan."
+  type        = number
+  default     = 1
+}

--- a/terraform/environments/d01.tfvars
+++ b/terraform/environments/d01.tfvars
@@ -12,6 +12,10 @@ app_service_plan_worker_count = 1
 function_dotnet_version       = "10.0"
 webapp_dotnet_version         = "10.0"
 use_stub_custodians           = true
+use_auxiliary_asp                       = true
+auxiliary_app_service_plan_sku          = "B1"
+auxiliary_app_service_plan_os_type      = "Linux"
+auxiliary_app_service_plan_worker_count = 1
 key_vault_use_rbac            = false
 
 find_app_settings = {

--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -12,6 +12,10 @@ app_service_plan_worker_count = 1
 function_dotnet_version       = "10.0"
 webapp_dotnet_version         = "10.0"
 use_stub_custodians           = true
+use_auxiliary_asp                       = true
+auxiliary_app_service_plan_sku          = "B1"
+auxiliary_app_service_plan_os_type      = "Linux"
+auxiliary_app_service_plan_worker_count = 1
 key_vault_use_rbac            = false
 
 find_app_settings = {


### PR DESCRIPTION
## Summary

Create a separate "Auxiliary" service plan for stubs and non-prod apps; so that the main app service plan is representative of how our system will run for real, and also so that the stubs, mocks, and demo apps do not interfere with the performance on the main apps (i.e. just Find API at the moment).  Ultimately this will ensure we get accurate readings on our Find API’s performance.

## Changes

New auxiliary ASP suffixed with `auxsvcs01` created in core.

- Optional via `use_auxiliary_asp` boolean
- `false` by default
- `d01` and `d02` set as true
- Created in the same region (UK West)
- Tier settings (B1, Linux, 1 worker)

## Validation

Plan terraform to d01 from branch
