### PR TITLE
feat(uiHarness): SUI-1774 - Update Custodian dropdown and label to display Organisation ID

### DIFF
--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/EnrolTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/EnrolTab.razor
@@ -52,13 +52,13 @@
                     <td>@(p.Email ?? "")</td>
                     <td>@p.Postcode</td>
                     <td class="nhs-number">
-                        @if (_enrolledForOrg == SelectedOrg)
+                        @if (_enrolledForOrg == SelectedOrgClientId)
                         {
                             @p.NhsNumber
                         }
                     </td>
                     <td class="actions">
-                        @if (!string.IsNullOrEmpty(p.NhsNumber) && p.NhsNumber != "Not Found" && _enrolledForOrg == SelectedOrg)
+                        @if (!string.IsNullOrEmpty(p.NhsNumber) && p.NhsNumber != "Not Found" && _enrolledForOrg == SelectedOrgClientId)
                         {
                             <button class="btn btn-primary" type="button" @onclick="_ => SetCurrentPerson(p)">Find Records</button>
                         }
@@ -117,7 +117,7 @@
     private string? _enrolledForOrg;
     
     [Parameter]
-    public required string SelectedOrg { get; set; }
+    public required string SelectedOrgClientId { get; set; }
     
     [Parameter]
     public EventCallback<LocalPerson> CurrentPersonChanged { get; set; }
@@ -130,17 +130,17 @@
 
     protected override void OnParametersSet()
     {
-        _noOrgSelected = string.IsNullOrEmpty(SelectedOrg);
+        _noOrgSelected = string.IsNullOrEmpty(SelectedOrgClientId);
     }
 
     private async Task Enrol()
     {
-        if (string.IsNullOrEmpty(SelectedOrg))
+        if (string.IsNullOrEmpty(SelectedOrgClientId))
         {
             return;
         }
         
-        Logger.LogInformation("Enrol button clicked for organisation: {SelectedOrg}", SelectedOrg);
+        Logger.LogInformation("Enrol button clicked for organisation: {SelectedOrgClientId}", SelectedOrgClientId);
 
         _enrolledForOrg = null;
         EnrolProgress = 0;
@@ -149,9 +149,9 @@
         foreach (var person in _dataToOnboard)
         {
             EnrolProgress += a;
-            var result = await FindService.MatchRecord(person, SelectedOrg);
+            var result = await FindService.MatchRecord(person, SelectedOrgClientId);
             person.NhsNumber = result.PersonId;
-            _enrolledForOrg ??= SelectedOrg;
+            _enrolledForOrg ??= SelectedOrgClientId;
             await InvokeAsync(StateHasChanged);
             await Task.Delay(500);
         }

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FetchTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FetchTab.razor
@@ -23,7 +23,7 @@
         </div>
     </div>
 }
