### PR TITLE
feat(AuthEmulator): SUI-1776 - Add JWKS endpoint to Auth Emulator

### DIFF
--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/JWKSController.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/JWKSController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using SUI.AuthEmulator.Services;
+
+namespace SUI.AuthEmulator.Controllers;
+
+[ApiController]
+[Route("api/v1/jwks")]
+public class JWKSController : ControllerBase
+{
+    private readonly IJwksKeyProvider _jwksKeyProvider;
+
+    public JWKSController(IJwksKeyProvider jwksKeyProvider)
+    {
+        _jwksKeyProvider = jwksKeyProvider;
+    }
+
+    [HttpGet]
+    public IActionResult GetJwks()
+    {
+        var rsaKeys = _jwksKeyProvider.GetKeys();
+
+        // Returns public key information in the prescribed JWKS specification format
+        var jwksDocument = new
+        {
+            keys = rsaKeys.Select(rsaKey => new
+            {
+                kty = "RSA",
+                use = "sig",
+                alg = "RS256",
+                kid = rsaKey.Key.KeyId,
+                n = rsaKey.Modulus, // Public Modulus
+                e = rsaKey.Exponent, // Public Exponent
+            }),
+        };
+
+        return Ok(jwksDocument);
+    }
+}

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Models/RsaKeyDetails.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Models/RsaKeyDetails.cs
@@ -1,0 +1,10 @@
+using Microsoft.IdentityModel.Tokens;
+
+namespace SUI.AuthEmulator.Models;
+
+public record RsaKeyDetails(
+    RsaSecurityKey Key,
+    SigningCredentials SigningCredentials,
+    string Modulus,
+    string Exponent
+);

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Program.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddSingleton<IAuthStoreService, MockAuthStoreService>();
 builder.Services.AddSingleton<IJwtTokenService, JwtTokenService>();
+builder.Services.AddSingleton<IJwksKeyProvider, JwksKeyProvider>();
 
 var app = builder.Build();
 

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/IJwksKeyProvider.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/IJwksKeyProvider.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using Microsoft.IdentityModel.Tokens;
 using SUI.AuthEmulator.Models;
 
 namespace SUI.AuthEmulator.Services;

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/IJwksKeyProvider.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/IJwksKeyProvider.cs
@@ -1,0 +1,10 @@
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+using SUI.AuthEmulator.Models;
+
+namespace SUI.AuthEmulator.Services;
+
+public interface IJwksKeyProvider
+{
+    IReadOnlyCollection<RsaKeyDetails> GetKeys();
+}

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/JwksKeyProvider.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/JwksKeyProvider.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+using SUI.AuthEmulator.Models;
+
+namespace SUI.AuthEmulator.Services;
+
+public class JwksKeyProvider : IJwksKeyProvider
+{
+    // Stored in a private field
+    private readonly RsaKeyDetails[] _rsaKeys;
+
+    public JwksKeyProvider()
+    {
+        // Generates 4 RSA Keys in the constructor
+        _rsaKeys = Enumerable
+            .Range(0, 4)
+            .Select(id =>
+            {
+                // Create 2048-bit RSA key pair
+                var rsa = RSA.Create(2048);
+
+                // Export only public parameters (false) for JWKS encoding safely
+                var publicParams = rsa.ExportParameters(false);
+
+                var rsaSecurityKey = new RsaSecurityKey(rsa)
+                {
+                    KeyId = $"{DateTime.UtcNow:o}_{id}",
+                };
+
+                return new RsaKeyDetails(
+                    rsaSecurityKey,
+                    new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256),
+                    Base64UrlEncoder.Encode(publicParams.Modulus),
+                    Base64UrlEncoder.Encode(publicParams.Exponent)
+                );
+            })
+            .ToArray();
+    }
+
+    public IReadOnlyCollection<RsaKeyDetails> GetKeys() => _rsaKeys;
+}

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Controllers/AuthControllerTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Controllers/AuthControllerTests.cs
@@ -10,7 +10,7 @@ using SUI.AuthEmulator.Controllers;
 using SUI.AuthEmulator.Models;
 using SUI.AuthEmulator.Services;
 
