### PR TITLE
feat(find): sui-1745 - Cache loaded org directory in FindAPI's Custodian Service

### DIFF
--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/MockCustodianService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/MockCustodianService.cs
@@ -11,22 +11,67 @@ using SUI.Find.Domain.Models;
 
 namespace SUI.Find.Infrastructure.Services;
 
-public class MockCustodianService(IFileSystem fileSystem, IConfiguration config) : ICustodianService
+public class MockCustodianService : ICustodianService
 {
-    public async Task<IReadOnlyList<ProviderDefinition>> GetCustodiansAsync()
+    private readonly IFileSystem _fileSystem;
+    private readonly IConfiguration _config;
+    private readonly Lazy<IReadOnlyList<ProviderDefinition>> _custodians;
+
+    public MockCustodianService(IFileSystem fileSystem, IConfiguration config)
+    {
+        _fileSystem = fileSystem;
+        _config = config;
+        _custodians = new Lazy<IReadOnlyList<ProviderDefinition>>(Load);
+    }
+
+    public Task<IReadOnlyList<ProviderDefinition>> GetCustodiansAsync()
+    {
+        // Instantly returns the cached in-memory list as a completed Task
+        return Task.FromResult(_custodians.Value);
+    }
+
+    public Task<Result<ProviderDefinition>> GetCustodianAsync(string orgId)
+    {
+        var custodian = GetCustodianById(orgId, _custodians.Value);
+
+        var result =
+            custodian == null
+                ? Result<ProviderDefinition>.Fail($"Custodian with OrgId '{orgId}' not found.")
+                : Result<ProviderDefinition>.Ok(custodian);
+
+        return Task.FromResult(result);
+    }
+
+    public ProviderDefinition GetCustodian(
+        string orgId,
+        IReadOnlyCollection<ProviderDefinition> custodians
+    ) =>
+        GetCustodianById(orgId, custodians)
+        ?? throw new InvalidOperationException($"Custodian with OrgId '{orgId}' not found.");
+
+    private static ProviderDefinition? GetCustodianById(
+        string orgId,
+        IReadOnlyCollection<ProviderDefinition> custodians
+    ) =>
+        custodians.FirstOrDefault(p =>
+            string.Equals(p.OrgId, orgId, StringComparison.OrdinalIgnoreCase)
+        );
+
+    private IReadOnlyList<ProviderDefinition> Load()
     {
         const string fileName = "org-directory.json";
         var baseDir = AppContext.BaseDirectory;
         var filePath = Path.Combine(baseDir, "Data", fileName);
 
-        if (!File.Exists(filePath))
+        if (!_fileSystem.File.Exists(filePath))
         {
             throw new InvalidOperationException($"File not found at: {filePath}");
         }
 
-        var json = await fileSystem.File.ReadAllTextAsync(filePath);
+        // Changed to synchronous reading to fit perfectly inside the Lazy initialization thread safety
+        var json = _fileSystem.File.ReadAllText(filePath);
 
-        var stubCustodiansBaseUrl = config["StubCustodiansBaseUrl"];
+        var stubCustodiansBaseUrl = _config["StubCustodiansBaseUrl"];
         if (!string.IsNullOrWhiteSpace(stubCustodiansBaseUrl))
         {
             json = json.Replace("{StubCustodiansBaseUrl}", stubCustodiansBaseUrl);
@@ -118,29 +163,6 @@ public class MockCustodianService(IFileSystem fileSystem, IConfiguration config)
 
         return providers;
     }
-
-    private static ProviderDefinition? GetCustodianById(
-        string orgId,
-        IReadOnlyCollection<ProviderDefinition> custodians
-    ) =>
-        custodians.FirstOrDefault(p =>
-            string.Equals(p.OrgId, orgId, StringComparison.OrdinalIgnoreCase)
-        );
-
-    public async Task<Result<ProviderDefinition>> GetCustodianAsync(string orgId)
-    {
-        var custodian = GetCustodianById(orgId, await GetCustodiansAsync());
-        return custodian == null
-            ? Result<ProviderDefinition>.Fail($"Custodian with OrgId '{orgId}' not found.")
-            : Result<ProviderDefinition>.Ok(custodian);
-    }
-
-    public ProviderDefinition GetCustodian(
-        string orgId,
-        IReadOnlyCollection<ProviderDefinition> custodians
-    ) =>
-        GetCustodianById(orgId, custodians)
-        ?? throw new InvalidOperationException($"Custodian with OrgId '{orgId}' not found.");
 
     // Only used for deserializing the mock org-directory.json, so it can exist locally
     private sealed class MockOrgDirectory

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockCustodianServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockCustodianServiceTests.cs
@@ -23,7 +23,10 @@ public class MockCustodianServiceTests
         // Arrange: load the actual org-directory.json from Data
         var filePath = Path.Combine(AppContext.BaseDirectory, "Data", "org-directory.json");
         var fileContent = await File.ReadAllTextAsync(filePath);
-        _mockFileSystem.File.ReadAllTextAsync(Arg.Any<string>()).Returns(fileContent);
+
+        // Mock both the Exists check and the synchronous ReadAllText call
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act: get all custodians
         var providers = await _sut.GetCustodiansAsync();
@@ -48,8 +51,8 @@ public class MockCustodianServiceTests
         Assert.Contains("find-record.read fetch-record.read", la.Connection.Auth.Scopes);
         Assert.Equal("SUI-SERVICE", la.Connection.Auth.ClientId);
         Assert.Equal("SUIProject", la.Connection.Auth.ClientSecret);
-        // dsa policy
 
+        // dsa policy
         Assert.Equal(DateTimeOffset.Parse("2025-11-10T12:00:00Z"), la.DsaPolicy.Version);
         Assert.NotEmpty(la.DsaPolicy.Defaults);
         var defaultRule = la.DsaPolicy.Defaults.First();
@@ -89,7 +92,10 @@ public class MockCustodianServiceTests
         // Arrange
         var filePath = Path.Combine(AppContext.BaseDirectory, "Data", "org-directory.json");
         var fileContent = await File.ReadAllTextAsync(filePath);
-        _mockFileSystem.File.ReadAllTextAsync(Arg.Any<string>()).Returns(fileContent);
+
+        // Mock both the Exists check and the synchronous ReadAllText call
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         var targetOrgId = "LOCAL-AUTHORITY-01";
 
@@ -109,7 +115,10 @@ public class MockCustodianServiceTests
         // Arrange
         var filePath = Path.Combine(AppContext.BaseDirectory, "Data", "org-directory.json");
         var fileContent = await File.ReadAllTextAsync(filePath);
-        _mockFileSystem.File.ReadAllTextAsync(Arg.Any<string>()).Returns(fileContent);
+
+        // Mock both the Exists check and the synchronous ReadAllText call
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         var targetOrgId = "NON-EXISTENT-ORG-ID";
 
@@ -167,7 +176,10 @@ public class MockCustodianServiceTests
         // Arrange
         var filePath = Path.Combine(AppContext.BaseDirectory, "Data", "org-directory.json");
         var fileContent = await File.ReadAllTextAsync(filePath);
-        _mockFileSystem.File.ReadAllTextAsync(Arg.Any<string>()).Returns(fileContent);
+
+        // Mock both the Exists check and the synchronous ReadAllText call
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         _mockConfiguration["StubCustodiansBaseUrl"].Returns("https://example123.com");
 


### PR DESCRIPTION
## Summary

Cache the loaded org directory in MockCustodianService, so that the frequently called polling endpoints do not unnecessarily slow down the system.

## Changes

Memory caching should be a straight forward hold in an lazy in-memory list, following the pattern in the Stub’s FindApiAuthClientProvider:
- The logic to load the ‘provider definitions’ is moved in to a Lazy<IReadOnlyList<ProviderDefinition>> that is initialised in the class constructor
- The classes methods are refactored to use that in-memory list
- Update tests

## Validation

Validated by local and pipeline tests (unit, integration and E2E)