### PR TITLE
chore: SUI-1794 - Tidy the generated OpenAPI spec for the find (search) and search results endpoints

### DIFF
--- a/Apps/Find/src/SUI.Find.Application/Models/CustodianRecord.cs
+++ b/Apps/Find/src/SUI.Find.Application/Models/CustodianRecord.cs
@@ -15,7 +15,7 @@ public record CustodianRecord
 
     [OpenApiProperty(
         Nullable = true,
-        Description = "The payload of the record, if available. An open object that can contain any number and type of properties, as defined by the `RecordType` and `SchemaUri` properties of this object."
+        Description = "The payload of the record, if available. This is an open object adhering to the schema defined by the `RecordType` and `SchemaUri`."
     )]
     public object? Payload { get; init; }
 }

--- a/Apps/Find/src/SUI.Find.Application/Models/CustodianRecord.cs
+++ b/Apps/Find/src/SUI.Find.Application/Models/CustodianRecord.cs
@@ -1,3 +1,5 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+
 namespace SUI.Find.Application.Models;
 
 public record CustodianRecord
@@ -10,5 +12,10 @@ public record CustodianRecord
     public List<ContactDetails>? ContactDetails { get; init; }
 
     public List<RecordLink>? RecordLinks { get; init; }
-    public System.Text.Json.JsonElement? Payload { get; init; }
+
+    [OpenApiProperty(
+        Nullable = true,
+        Description = "The payload of the record, if available. An open object that can contain any number and type of properties, as defined by the `RecordType` and `SchemaUri` properties of this object."
+    )]
+    public object? Payload { get; init; }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchFunctionV2.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchFunctionV2.cs
@@ -21,7 +21,8 @@ public class SearchFunctionV2(ILogger<SearchFunctionV2> logger, IJobQueueService
     [OpenApiOperation(
         operationId: "searches-v2",
         tags: ["SearchesV2"],
-        Summary = "Submit a new search request"
+        Summary = "Submit a new search request",
+        Description = "Starts a search to find which Custodians (Data Owners) have a record relating to the specified child's identifier (NHS Number)."
     )]
     [OpenApiRequestBody(
         contentType: "application/json",
@@ -32,14 +33,26 @@ public class SearchFunctionV2(ILogger<SearchFunctionV2> logger, IJobQueueService
     [OpenApiResponseWithBody(
         statusCode: HttpStatusCode.Accepted,
         contentType: "application/json",
-        bodyType: typeof(SearchJob),
-        Summary = "The accepted search job"
+        bodyType: typeof(SearchWorkItem),
+        Description = "Request was accepted for processing, a search has been initiated."
     )]
     [OpenApiResponseWithBody(
         statusCode: HttpStatusCode.BadRequest,
         contentType: "application/json",
         bodyType: typeof(Problem),
-        Summary = "Invalid search request"
+        Description = "Request was refused because it contained invalid data, or was missing required data."
+    )]
+    [OpenApiResponseWithBody(
+        HttpStatusCode.Unauthorized,
+        "application/json",
+        typeof(Problem),
+        Description = "Request was refused because it lacks valid authentication credentials."
+    )]
+    [OpenApiResponseWithBody(
+        HttpStatusCode.InternalServerError,
+        "application/json",
+        typeof(Problem),
+        Description = "The server encountered an unexpected condition that prevented it from fulfilling the request."
     )]
     [RequiredScopes("find-record.write")]
     [Function(nameof(SearchesV2))]
@@ -111,7 +124,7 @@ public class SearchFunctionV2(ILogger<SearchFunctionV2> logger, IJobQueueService
 
         return await HttpResponseUtility.AcceptedResponse(
             req,
-            SearchJobV2.FromDto(result),
+            SearchWorkItem.FromDto(result),
             cancellationToken
         );
     }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsV2Function.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsV2Function.cs
@@ -33,26 +33,31 @@ public class SearchResultsV2Function(
         In = ParameterLocation.Path,
         Required = true,
         Type = typeof(string),
-        Summary = "Identifier of the search work item.",
-        Description = "Identifier of the search work item."
+        Summary = "Identifier of the search work item."
     )]
     [OpenApiResponseWithBody(
         statusCode: HttpStatusCode.OK,
         contentType: "application/json",
         bodyType: typeof(SearchResultsV2),
-        Summary = "Results for the specified search work item."
+        Description = "The status of a Find a Record search work item, and the results if available."
     )]
     [OpenApiResponseWithBody(
         statusCode: HttpStatusCode.NotFound,
         contentType: "application/json",
         bodyType: typeof(Problem),
-        Summary = "Search work item not found."
+        Description = "The requested search work item was not found."
     )]
     [OpenApiResponseWithBody(
-        statusCode: HttpStatusCode.InternalServerError,
-        contentType: "application/json",
-        bodyType: typeof(Problem),
-        Summary = "Error"
+        HttpStatusCode.Unauthorized,
+        "application/json",
+        typeof(Problem),
+        Description = "Request was refused because it lacks valid authentication credentials."
+    )]
+    [OpenApiResponseWithBody(
+        HttpStatusCode.InternalServerError,
+        "application/json",
+        typeof(Problem),
+        Description = "The server encountered an unexpected condition that prevented it from fulfilling the request."
     )]
     #endregion
 

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/ResponseTracingMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/ResponseTracingMiddleware.cs
@@ -12,6 +12,9 @@ namespace SUI.Find.FindApi.Middleware;
 // ReSharper disable once ClassNeverInstantiated.Global
 public class ResponseTracingMiddleware : IFunctionsWorkerMiddleware
 {
+    public const string TraceIdHeaderName = "Trace-Id";
+    public const string InvocationIdHeaderName = "Invocation-Id";
+
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
         await next(context);
@@ -20,8 +23,8 @@ public class ResponseTracingMiddleware : IFunctionsWorkerMiddleware
 
         if (result?.Value is HttpResponseData response)
         {
-            response.Headers.Add("Trace-Id", Activity.Current?.TraceId.ToString());
-            response.Headers.Add("Invocation-Id", context.InvocationId);
+            response.Headers.Add(TraceIdHeaderName, Activity.Current?.TraceId.ToString());
+            response.Headers.Add(InvocationIdHeaderName, context.InvocationId);
         }
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Models/SearchWorkItem.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Models/SearchWorkItem.cs
@@ -1,10 +1,9 @@
 using System.Text.Json.Serialization;
-using SUI.Find.Application.Enums;
 using SUI.Find.Application.Models;
 
 namespace SUI.Find.FindApi.Models;
 
-public record SearchJobV2
+public record SearchWorkItem
 {
     public required string WorkItemId { get; init; }
     public string Suid { get; init; } = string.Empty;
@@ -25,9 +24,9 @@ public record SearchJobV2
         }
     }
 
-    public static SearchJobV2 FromDto(SearchWorkItemDto dto)
+    public static SearchWorkItem FromDto(SearchWorkItemDto dto)
     {
-        return new SearchJobV2
+        return new SearchWorkItem
         {
             WorkItemId = dto.WorkItemId,
             Suid = dto.PersonId,

--- a/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
@@ -31,6 +31,13 @@ public sealed class FindDocumentFilter : IDocumentFilter
 
         TransformPaths(document);
 
+        ConfigureTags(document);
+
+        TransformIntEnumsToStrings(document);
+    }
+
+    private static void ConfigureTags(OpenApiDocument document)
+    {
         document.Tags = new List<OpenApiTag>
         {
             Tag("Health", "Service health check", 1),
@@ -41,8 +48,6 @@ public sealed class FindDocumentFilter : IDocumentFilter
             Tag("Work", "Check for and submit results to searches (Polling Architecture)", 6),
             Tag("Fetch", "Fetch records from providers", 7),
         };
-
-        TransformIntEnumsToStrings(document);
     }
 
     private static void TransformPaths(OpenApiDocument document)

--- a/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text.Json.Serialization;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
@@ -204,6 +206,61 @@ public sealed class FindDocumentFilter : IDocumentFilter
             Tag("Work", "Check for and submit results to searches (Polling Architecture)", 6),
             Tag("Fetch", "Fetch records from providers", 7),
         };
+
+        TransformIntEnumsToStrings(document);
+    }
+
+    /// <summary>
+    /// Searches for and transforms integer enum properties to string representations where applicable in the OpenAPI document.
+    /// Ordinarily this would have been done using a Schema Transformer, but the Azure Functions SDK does not support them.
+    /// </summary>
+    private static void TransformIntEnumsToStrings(OpenApiDocument document)
+    {
+        // Get all the loaded public types
+        var publicTypes = AppDomain
+            .CurrentDomain.GetAssemblies()
+            .SelectMany(assembly => assembly.ExportedTypes.Where(x => !x.IsAbstract))
+            .ToLookup(x => x.Name, StringComparer.OrdinalIgnoreCase);
+
+        // For each schema, check any of the properties which are integer enums and then try and find the
+        // corresponding C# enum and convert the schema property to a string representation.
+        foreach (var (schemaName, schema) in document.Components.Schemas)
+        {
+            foreach (
+                var (schemaPropertyName, schemaEnumProperty) in schema.Properties.Where(p =>
+                    p.Value.Type == "integer" && p.Value.Enum.Any()
+                )
+            )
+            {
+                var modelProperty = publicTypes[schemaName]
+                    .SelectMany(t =>
+                        t.GetProperties()
+                            .Where(p =>
+                                p.Name.Equals(
+                                    schemaPropertyName,
+                                    StringComparison.OrdinalIgnoreCase
+                                )
+                                && p.PropertyType.IsEnum
+                                && p.GetCustomAttribute<JsonConverterAttribute>()?.ConverterType
+                                    == typeof(JsonStringEnumConverter)
+                            )
+                    )
+                    .FirstOrDefault();
+
+                if (modelProperty != null)
+                {
+                    schemaEnumProperty.Type = "string";
+                    schemaEnumProperty.Enum.Clear();
+                    schemaEnumProperty.Format = null;
+                    schemaEnumProperty.Default = null;
+                    var names = Enum.GetNames(modelProperty.PropertyType);
+                    foreach (var name in names)
+                    {
+                        schemaEnumProperty.Enum.Add(new OpenApiString(name));
+                    }
+                }
+            }
+        }
     }
 
     private static OpenApiTag Tag(string name, string description, int order) =>

--- a/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
@@ -214,6 +214,40 @@ public sealed class FindDocumentFilter : IDocumentFilter
     /// Searches for and transforms integer enum properties to string representations where applicable in the OpenAPI document.
     /// Ordinarily this would have been done using a Schema Transformer, but the Azure Functions SDK does not support them.
     /// </summary>
+    /// <example>
+    /// For example, transforms:
+    /// <code language="yaml">
+    ///   searchResultsV2:
+    ///     properties:
+    ///       status:
+    ///         enum:
+    ///           - 0
+    ///           - 1
+    ///           - 2
+    ///           - 3
+    ///           - 4
+    ///           - 5
+    ///           - 6
+    ///         type: integer
+    ///         format: int32
+    ///         default: 0
+    /// </code>
+    /// to:
+    /// <code language="yaml">
+    ///   searchResultsV2:
+    ///     properties:
+    ///       status:
+    ///         enum:
+    ///           - None
+    ///           - Queued
+    ///           - Running
+    ///           - Completed
+    ///           - Failed
+    ///           - Cancelled
+    ///           - Expired
+    ///         type: string
+    /// </code>
+    /// </example>
     private static void TransformIntEnumsToStrings(OpenApiDocument document)
     {
         // Get all the loaded public types

--- a/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
@@ -36,17 +36,36 @@ public sealed class FindDocumentFilter : IDocumentFilter
         TransformIntEnumsToStrings(document);
     }
 
-    private static void ConfigureTags(OpenApiDocument document)
+    private static void ConfigureSecuritySchemes(OpenApiDocument document)
     {
-        document.Tags = new List<OpenApiTag>
+        document.Components.SecuritySchemes["oauth2_clientCredentials"] = new OpenApiSecurityScheme
         {
-            Tag("Health", "Service health check", 1),
-            Tag("Auth", "Simulate an OAuth provider", 2),
-            Tag("Match", "Locate the id for a person", 3),
-            Tag("Searches", "Start, get or cancel a search (Fan-out Architecture)", 4),
-            Tag("SearchesV2", "Start or get a search (Polling Architecture)", 5),
-            Tag("Work", "Check for and submit results to searches (Polling Architecture)", 6),
-            Tag("Fetch", "Fetch records from providers", 7),
+            Type = SecuritySchemeType.OAuth2,
+            Flows = new OpenApiOAuthFlows
+            {
+                ClientCredentials = new OpenApiOAuthFlow
+                {
+                    TokenUrl = new Uri("/api/v1/auth/token", UriKind.Relative),
+                    Scopes = new Dictionary<string, string>
+                    {
+                        { "match-record.read", "Obtain the id for a person." },
+                        { "find-record.read", "Read search status and results." },
+                        { "find-record.write", "Create and cancel searches." },
+                        { "fetch-record.read", "Retrieve records." },
+                        { "fetch-record.write", "Share records." },
+                        { "work-item.read", "Query the work item queue" },
+                        { "work-item.write", "Update the work item queue" },
+                    },
+                },
+            },
+        };
+
+        document.Components.SecuritySchemes["x-api-key"] = new OpenApiSecurityScheme
+        {
+            Type = SecuritySchemeType.ApiKey,
+            In = ParameterLocation.Header,
+            Name = "x-api-key",
+            Description = "API Key for authentication",
         };
     }
 
@@ -192,36 +211,17 @@ public sealed class FindDocumentFilter : IDocumentFilter
         document.Paths = newPaths;
     }
 
-    private static void ConfigureSecuritySchemes(OpenApiDocument document)
+    private static void ConfigureTags(OpenApiDocument document)
     {
-        document.Components.SecuritySchemes["oauth2_clientCredentials"] = new OpenApiSecurityScheme
+        document.Tags = new List<OpenApiTag>
         {
-            Type = SecuritySchemeType.OAuth2,
-            Flows = new OpenApiOAuthFlows
-            {
-                ClientCredentials = new OpenApiOAuthFlow
-                {
-                    TokenUrl = new Uri("/api/v1/auth/token", UriKind.Relative),
-                    Scopes = new Dictionary<string, string>
-                    {
-                        { "match-record.read", "Obtain the id for a person." },
-                        { "find-record.read", "Read search status and results." },
-                        { "find-record.write", "Create and cancel searches." },
-                        { "fetch-record.read", "Retrieve records." },
-                        { "fetch-record.write", "Share records." },
-                        { "work-item.read", "Query the work item queue" },
-                        { "work-item.write", "Update the work item queue" },
-                    },
-                },
-            },
-        };
-
-        document.Components.SecuritySchemes["x-api-key"] = new OpenApiSecurityScheme
-        {
-            Type = SecuritySchemeType.ApiKey,
-            In = ParameterLocation.Header,
-            Name = "x-api-key",
-            Description = "API Key for authentication",
+            Tag("Health", "Service health check", 1),
+            Tag("Auth", "Simulate an OAuth provider", 2),
+            Tag("Match", "Locate the id for a person", 3),
+            Tag("Searches", "Start, get or cancel a search (Fan-out Architecture)", 4),
+            Tag("SearchesV2", "Start or get a search (Polling Architecture)", 5),
+            Tag("Work", "Check for and submit results to searches (Polling Architecture)", 6),
+            Tag("Fetch", "Fetch records from providers", 7),
         };
     }
 

--- a/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
@@ -27,36 +27,26 @@ public sealed class FindDocumentFilter : IDocumentFilter
             schema.Properties.Clear();
         }
 
