### PR TITLE
feat(authEmulator): SUI-1777 - Add OIDC discovery endpoint to Auth Emulator

### DIFF
--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Configurations/AuthSettings.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Configurations/AuthSettings.cs
@@ -1,0 +1,11 @@
+namespace SUI.AuthEmulator.Configurations;
+
+public class AuthSettings
+{
+    public const string SectionName = "AuthSettings";
+
+    public string Issuer { get; set; } =
+        "https://sandbox.api.example.gov.uk/sui-find-a-record/auth";
+
+    public string BaseUrl { get; set; } = "https://localhost:7250/api";
+}

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/OIDCDiscoveryController.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/OIDCDiscoveryController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using SUI.AuthEmulator.Configurations;
+
+namespace SUI.AuthEmulator.Controllers;
+
+[ApiController]
+[Route("api/v1/.well-known/openid-configuration")]
+public class OIDCDiscoveryController : ControllerBase
+{
+    private readonly AuthSettings _authSettings;
+
+    public OIDCDiscoveryController(IOptions<AuthSettings> authSettings)
+    {
+        _authSettings = authSettings.Value;
+    }
+
+    [HttpGet]
+    public IActionResult GetDiscoveryDocument()
+    {
+        var baseUrl = _authSettings.BaseUrl.TrimEnd('/');
+
+        var discoveryDocument = new
+        {
+            issuer = _authSettings.Issuer,
+            token_endpoint = $"{baseUrl}/v1/token",
+            jwks_uri = $"{baseUrl}/v1/jwks",
+            id_token_signing_alg_values_supported = new[] { "RS256" },
+            grant_types_supported = new[] { "client_credentials" },
+            response_types_supported = new[] { "token" },
+            subject_types_supported = new[] { "public" },
+            authorization_endpoint = $"{baseUrl}/dummy",
+        };
+
+        return Ok(discoveryDocument);
+    }
+}

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Program.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Program.cs
@@ -1,4 +1,5 @@
 using SUI.AuthEmulator;
+using SUI.AuthEmulator.Configurations;
 using SUI.AuthEmulator.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -13,6 +14,10 @@ builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddSingleton<IAuthStoreService, MockAuthStoreService>();
 builder.Services.AddSingleton<IJwtTokenService, JwtTokenService>();
+
+builder.Services.Configure<AuthSettings>(
+    builder.Configuration.GetSection(AuthSettings.SectionName)
+);
 
 var app = builder.Build();
 

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/appsettings.json
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AuthSettings": {
+    "Issuer": "https://sandbox.api.example.gov.uk/sui-find-a-record/auth",
+    "BaseUrl": "https://localhost:7250/api"
+  }
 }

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/OIDCDiscoveryControllerTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/OIDCDiscoveryControllerTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SUI.AuthEmulator.Configurations;
+using SUI.AuthEmulator.Controllers;
+
+namespace SUI.AuthEmulator.UnitTests;
+
+public class OIDCDiscoveryControllerTests
+{
+    private readonly IOptions<AuthSettings> _mockOptions = Substitute.For<IOptions<AuthSettings>>();
+
+    [Fact]
+    public void GetDiscoveryDocument_ShouldReturnOkWithMappedProperties()
+    {
+        // Arrange
+        var settings = new AuthSettings
+        {
+            Issuer = "https://test.issuer.com",
+            BaseUrl = "https://test.api.com/api/", // Testing with a trailing slash to verify truncation logic
+        };
+        _mockOptions.Value.Returns(settings);
+
+        var sut = new OIDCDiscoveryController(_mockOptions);
+
+        // Act
+        var response = sut.GetDiscoveryDocument();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(response);
+        Assert.NotNull(okResult.Value);
+
+        // Extract anonymous properties safely using reflection
+        var val = okResult.Value;
+        Assert.Equal("https://test.issuer.com", val.GetType().GetProperty("issuer")?.GetValue(val));
+        Assert.Equal(
+            "https://test.api.com/api/v1/token",
+            val.GetType().GetProperty("token_endpoint")?.GetValue(val)
+        );
+        Assert.Equal(
+            "https://test.api.com/api/v1/jwks",
+            val.GetType().GetProperty("jwks_uri")?.GetValue(val)
+        );
+        Assert.Equal(
+            "https://test.api.com/api/dummy",
+            val.GetType().GetProperty("authorization_endpoint")?.GetValue(val)
+        );
+
+        var algs =
+            val.GetType().GetProperty("id_token_signing_alg_values_supported")?.GetValue(val)
+            as string[];
+        Assert.Contains("RS256", algs!);
+    }
+}

--- a/terraform/auth-emulator/main.tf
+++ b/terraform/auth-emulator/main.tf
@@ -46,6 +46,9 @@ module "web_app" {
     {
       APPLICATIONINSIGHTS_CONNECTION_STRING = data.terraform_remote_state.core.outputs.app_insights_connection_string
       OTEL_RESOURCE_ATTRIBUTES = local.otel_resource_attributes
+
+      # Map the environment's dynamic base URL down to the Auth Emulator config
+      AuthSettings__BaseUrl                  = format("https://%s%sapp-%s-authemulator01.azurewebsites.net/", var.subscription_prefix, var.environment_id, var.region_short)
     },
     var.authemulator_app_settings,
   )


### PR DESCRIPTION
## Summary

Add an OIDC discovery endpoint to the Auth Emulator, so that we avoid auth bypasses becoming part of the architecture (i.e. Local / CI / Ephemeral / Dev environments should still provide and use OIDC).

## Changes

- Endpoint is mapped to GET api/v1/.well-known/openid-configuration (in a new OIDCDiscoveryController).
- The config values are loaded via a .NET Options Pattern object called AuthSettings.
- The BaseUrl for the deployed environments should be specified via App Settings in the Terraform:
> AuthSettings__BaseUrl with value of format("https://%s%sapp-%s-authemulator01.azurewebsites.net/", var.subscription_prefix, var.environment_id, var.region_short)

## Validation

Successful Unit tests / terraform plan and application
