### PR TITLE
ops: SUI-1747 - Move the StubCustodians and UI Test Harness web apps in to the new "Auxiliary" service plan

### DIFF
--- a/terraform/custodians/main.tf
+++ b/terraform/custodians/main.tf
@@ -33,7 +33,9 @@ module "web_app" {
   name                = local.web_app_name
   resource_group_name = data.terraform_remote_state.core.outputs.resource_group_name
   location            = data.terraform_remote_state.core.outputs.resource_group_location
-  service_plan_id     = data.terraform_remote_state.core.outputs.app_service_plan_id
+  
+  # UPDATED: Use auxiliary plan if it exists, otherwise fall back to the shared plan
+  service_plan_id     = data.terraform_remote_state.core.outputs.auxiliary_app_service_plan_id != null ? data.terraform_remote_state.core.outputs.auxiliary_app_service_plan_id : data.terraform_remote_state.core.outputs.app_service_plan_id
 
   environment_tag  = var.environment_tag
   product          = var.product

--- a/terraform/ui_test_harness/main.tf
+++ b/terraform/ui_test_harness/main.tf
@@ -108,7 +108,9 @@ module "web_app" {
   name                = local.web_app_name
   resource_group_name = data.terraform_remote_state.core.outputs.resource_group_name
   location            = data.terraform_remote_state.core.outputs.resource_group_location
-  service_plan_id     = data.terraform_remote_state.core.outputs.app_service_plan_id
+  
+  # UPDATED: Use auxiliary plan if it exists, otherwise fall back to the shared plan
+  service_plan_id     = data.terraform_remote_state.core.outputs.auxiliary_app_service_plan_id != null ? data.terraform_remote_state.core.outputs.auxiliary_app_service_plan_id : data.terraform_remote_state.core.outputs.app_service_plan_id
 
   environment_tag  = var.environment_tag
   product          = var.product


### PR DESCRIPTION
## Summary

Move the StubCustodians and UI Test Harness web apps in to the new "Auxiliary" service plan; so that the main app service plan is representative of how our system will run for real, and also so that the stubs, mocks, and demo apps do not interfere with the performance on the main apps

## Changes

- The StubCustodians web app is moved to be inside the new Auxiliary service plan
- The UI Test Harness web app is moved to be inside the new Auxiliary service plan
- The changes are applied to the d01 environment
- The d02 environment is unchanged (we’ll deploy the changes to d02 in a batch at a later date)

## Validation

Planned and deployed from branch
Checked via Azure portal