-        document.Components.SecuritySchemes["oauth2_clientCredentials"] = new OpenApiSecurityScheme
+        ConfigureSecuritySchemes(document);
+
+        TransformPaths(document);
+
+        document.Tags = new List<OpenApiTag>
         {
-            Type = SecuritySchemeType.OAuth2,
-            Flows = new OpenApiOAuthFlows
-            {
-                ClientCredentials = new OpenApiOAuthFlow
-                {
-                    TokenUrl = new Uri("/api/v1/auth/token", UriKind.Relative),
-                    Scopes = new Dictionary<string, string>
-                    {
-                        { "match-record.read", "Obtain the id for a person." },
-                        { "find-record.read", "Read search status and results." },
-                        { "find-record.write", "Create and cancel searches." },
-                        { "fetch-record.read", "Retrieve records." },
-                        { "fetch-record.write", "Share records." },
-                        { "work-item.read", "Query the work item queue" },
-                        { "work-item.write", "Update the work item queue" },
-                    },
-                },
-            },
+            Tag("Health", "Service health check", 1),
+            Tag("Auth", "Simulate an OAuth provider", 2),
+            Tag("Match", "Locate the id for a person", 3),
+            Tag("Searches", "Start, get or cancel a search (Fan-out Architecture)", 4),
+            Tag("SearchesV2", "Start or get a search (Polling Architecture)", 5),
+            Tag("Work", "Check for and submit results to searches (Polling Architecture)", 6),
+            Tag("Fetch", "Fetch records from providers", 7),
         };
 
