### PR TITLE
chore(uiHarness): Deployment diagnostics improvements

### DIFF
--- a/Apps/UIHarness/src/SUI.UIHarness.Web/BuildTimestampUtility.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/BuildTimestampUtility.cs
@@ -1,0 +1,32 @@
+﻿using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace SUI.UIHarness.Web;
+
+public static partial class BuildTimestampUtility
+{
+    public static DateTimeOffset BuildTimestamp { get; } = ExtractBuildTimestampFromAssembly();
+
+    private static DateTimeOffset ExtractBuildTimestampFromAssembly()
+    {
+        // Note: `SourceRevisionId` must be set as expected in assembly's project file
+        var match = ExtractBuildTimestampRegex()
+            .Match(
+                typeof(BuildTimestampUtility)
+                    .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion
+                    ?? ""
+            );
+
+        return DateTimeOffset.ParseExact(
+            match.Groups["timestamp"].Value,
+            "O",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal
+        );
+    }
+
+    [GeneratedRegex(@"\+timestamp_(?<timestamp>.+)")]
+    private static partial Regex ExtractBuildTimestampRegex();
+}

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
@@ -50,8 +50,11 @@ app.MapStaticAssets();
 
 app.MapGet(
     "/api/health",
-    ([FromServices] IHostEnvironment env) =>
-        Results.Ok(
+    ([FromServices] IHostEnvironment env, [FromServices] ILogger<Program> logger) =>
+    {
+        logger.LogInformation("Health check was called");
+
+        return Results.Ok(
             new
             {
                 Value = "Healthy",
@@ -59,8 +62,10 @@ app.MapGet(
                 env.EnvironmentName,
                 nowUtc = DateTimeOffset.UtcNow,
                 nowLocal = DateTimeOffset.Now,
+                BuildTimestampUtility.BuildTimestamp,
             }
-        )
+        );
+    }
 );
 
 app.MapPost(

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/SUI.UIHarness.Web.csproj
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/SUI.UIHarness.Web.csproj
@@ -20,4 +20,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
+  <PropertyGroup>
+    <SourceRevisionId>timestamp_$([System.DateTimeOffset]::UtcNow.ToString("O"))</SourceRevisionId>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR adds a `BuildTimestamp` value and logging to the Test Harness' health check endpoint, to simplify Azure deployment debugging and diagnostics.  Manually tested and verified locally.