-@if (_currentRecord != null && _fetchedForOrg == SelectedOrg)
+@if (_currentRecord != null && _fetchedForOrg == SelectedOrgClientId)
 {
     <div id="fetchContent">
         <div class="row g-3">
@@ -355,7 +355,7 @@
     public required string SelectedRecordUrl { get; set; }
     
     [Parameter]
-    public required string SelectedOrg { get; set; }
+    public required string SelectedOrgClientId { get; set; }
     
     [Inject]
     public required IFindService FindService { get; set; }
@@ -371,7 +371,7 @@
     
     private async Task FetchRecord()
     {
-        if (string.IsNullOrEmpty(SelectedRecordUrl) || string.IsNullOrEmpty(SelectedOrg))
+        if (string.IsNullOrEmpty(SelectedRecordUrl) || string.IsNullOrEmpty(SelectedOrgClientId))
         {
             return;
         }
@@ -381,8 +381,8 @@
         _fetchProgress = 10;
         await InvokeAsync(StateHasChanged);
         _showFetchProgress = true;
-        _currentRecord = await FindService.FetchRecord(SelectedOrg, SelectedRecordUrl);
-        _fetchedForOrg = SelectedOrg;
+        _currentRecord = await FindService.FetchRecord(SelectedOrgClientId, SelectedRecordUrl);
+        _fetchedForOrg = SelectedOrgClientId;
         _fetchProgress = 50;
         await InvokeAsync(StateHasChanged);
         if (_currentRecord is { RecordType: "education.details", Payload: not null })

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Controls/FindTab.razor
@@ -41,7 +41,7 @@
         </tr>
         </thead>
         <tbody>
-        @if (_foundRecordsFor?.Org == SelectedOrg && _foundRecordsFor?.NhsNumber == CurrentPerson?.NhsNumber)
+        @if (_foundRecordsFor?.Org == SelectedOrgClientId && _foundRecordsFor?.NhsNumber == CurrentPerson?.NhsNumber)
         {
             foreach (var p in _foundRecords)
             {
@@ -82,7 +82,7 @@
     public LocalPerson? CurrentPerson { get; set; }
     
     [Parameter]
-    public required string SelectedOrg { get; set; }
+    public required string SelectedOrgClientId { get; set; }
     
     [Parameter]
     public required string Architecture { get; set; }
@@ -106,7 +106,7 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (!_showFindProgress && _foundRecordsFor != (SelectedOrg, CurrentPerson?.NhsNumber))
+        if (!_showFindProgress && _foundRecordsFor != (SelectedOrgClientId, CurrentPerson?.NhsNumber))
         {
             await FindRecords();
         }
@@ -131,14 +131,14 @@
 
         try
         {
-            var workItemId = await FindService.StartSearch(SelectedOrg, CurrentPerson.NhsNumber, usePolling);
+            var workItemId = await FindService.StartSearch(SelectedOrgClientId, CurrentPerson.NhsNumber, usePolling);
             await CurrentWorkItemIdChanged.InvokeAsync(workItemId);
 
             var keepPolling = true;
             var stopwatch = Stopwatch.StartNew();
             while (keepPolling && !HasCurrentNhsNumberChanged())
             {
-                var result = await FindService.FindRecords(SelectedOrg, workItemId, usePolling);
+                var result = await FindService.FindRecords(SelectedOrgClientId, workItemId, usePolling);
 
                 if (HasCurrentNhsNumberChanged())
                 {
@@ -166,7 +166,7 @@
                     }
 
                     _foundRecords.Add(record);
-                    _foundRecordsFor ??= (SelectedOrg, CurrentPerson.NhsNumber);
+                    _foundRecordsFor ??= (SelectedOrgClientId, CurrentPerson.NhsNumber);
                 
                     await InvokeAsync(StateHasChanged);
                 }

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Pages/Home.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Pages/Home.razor
@@ -2,7 +2,6 @@
 @attribute [Authorize]
 @using SUI.UIHarness.Web.Components.Controls
 @using SUI.UIHarness.Web.Models
-@using SUI.UIHarness.Web.Models.Find
 @using SUI.UIHarness.Web.Services
 
 <PageTitle>SUI Test Harness</PageTitle>
@@ -11,7 +10,7 @@
 
 <div class="" style="padding-top: 24px;">
     <div class="mb-3">
-        <p><strong>Current Custodian:</strong> @_selectedOrg</p>
+        <p><strong>Current Custodian:</strong> @_displayOrganisationId</p>
     </div>
     
     <ul class="nav nav-tabs mt-3" id="mainTabs" role="tablist">
@@ -27,13 +26,13 @@
     </ul>
     <div class="tab-content border border-top-0 p-3" id="mainTabsContent">
         <div class="tab-pane fade show active" id="tab-enrol" role="tabpanel" hidden='@(_currentTab != "enrol")'>
-            <EnrolTab SelectedOrg="@_selectedOrg" CurrentPersonChanged="HandleCurrentPersonChanged"></EnrolTab>
+            <EnrolTab SelectedOrgClientId="@_selectedOrgClientId" CurrentPersonChanged="HandleCurrentPersonChanged"></EnrolTab>
         </div>
         <div class="tab-pane fade show active" id="tab-find" role="tabpanel" hidden='@(_currentTab != "find")'>
-            <FindTab SelectedOrg="@_selectedOrg" Architecture="@_architecture" CurrentPerson="_currentPerson" CurrentRecordChanged="HandleCurrentRecordChanged" CurrentWorkItemIdChanged="workItemId => _currentWorkItemId = workItemId"></FindTab>
+            <FindTab SelectedOrgClientId="@_selectedOrgClientId" Architecture="@_architecture" CurrentPerson="_currentPerson" CurrentRecordChanged="HandleCurrentRecordChanged" CurrentWorkItemIdChanged="workItemId => _currentWorkItemId = workItemId"></FindTab>
         </div>
         <div class="tab-pane fade show active" id="tab-fetch" role="tabpanel" hidden='@(_currentTab != "fetch")'>
-            <FetchTab SelectedOrg="@_selectedOrg" SelectedRecordUrl="@_selectedRecordUrl"></FetchTab>
+            <FetchTab SelectedOrgClientId="@_selectedOrgClientId" SelectedRecordUrl="@_selectedRecordUrl"></FetchTab>
         </div>
     </div>
     <div class="pt-3 small text-black-50">
@@ -55,7 +54,8 @@
     [CascadingParameter]
     private Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
 
-    private string _selectedOrg = string.Empty;
+    private string _selectedOrgClientId = string.Empty;
+    private string _displayOrganisationId = string.Empty;
     private string _architecture = string.Empty;
     private string _currentTab = "enrol";
     private LocalPerson? _currentPerson;
@@ -69,14 +69,25 @@
     [Inject]
     public required IConfiguration Configuration { get; set; }
 
+    // Inject the provider to resolve Organisation IDs from Client IDs
+    [Inject]
+    public required IFindApiAuthClientProvider FindApiAuthClientProvider { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthenticationStateTask;
         var user = authState.User;
         if (user.Identity?.IsAuthenticated == true)
         {
-            _selectedOrg = user.Identity.Name ?? string.Empty;
+            _selectedOrgClientId = user.Identity.Name ?? string.Empty;
             _architecture = user.FindFirst("Architecture")?.Value ?? ArchitectureConstants.DefaultArchitecture;
+
+            // Resolve the OrganisationId from the loaded directory list
+            var clients = FindApiAuthClientProvider.GetAuthClients();
+            var matchingClient = clients.FirstOrDefault(c => c.ClientId == _selectedOrgClientId);
+            
+            // Fall back to the Client ID if no mapping exists
+            _displayOrganisationId = matchingClient?.OrganisationId ?? _selectedOrgClientId;
         }
     }
 

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Pages/Login.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Pages/Login.razor
@@ -26,7 +26,7 @@
                         <option value="" selected="@(string.IsNullOrEmpty(CustodianName))">Select...</option>
                         @foreach (var authClient in _authClients)
                         {
-                            <option key="@authClient.ClientId" value="@authClient.ClientId" selected="@(CustodianName == authClient.ClientId)">@authClient.ClientId</option>
+                            <option key="@authClient.ClientId" value="@authClient.ClientId" selected="@(CustodianName == authClient.ClientId)">@authClient.OrganisationId</option>
                         }
                     </select>
                 </div>

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Models/AuthClient.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Models/AuthClient.cs
@@ -1,3 +1,3 @@
 ﻿namespace SUI.UIHarness.Web.Models;
 
-public record AuthClient(string ClientId, string ClientSecret, bool Enabled);
+public record AuthClient(string ClientId, string ClientSecret, string OrganisationId, bool Enabled);


### PR DESCRIPTION
## Summary

Display the Organisation ID property in the Custodian dropdown and label in the Test Harness, so that eventually the Client ID can be any value to enable integrating with 3rd party identity providers.

## Changes

- string `OrganisationId` property is added to `SUI.UIHarness.Web.Models.AuthClient`.
- Custodian dropdown (Login.razor) updated to display `OrganisationId` but still use `ClientId` as value.
- The “Current Custodian” label (Home.razor) is updated to display the `OrganisationId`.
- It will most likely need to lookup the `OrganisationId` from the `_selectedOrgClientId` in the `OnInitializedAsync` method (Home.razor).
- The `SelectedOrg` value remain as the ClientId.
- The `SelectedOrg` properties and `_selectedOrg` fields are renamed to `SelectedOrgClientId` and `_selectedOrgClientId` respectively.

## Validation

Test Harness UI based validation
