### PR TITLE
chore: SUI-1792 - Remove PersonIdValue record and related components

### DIFF
--- a/Apps/Find/src/SUI.Find.Application/Interfaces/IMatchPersonOrchestrationService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Interfaces/IMatchPersonOrchestrationService.cs
@@ -11,7 +11,7 @@ namespace SUI.Find.Application.Interfaces;
 /// </summary>
 public interface IMatchPersonOrchestrationService
 {
-    Task<OneOf<PersonIdValue, DataQualityResult, NotFound, Error>> FindPersonIdAsync(
+    Task<OneOf<string, DataQualityResult, NotFound, Error>> FindPersonIdAsync(
         PersonSpecification specification,
         string clientId,
         CancellationToken ct

--- a/Apps/Find/src/SUI.Find.Application/Models/Matching/PersonIdValue.cs
+++ b/Apps/Find/src/SUI.Find.Application/Models/Matching/PersonIdValue.cs
@@ -1,5 +1,0 @@
-namespace SUI.Find.Application.Models.Matching;
-
-public abstract record PersonIdValue(string Value);
-
-public sealed record PlainPersonId(string Value) : PersonIdValue(Value);

--- a/Apps/Find/src/SUI.Find.Application/Services/MatchPersonOrchestrationService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/MatchPersonOrchestrationService.cs
@@ -15,7 +15,7 @@ public class MatchPersonOrchestrationService(
     ICustodianService custodianService
 ) : IMatchPersonOrchestrationService
 {
-    public async Task<OneOf<PersonIdValue, DataQualityResult, NotFound, Error>> FindPersonIdAsync(
+    public async Task<OneOf<string, DataQualityResult, NotFound, Error>> FindPersonIdAsync(
         PersonSpecification specification,
         string clientId,
         CancellationToken ct
@@ -26,19 +26,20 @@ public class MatchPersonOrchestrationService(
         if (matchResult.TryPickT0(out var personId, out var remainder))
         {
             var getPersonIdResult = await HandlePersonIdRepresentationAsync(personId, clientId);
-            return getPersonIdResult.Match<
-                OneOf<PersonIdValue, DataQualityResult, NotFound, Error>
-            >(plainId => plainId, error => error);
+            return getPersonIdResult.Match<OneOf<string, DataQualityResult, NotFound, Error>>(
+                plainId => plainId,
+                error => error
+            );
         }
 
-        return remainder.Match<OneOf<PersonIdValue, DataQualityResult, NotFound, Error>>(
+        return remainder.Match<OneOf<string, DataQualityResult, NotFound, Error>>(
             dataQuality => dataQuality,
             notFound => notFound,
             error => error
         );
     }
 
-    private async Task<OneOf<PersonIdValue, Error>> HandlePersonIdRepresentationAsync(
+    private async Task<OneOf<string, Error>> HandlePersonIdRepresentationAsync(
         NhsPersonId nhsPersonId,
         string clientId
     )
@@ -50,6 +51,6 @@ public class MatchPersonOrchestrationService(
             return new Error();
         }
 
-        return new PlainPersonId(nhsPersonId.Value);
+        return nhsPersonId.Value;
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/MatchFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/MatchFunction.cs
@@ -150,7 +150,7 @@ public class MatchFunction(
                         await idRegisterRepository.UpsertAsync(
                             new IdRegisterEntry
                             {
-                                Sui = id.Value,
+                                Sui = id,
                                 CustodianId = authContext.ClientId,
                                 RecordType = entry.RecordType,
                                 SystemId = entry.SystemId,
@@ -165,7 +165,7 @@ public class MatchFunction(
 
                 return await HttpResponseUtility.OkResponse(
                     req,
-                    new PersonMatch(id.Value),
+                    new PersonMatch(id),
                     cancellationToken
                 );
             },

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/PersonIdRepresentationServiceTests/FindPersonIdAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/PersonIdRepresentationServiceTests/FindPersonIdAsyncTests.cs
@@ -50,7 +50,7 @@ public class FindPersonIdAsyncTests
         );
 
         // Assert
-        Assert.IsType<PlainPersonId>(result.Value);
+        Assert.IsType<string>(result.Value);
     }
 
     [Fact]

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/MatchFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/MatchFunctionTests.cs
@@ -87,7 +87,7 @@ public class MatchFunctionTests
         var validRequest = CreateMatchRequest();
         var headers = CreateHeadersWithApiKey();
         var req = MockHttpRequestData.CreateJson(validRequest, headers: headers);
-        var personId = new PlainPersonId("some-person-id");
+        var personId = "some-person-id";
         _matchPersonOrchestrationService
             .FindPersonIdAsync(
                 Arg.Any<PersonSpecification>(),
@@ -104,7 +104,7 @@ public class MatchFunctionTests
         response.Body.Position = 0;
         var responseBody = await JsonSerializer.DeserializeAsync<PersonMatch>(response.Body);
         Assert.NotNull(responseBody);
-        Assert.Equal(personId.Value, responseBody.PersonId);
+        Assert.Equal(personId, responseBody.PersonId);
         await _idRegisterRepository
             .Received(1)
             .UpsertAsync(
@@ -369,7 +369,7 @@ public class MatchFunctionTests
         var headers = CreateHeadersWithApiKey();
         var req = MockHttpRequestData.CreateJson(request, headers: headers);
 
-        var personId = new PlainPersonId("some-person-id");
+        var personId = "some-person-id";
 
         _matchPersonOrchestrationService
             .FindPersonIdAsync(


### PR DESCRIPTION
## Summary

Remove the PersonId record from Find since it serves no purpose after the removal of encryption components.

## Changes

- PersonId record and all of it’s extensions are removed

## Validation

Unit tests, E2E tests and pipeline workflows pass successfully
