### PR TITLE
chore: SUI-1710 - trigger the E2E Test workflow when the Auth Emulator changes

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -48,6 +48,7 @@ on:
       - Terraform Custodians
       - 'Build, Test, Deploy: "Find" Solution'
       - 'Build, Test, Deploy: "Custodians" Solution'
+      - 'Build, Test, Deploy: "Auth Emulator" Solution'
     branches: [main]
     types: [completed]
 
@@ -57,6 +58,8 @@ on:
     paths:
       - "Apps/Find/**"
       - "Apps/StubCustodians/**"
+      - "Apps/AuthEmulator/**"
+      - "Data/**"
       - .github/workflows/find-e2e-tests.yml
 
   pull_request:
@@ -65,6 +68,8 @@ on:
     paths:
       - "Apps/Find/**"
       - "Apps/StubCustodians/**"
+      - "Apps/AuthEmulator/**"
+      - "Data/**"
       - .github/workflows/find-e2e-tests.yml
 
 concurrency:
@@ -240,9 +245,9 @@ jobs:
             -e E2E__AccessTokenUrl="v1/auth/token" \
             -e E2E__AuthEmulatorHealthCheckEndpoint="" \
             -e E2E__SkipResetAzureTables=True \
-            -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Custodian') && github.event.workflow_run.run_started_at || '' }} \
-            -e E2E__CheckAuthEmulatorApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'AuthEmulator') && github.event.workflow_run.run_started_at || '' }} \
-            -e E2E__CheckFindApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Find') && github.event.workflow_run.run_started_at || '' }} # We pass the run_started_at value(s) so that we ensure the relevant API has restarted with the latest version. Note that this will pass an empty value if this pipeline was not trigerred by a workflow_run for that specific API, but that is fine and desired in that case (because we only need the check when this pipeline is immediately trigerred by the workflow_run after deployment of that specific API)
+            -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Build, Test, Deploy: "Custodians" Solution') && github.event.workflow_run.run_started_at || '' }} \
+            -e E2E__CheckAuthEmulatorApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Build, Test, Deploy: "Auth Emulator" Solution') && github.event.workflow_run.run_started_at || '' }} \
+            -e E2E__CheckFindApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Build, Test, Deploy: "Find" Solution') && github.event.workflow_run.run_started_at || '' }} # We pass the run_started_at value(s) so that we ensure the relevant API has restarted with the latest version. Note that this will pass an empty value if this pipeline was not trigerred by a workflow_run for that specific API, but that is fine and desired in that case (because we only need the check when this pipeline is immediately trigerred by the workflow_run after deployment of that specific API)
 
       - name: Publish E2E test summary (dev)
         if: always()


### PR DESCRIPTION
## Summary

This PR hooks the E2E Test workflow to be triggered when the Auth Emulator changes, like the Find and Stubs apps, because the Auth Emulator is involved in the E2E flow (ephemeral and deployed dev environments).

## Changes

- Updated triggers to hook in to changes to the Auth Emulator.

Also:
* Updated build timestamp threshold checks to specify the corresponding workflow names explicitly, to improve cohesion when looking at the code.
* Added missing Data directory trigger.

## Validation

- Linting and manually double checking
- PR validation checks