-        document.Components.SecuritySchemes["x-api-key"] = new OpenApiSecurityScheme
-        {
-            Type = SecuritySchemeType.ApiKey,
-            In = ParameterLocation.Header,
-            Name = "x-api-key",
-            Description = "API Key for authentication",
-        };
+        TransformIntEnumsToStrings(document);
+    }
 
+    private static void TransformPaths(OpenApiDocument document)
+    {
         var traceIdHeader = new OpenApiHeader
         {
             Description = "Primary trace ID for the whole operation",
@@ -195,19 +185,39 @@ public sealed class FindDocumentFilter : IDocumentFilter
         }
 
         document.Paths = newPaths;
+    }
 
-        document.Tags = new List<OpenApiTag>
+    private static void ConfigureSecuritySchemes(OpenApiDocument document)
+    {
+        document.Components.SecuritySchemes["oauth2_clientCredentials"] = new OpenApiSecurityScheme
         {
-            Tag("Health", "Service health check", 1),
-            Tag("Auth", "Simulate an OAuth provider", 2),
-            Tag("Match", "Locate the id for a person", 3),
-            Tag("Searches", "Start, get or cancel a search (Fan-out Architecture)", 4),
-            Tag("SearchesV2", "Start or get a search (Polling Architecture)", 5),
-            Tag("Work", "Check for and submit results to searches (Polling Architecture)", 6),
-            Tag("Fetch", "Fetch records from providers", 7),
+            Type = SecuritySchemeType.OAuth2,
+            Flows = new OpenApiOAuthFlows
+            {
+                ClientCredentials = new OpenApiOAuthFlow
+                {
+                    TokenUrl = new Uri("/api/v1/auth/token", UriKind.Relative),
+                    Scopes = new Dictionary<string, string>
+                    {
+                        { "match-record.read", "Obtain the id for a person." },
+                        { "find-record.read", "Read search status and results." },
+                        { "find-record.write", "Create and cancel searches." },
+                        { "fetch-record.read", "Retrieve records." },
+                        { "fetch-record.write", "Share records." },
+                        { "work-item.read", "Query the work item queue" },
+                        { "work-item.write", "Update the work item queue" },
+                    },
+                },
+            },
         };
 
-        TransformIntEnumsToStrings(document);
+        document.Components.SecuritySchemes["x-api-key"] = new OpenApiSecurityScheme
+        {
+            Type = SecuritySchemeType.ApiKey,
+            In = ParameterLocation.Header,
+            Name = "x-api-key",
+            Description = "API Key for authentication",
+        };
     }
 
     /// <summary>

