### PR TITLE
feat(auth): SUI-1757 - Auth Emulator app: add health check endpoint

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -236,7 +236,7 @@ jobs:
             --results-directory TestResults \
             -e E2E__BaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}func-${{ steps.env_config.outputs.region_short }}-find01.azurewebsites.net/api/ \
             -e E2E__StubCustodiansBaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-custodians01.azurewebsites.net/api/ \
-            -e E2E__AuthEmulatorHealthCheckEndpoint=null \
+            -e E2E__AuthEmulatorHealthCheckEndpoint="" \
             -e E2E__SkipResetAzureTables=True \
             -e E2E__AccessTokenUrl="v1/auth/token" \
             -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Custodian') && github.event.workflow_run.run_started_at || '' }} \

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -189,6 +189,7 @@ jobs:
             -e E2E__BaseUrl=http://localhost:7182/api/ \
             -e E2E__StubCustodiansBaseUrl=http://localhost:5193/api/ \
             -e E2E__AccessTokenUrl=http://localhost:5250/api/v1/auth/token \
+            -e E2E__AuthEmulatorHealthCheckEndpoint=http://localhost:5250/api/health \
             -e E2E__SkipResetAzureTables=False \
             -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} \
             -e E2E__CheckFindApiBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} # The threshold checks are not necessary for ephemeral e2e tests, but are included to verify the threshold behaviour at pull request stage

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -236,6 +236,7 @@ jobs:
             --results-directory TestResults \
             -e E2E__BaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}func-${{ steps.env_config.outputs.region_short }}-find01.azurewebsites.net/api/ \
             -e E2E__StubCustodiansBaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-custodians01.azurewebsites.net/api/ \
+            -e E2E__AuthEmulatorHealthCheckEndpoint=null \
             -e E2E__SkipResetAzureTables=True \
             -e E2E__AccessTokenUrl="v1/auth/token" \
             -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Custodian') && github.event.workflow_run.run_started_at || '' }} \

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -192,6 +192,7 @@ jobs:
             -e E2E__AuthEmulatorHealthCheckEndpoint=http://localhost:5250/api/health \
             -e E2E__SkipResetAzureTables=False \
             -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} \
+            -e E2E__CheckAuthEmulatorApiBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} \
             -e E2E__CheckFindApiBuildTimestampThreshold=${{ needs.eval-workflow-setup.outputs.job_start_time }} # The threshold checks are not necessary for ephemeral e2e tests, but are included to verify the threshold behaviour at pull request stage
 
       - name: Publish E2E test summary (ephemeral)
@@ -236,10 +237,11 @@ jobs:
             --results-directory TestResults \
             -e E2E__BaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}func-${{ steps.env_config.outputs.region_short }}-find01.azurewebsites.net/api/ \
             -e E2E__StubCustodiansBaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-custodians01.azurewebsites.net/api/ \
+            -e E2E__AccessTokenUrl="v1/auth/token" \
             -e E2E__AuthEmulatorHealthCheckEndpoint="" \
             -e E2E__SkipResetAzureTables=True \