-namespace SUI.AuthEmulator.UnitTests;
+namespace SUI.AuthEmulator.UnitTests.Controllers;
 
 public class AuthControllerTests
 {

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Controllers/JWKSControllerTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Controllers/JWKSControllerTests.cs
@@ -22,7 +22,7 @@ public class JWKSControllerTests
     public void GetJwks_ShouldReturnOkWithCorrectJsonStructure()
     {
         // Arrange
-        var rsa = RSA.Create(2048);
+        using var rsa = RSA.Create(2048);
         var rsaSecurityKey = new RsaSecurityKey(rsa) { KeyId = "test-key-id" };
         var mockDetails = new RsaKeyDetails(
             rsaSecurityKey,

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Controllers/JWKSControllerTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Controllers/JWKSControllerTests.cs
@@ -1,0 +1,64 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+using SUI.AuthEmulator.Controllers;
+using SUI.AuthEmulator.Models;
+using SUI.AuthEmulator.Services;
+
+namespace SUI.AuthEmulator.UnitTests.Controllers;
+
+public class JWKSControllerTests
+{
+    private readonly IJwksKeyProvider _mockKeyProvider = Substitute.For<IJwksKeyProvider>();
+    private readonly JWKSController _sut;
+
+    public JWKSControllerTests()
+    {
+        _sut = new JWKSController(_mockKeyProvider);
+    }
+
+    [Fact]
+    public void GetJwks_ShouldReturnOkWithCorrectJsonStructure()
+    {
+        // Arrange
+        var rsa = RSA.Create(2048);
+        var rsaSecurityKey = new RsaSecurityKey(rsa) { KeyId = "test-key-id" };
+        var mockDetails = new RsaKeyDetails(
+            rsaSecurityKey,
+            new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256),
+            "mock-modulus-n",
+            "mock-exponent-e"
+        );
+
+        _mockKeyProvider.GetKeys().Returns(new[] { mockDetails });
+
+        // Act
+        var response = _sut.GetJwks();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(response);
+        Assert.NotNull(okResult.Value);
+
+        // Dig into the anonymous structure returned by the controller
+        var keysProperty = okResult.Value.GetType().GetProperty("keys");
+        Assert.NotNull(keysProperty);
+
+        var keysEnumerable =
+            keysProperty.GetValue(okResult.Value) as System.Collections.IEnumerable;
+        Assert.NotNull(keysEnumerable);
+
+        var keyList = keysEnumerable.Cast<object>().ToList();
+        Assert.Single(keyList);
+
+        // Verify the individual JWKS parameter mapping
+        var firstKey = keyList.First();
+
+        Assert.Equal("RSA", firstKey.GetType().GetProperty("kty")?.GetValue(firstKey));
+        Assert.Equal("sig", firstKey.GetType().GetProperty("use")?.GetValue(firstKey));
+        Assert.Equal("RS256", firstKey.GetType().GetProperty("alg")?.GetValue(firstKey));
+        Assert.Equal("test-key-id", firstKey.GetType().GetProperty("kid")?.GetValue(firstKey));
+        Assert.Equal("mock-modulus-n", firstKey.GetType().GetProperty("n")?.GetValue(firstKey));
+        Assert.Equal("mock-exponent-e", firstKey.GetType().GetProperty("e")?.GetValue(firstKey));
+    }
+}

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/JwksKeyProviderTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/JwksKeyProviderTests.cs
@@ -1,0 +1,60 @@
+using SUI.AuthEmulator.Services;
+
+namespace SUI.AuthEmulator.UnitTests.Services;
+
+public class JwksKeyProviderTests
+{
+    [Fact]
+    public void Constructor_ShouldInitializeFourRsaKeys()
+    {
+        // Act
+        var provider = new JwksKeyProvider();
+        var keys = provider.GetKeys();
+
+        // Assert
+        Assert.NotNull(keys);
+        Assert.Equal(4, keys.Count);
+    }
+
+    [Fact]
+    public void Keys_ShouldHaveDistinctAndFormattedKeyIds()
+    {
+        // Arrange & Act
+        var provider = new JwksKeyProvider();
+        var keys = provider.GetKeys().ToList();
+
+        // Assert
+        var keyIds = keys.Select(k => k.Key.KeyId).ToList();
+
+        // Ensure all 4 IDs are completely unique
+        Assert.Equal(4, keyIds.Distinct().Count());
+
+        // Verify suffix matches the indexing strategy (0 to 3)
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.EndsWith($"_{i}", keys[i].Key.KeyId);
+        }
+    }
+
+    [Fact]
+    public void Keys_ShouldContainValidPublicParameters()
+    {
+        // Arrange & Act
+        var provider = new JwksKeyProvider();
+        var keys = provider.GetKeys();
+
+        // Assert
+        foreach (var keyDetails in keys)
+        {
+            Assert.NotNull(keyDetails.Key);
+            Assert.NotNull(keyDetails.SigningCredentials);
+
+            // Public Modulus (n) and Exponent (e) must be populated for JWKS
+            Assert.False(string.IsNullOrWhiteSpace(keyDetails.Modulus));
+            Assert.False(string.IsNullOrWhiteSpace(keyDetails.Exponent));
+
+            // Confirm the algorithm is explicitly RS256
+            Assert.Equal("RS256", keyDetails.SigningCredentials.Algorithm);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a JWKS endpoint to the Auth Emulator, so that we avoid auth bypasses becoming part of the architecture (i.e. Local / CI / Ephemeral / Dev environments should still provide and use OIDC).

## Changes

- Class-level service(s):
> Class-level service that generates 4 RSA Keys in the constructor, and stores them in a private field
> Registered as a singleton

- JSON Web Key Set (JWKS) endpoint:
> Endpoint is mapped to GET api/v1/jwks (in a new JWKSController)
> Endpoint should return the public key information in the format as described below.

## Validation

Successful unit test runs.
