### PR TITLE
fix: show gitleaks findings in pre-commit output

### DIFF
--- a/scripts/security/run-gitleaks.ps1
+++ b/scripts/security/run-gitleaks.ps1
@@ -171,7 +171,7 @@ function Invoke-Gitleaks {
     )
 
     & $CommandPath @Arguments
-    return $LASTEXITCODE
+    $script:gitleaksExitCode = $LASTEXITCODE
 }
 
 if ($env:SUI_SKIP_GITLEAKS -eq "1") {
@@ -196,7 +196,8 @@ try {
             "--report-path", $baselinePath
         )
 
-        $exitCode = Invoke-Gitleaks -CommandPath $gitleaksCommand -Arguments $baselineArguments
+        Invoke-Gitleaks -CommandPath $gitleaksCommand -Arguments $baselineArguments
+        $exitCode = $script:gitleaksExitCode
         if ($exitCode -ne 0) {
             exit $exitCode
         }
@@ -210,6 +211,7 @@ try {
         "--pre-commit",
         "--staged",
         "--redact",
+        "--verbose",
         "--config", $configPath
     )
 
@@ -217,7 +219,8 @@ try {
         $preCommitArguments += @("--baseline-path", $baselinePath)
     }
 
-    $exitCode = Invoke-Gitleaks -CommandPath $gitleaksCommand -Arguments $preCommitArguments
+    Invoke-Gitleaks -CommandPath $gitleaksCommand -Arguments $preCommitArguments
+    $exitCode = $script:gitleaksExitCode
     if ($exitCode -eq 0) {
         exit 0
     }


### PR DESCRIPTION
## Summary

Updates the local GitLeaks pre-commit wrapper so developers can see where a finding is, while still keeping detected secret values redacted.

Previously, the PowerShell wrapper captured GitLeaks stdout when reading the exit code, which meant useful verbose finding details such as file, line, rule ID, and fingerprint were not shown in the hook output.

## Changes

- Adds `--verbose` to the pre-commit GitLeaks invocation so findings include actionable location metadata.
- Keeps `--redact` enabled so secret values are not printed to the terminal.
- Changes the wrapper to preserve GitLeaks stdout while still using the native exit code to block commits when findings are present.

## Validation

- Ran the pre-commit wrapper with no staged leaks: `dotnet pwsh ./scripts/security/run-gitleaks.ps1 -NoInstall`.
- Verified a staged dummy high-entropy `api_key` finding prints `RuleID`, `File`, `Line`, and `Fingerprint` with the secret value redacted.
- Confirmed Husky ran successfully during the commit and GitLeaks passed for the committed change.