-            -e E2E__AccessTokenUrl="v1/auth/token" \
             -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Custodian') && github.event.workflow_run.run_started_at || '' }} \
+            -e E2E__CheckAuthEmulatorApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'AuthEmulator') && github.event.workflow_run.run_started_at || '' }} \
             -e E2E__CheckFindApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Find') && github.event.workflow_run.run_started_at || '' }} # We pass the run_started_at value(s) so that we ensure the relevant API has restarted with the latest version. Note that this will pass an empty value if this pipeline was not trigerred by a workflow_run for that specific API, but that is fine and desired in that case (because we only need the check when this pipeline is immediately trigerred by the workflow_run after deployment of that specific API)
 
       - name: Publish E2E test summary (dev)

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/HealthController.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/HealthController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using SUI.AuthEmulator.Utility;
+
+namespace SUI.AuthEmulator.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class HealthController(IHostEnvironment env, ILogger<AuthController> logger) : ControllerBase
+{
+    private const string ServiceName = nameof(AuthEmulator);
+
+    [HttpGet]
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public object Get()
+    {
+        logger.LogInformation($"`{nameof(HealthController)}` was called");
+
+        Response.Headers["x-service-name"] = ServiceName;
+        Response.Headers["x-environment-name"] = env.EnvironmentName;
+
+        return new
+        {
+            Value = "Healthy",
+            ServiceName,
+            env.EnvironmentName,
+            nowUtc = DateTimeOffset.UtcNow,
+            nowLocal = DateTimeOffset.Now,
+            BuildTimestampUtility.BuildTimestamp,
+        };
+    }
+}

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/SUI.AuthEmulator.csproj
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/SUI.AuthEmulator.csproj
@@ -16,4 +16,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <PropertyGroup>
+    <SourceRevisionId>timestamp_$([System.DateTimeOffset]::UtcNow.ToString("O"))</SourceRevisionId>
+  </PropertyGroup>
 </Project>

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Utility/BuildTimestampUtility.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Utility/BuildTimestampUtility.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace SUI.AuthEmulator.Utility;
+
+public static partial class BuildTimestampUtility
+{
+    public static DateTimeOffset BuildTimestamp { get; } = ExtractBuildTimestampFromAssembly();
+
+    private static DateTimeOffset ExtractBuildTimestampFromAssembly()
+    {
+        // Note: `SourceRevisionId` must be set as expected in assembly's project file
+        var match = ExtractBuildTimestampRegex()
+            .Match(
+                typeof(BuildTimestampUtility)
+                    .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion
+                    ?? ""
+            );
+
+        return DateTimeOffset.ParseExact(
+            match.Groups["timestamp"].Value,
+            "O",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal
+        );
+    }
+
+    [GeneratedRegex(@"\+timestamp_(?<timestamp>.+)")]
+    private static partial Regex ExtractBuildTimestampRegex();
+}

--- a/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
@@ -23,4 +23,7 @@ public record Config
     public DateTimeOffset? CheckStubCustodiansApiBuildTimestampThreshold { get; init; }
 
     public string AccessTokenUrl { get; init; } = "https://localhost:7250/api/v1/auth/token";
+
+    public string? AuthEmulatorHealthCheckEndpoint { get; init; } =
+        "https://localhost:7250/api/health";
 }

--- a/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
@@ -26,4 +26,6 @@ public record Config
 
     public string? AuthEmulatorHealthCheckEndpoint { get; init; } =
         "https://localhost:7250/api/health";