--- a/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/OpenApi/FindDocumentFilter.cs
@@ -3,6 +3,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using static SUI.Find.FindApi.Middleware.ResponseTracingMiddleware;
 
 namespace SUI.Find.FindApi.OpenApi;
 
@@ -54,7 +55,7 @@ public sealed class FindDocumentFilter : IDocumentFilter
             Description = "API Key for authentication",
         };
 
-        var operationIdHeader = new OpenApiHeader
+        var traceIdHeader = new OpenApiHeader
         {
             Description = "Primary trace ID for the whole operation",
             Schema = new OpenApiSchema { Type = "string" },
@@ -68,8 +69,8 @@ public sealed class FindDocumentFilter : IDocumentFilter
             Example = new OpenApiString("a49d73e8-dc36-4be5-92a6-9bf62868aa99"),
         };
 
-        document.Components.Headers["Operation-Id"] = operationIdHeader;
-        document.Components.Headers["Invocation-Id"] = invocationIdHeader;
+        document.Components.Headers[TraceIdHeaderName] = traceIdHeader;
+        document.Components.Headers[InvocationIdHeaderName] = invocationIdHeader;
 
         var oauthRequirement = new OpenApiSecurityRequirement
         {
@@ -156,8 +157,8 @@ public sealed class FindDocumentFilter : IDocumentFilter
                 {
                     foreach (var responseHeaders in op.Responses.Values.Select(x => x.Headers))
                     {
-                        responseHeaders["Operation-Id"] = operationIdHeader;
-                        responseHeaders["Invocation-Id"] = invocationIdHeader;
+                        responseHeaders[TraceIdHeaderName] = traceIdHeader;
+                        responseHeaders[InvocationIdHeaderName] = invocationIdHeader;
                     }
                 }
             }