+
+    public DateTimeOffset? CheckAuthEmulatorApiBuildTimestampThreshold { get; init; }
 }

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -84,7 +84,7 @@ public class FunctionTestFixture : IAsyncLifetime
 
     private async Task EnsureAuthEndpointApiIsUpAsync(ITestOutputHelper testOutputHelper)
     {
-        if (Config.AuthEmulatorHealthCheckEndpoint != null)
+        if (!string.IsNullOrEmpty(Config.AuthEmulatorHealthCheckEndpoint))
         {
             TestContext.Current.SendDiagnosticMessage("Checking Auth Emulator API health...");
 

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -12,6 +12,7 @@ public class FunctionTestFixture : IAsyncLifetime
 {
     private bool _tableResetComplete;
     private readonly SemaphoreSlim _resetTablesMutex = new(1, 1);
+    private const string HealthEndpointUrl = "health";
 
     public Config Config { get; }
 
@@ -64,19 +65,37 @@ public class FunctionTestFixture : IAsyncLifetime
         await EnsureServiceIsUpAsync(
             "Find API",
             Client,
+            HealthEndpointUrl,
             testOutputHelper,
             checkBuildTimestampThreshold: Config.CheckFindApiBuildTimestampThreshold
         );
     }
 
-    public async Task EnsureStubCustodiansApiIsUpAsync(ITestOutputHelper testOutputHelper)
+    private async Task EnsureStubCustodiansApiIsUpAsync(ITestOutputHelper testOutputHelper)
     {
         await EnsureServiceIsUpAsync(
             "StubCustodians API",
             StubCustodiansClient,
+            HealthEndpointUrl,
             testOutputHelper,
             checkBuildTimestampThreshold: Config.CheckStubCustodiansApiBuildTimestampThreshold
         );
+    }
+
+    private async Task EnsureAuthEndpointApiIsUpAsync(ITestOutputHelper testOutputHelper)
+    {
+        if (Config.AuthEmulatorHealthCheckEndpoint != null)
+        {
+            TestContext.Current.SendDiagnosticMessage("Checking Auth Emulator API health...");
+
+            await EnsureServiceIsUpAsync(
+                "AuthEmulator API",
+                Client,
+                Config.AuthEmulatorHealthCheckEndpoint,
+                testOutputHelper,
+                checkBuildTimestampThreshold: Config.CheckFindApiBuildTimestampThreshold
+            );
+        }
     }
 
     public async Task EnsureServicesAreUpAsync(ITestOutputHelper testOutputHelper)
@@ -87,7 +106,8 @@ public class FunctionTestFixture : IAsyncLifetime
 
         await Task.WhenAll(
             EnsureFindApiIsUpAsync(testOutputHelper),
-            EnsureStubCustodiansApiIsUpAsync(testOutputHelper)
+            EnsureStubCustodiansApiIsUpAsync(testOutputHelper),
+            EnsureAuthEndpointApiIsUpAsync(testOutputHelper)
         );
     }
 
@@ -152,11 +172,11 @@ public class FunctionTestFixture : IAsyncLifetime
     private static async Task EnsureServiceIsUpAsync(
         string serviceName,
         HttpClient client,
+        string url,
         ITestOutputHelper testOutputHelper,
         DateTimeOffset? checkBuildTimestampThreshold = null
     )
     {
-        const string url = "health";
         var waitInterval = TimeSpan.FromSeconds(10);
 
         testOutputHelper.WriteLine($"Checking {serviceName} is up: {client.BaseAddress}{url}");

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -82,7 +82,7 @@ public class FunctionTestFixture : IAsyncLifetime
         );
     }
 
-    private async Task EnsureAuthEndpointApiIsUpAsync(ITestOutputHelper testOutputHelper)
+    private async Task EnsureAuthEmulatorApiIsUpAsync(ITestOutputHelper testOutputHelper)
     {
         if (!string.IsNullOrEmpty(Config.AuthEmulatorHealthCheckEndpoint))
         {
@@ -93,7 +93,7 @@ public class FunctionTestFixture : IAsyncLifetime
                 Client,
                 Config.AuthEmulatorHealthCheckEndpoint,
                 testOutputHelper,
-                checkBuildTimestampThreshold: Config.CheckFindApiBuildTimestampThreshold
+                checkBuildTimestampThreshold: Config.CheckAuthEmulatorApiBuildTimestampThreshold
             );
         }
     }
@@ -107,7 +107,7 @@ public class FunctionTestFixture : IAsyncLifetime
         await Task.WhenAll(
             EnsureFindApiIsUpAsync(testOutputHelper),
             EnsureStubCustodiansApiIsUpAsync(testOutputHelper),
-            EnsureAuthEndpointApiIsUpAsync(testOutputHelper)
+            EnsureAuthEmulatorApiIsUpAsync(testOutputHelper)
         );
     }
 


### PR DESCRIPTION
## Summary

Add a health check endpoint for the Auth Emulator app, and update the E2E tests to also check for this endpoint.

## Changes
- Add new controller with health check endpoint
- Add new method in E2E test fixture to include new endpoint in the health check step
- Add new config to isolate the health check endpoint to specific environments

## Validation
- Unit, integration, and E2E tests all pass