--- a/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
@@ -198,7 +198,7 @@ public abstract class SearchTestsBase(
 
         if (UsePolling)
         {
-            var searchJob = JsonSerializer.Deserialize<SearchJobV2>(searchJobContent);
+            var searchJob = JsonSerializer.Deserialize<SearchWorkItem>(searchJobContent);
             if (searchJob != null)
             {
                 searchId = searchJob.WorkItemId;
@@ -477,7 +477,7 @@ public abstract class SearchTestsBase(
         using var finalResponse = await Fixture.Client.SendAsync(finalRequest);
 
         object? typedResult = UsePolling
-            ? await finalResponse.Content.ReadFromJsonAsync<SearchJobV2>()
+            ? await finalResponse.Content.ReadFromJsonAsync<SearchWorkItem>()
             : await finalResponse.Content.ReadFromJsonAsync<SearchJob>();
 
         Assert.NotNull(typedResult);

--- a/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
@@ -339,7 +339,11 @@ public abstract class SearchTestsBase(
 
             TestOutputHelper.WriteLine("Fetch verified ok");
 
-            var payload = fetchResultTypedContent.Payload!.Value;
+            var payloadJson = fetchResultTypedContent.Payload as JsonElement?;
+
+            Assert.NotNull(payloadJson);
+
+            var payload = payloadJson.Value;
 
             switch (fetchResultTypedContent.RecordType)
             {

--- a/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
@@ -339,11 +339,7 @@ public abstract class SearchTestsBase(
 
             TestOutputHelper.WriteLine("Fetch verified ok");
 
-            var payloadJson = fetchResultTypedContent.Payload as JsonElement?;
-
-            Assert.NotNull(payloadJson);
-
-            var payload = payloadJson.Value;
+            var payload = Assert.IsType<JsonElement>(fetchResultTypedContent.Payload);
 
             switch (fetchResultTypedContent.RecordType)
             {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchFunctionV2Tests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchFunctionV2Tests.cs
@@ -97,7 +97,7 @@ public class SearchFunctionV2Tests
         result.Body.Position = 0;
         using var reader = new StreamReader(result.Body);
         var responseBody = await reader.ReadToEndAsync();
-        var searchJob = JsonSerializer.Deserialize<SearchJobV2>(responseBody, _jsonOptions);
+        var searchJob = JsonSerializer.Deserialize<SearchWorkItem>(responseBody, _jsonOptions);
 
         Assert.NotNull(searchJob);
         Assert.Equal(expectedJobId, searchJob.WorkItemId);

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Models/Find/FindSearchWorkItem.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Models/Find/FindSearchWorkItem.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace SUI.UIHarness.Web.Models.Find;
 
-public record FindSearchJobV2
+public record FindSearchWorkItem
 {
     public required string WorkItemId { get; init; }
     public string Suid { get; init; } = string.Empty;

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindService.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindService.cs
@@ -116,7 +116,7 @@ public class FindService : IFindService
             {
                 if (usePolling)
                 {
-                    var searchJobV2 = await result.Content.ReadFromJsonAsync<FindSearchJobV2>();
+                    var searchJobV2 = await result.Content.ReadFromJsonAsync<FindSearchWorkItem>();
                     if (searchJobV2 != null)
                     {
                         return searchJobV2.WorkItemId;


### PR DESCRIPTION
## Summary

This PR improves and fixes the generated OpenAPI spec for the find (search) and search results endpoints; so that we move the generated spec closer to one that suppliers can integrate with, and so that this part of the spec is ready to be shared with the wider programme of work.

## Changes

- Corrected the name of the search endpoint's response model from `SearchJobV2` to `SearchWorkItem`.
- Added missing 401 and 500 responses.
- Improved and tidied descriptions.
- Improved and fixed the tracing header names in the OpenAPI spec.
- Resolved the enums being incorrectly `int` rather than `string` in Find’s generated OpenAPI spec.
    - Generic implementation is a workaround because Azure Function’s do not have the Schema Transformer ability.
- The payload property of `CustodianRecord` was incorrectly getting generated in the OpenAPI spec as a schema of type `JsonElement`.  This PR fixes that to be an open object whose schema will match the `SchemaUri`, which best represents the intention of the API.
- Refactored `FindDocumentFilter.Apply()` method in to smaller methods so its easier to read and follow.

## Validation

- Generating the OpenAPI spec and manual verification it.