### PR TITLE
feat(find): SUI-1769 - Cache loaded data in FindAPI's Auth Store Service

### DIFF
--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
@@ -11,19 +11,26 @@ public interface IAuthStoreService
     Task<Result<AuthClient>> GetClientByCredentials(string clientId, string clientSecret);
 }
 
-public class MockAuthStoreService(IFileSystem fileSystem) : IAuthStoreService
+public class MockAuthStoreService : IAuthStoreService
 {
-    public async Task<AuthStore> GetAuthStoreAsync()
+    private readonly IFileSystem _fileSystem;
+    private readonly Lazy<AuthStore> _authStore;
+
+    public MockAuthStoreService(IFileSystem fileSystem)
     {
-        return await GetStore();
+        _fileSystem = fileSystem;
+        _authStore = new Lazy<AuthStore>(LoadStore);
     }
 
-    public async Task<Result<AuthClient>> GetClientByCredentials(
-        string clientId,
-        string clientSecret
-    )
+    public Task<AuthStore> GetAuthStoreAsync()
     {
-        var store = await GetStore();
+        // Instantly returns the cached in-memory store as a completed Task
+        return Task.FromResult(_authStore.Value);
+    }
+
+    public Task<Result<AuthClient>> GetClientByCredentials(string clientId, string clientSecret)
+    {
+        var store = _authStore.Value;
 
         if (
             string.IsNullOrWhiteSpace(store.Issuer)
@@ -31,7 +38,6 @@ public class MockAuthStoreService(IFileSystem fileSystem) : IAuthStoreService
             || string.IsNullOrWhiteSpace(store.SigningKey)
         )
         {
-            // May be better to log this error instead of throwing, doesn't stop the service
             throw new InvalidOperationException(
                 "Auth store file is missing issuer, audience, or signingKey."
             );
@@ -43,28 +49,31 @@ public class MockAuthStoreService(IFileSystem fileSystem) : IAuthStoreService
             c.ClientId == clientId && c.ClientSecret == clientSecret && c.Enabled
         );
 
-        return client is null
+        var result = client is null
             ? Result<AuthClient>.Fail("Unauthorized")
             : Result<AuthClient>.Ok(client);
+
+        return Task.FromResult(result);
     }
 
-    private async Task<AuthStore> GetStore()
+    private AuthStore LoadStore()
     {
         var baseDir = AppContext.BaseDirectory;
         var filePath = Path.Combine(baseDir, "Data", "auth-clients-inbound.json");
 
-        if (!File.Exists(filePath))
+        if (!_fileSystem.File.Exists(filePath))
         {
             throw new InvalidOperationException($"Auth store file not found at: {filePath}");
         }
 
-        var json = await fileSystem.File.ReadAllTextAsync(filePath);
+        var json = _fileSystem.File.ReadAllText(filePath);
         var store = JsonSerializer.Deserialize<AuthStore>(json, JsonSerializerOptions.Web);
 
         if (store is null)
         {
             throw new InvalidOperationException("Auth store file could not be deserialized.");
         }
+
         return store;
     }
 }

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -1,35 +1,138 @@
 using System.IO.Abstractions;
+using System.Text.Json;
 using NSubstitute;
+using SUI.Find.Infrastructure.Models;
 using SUI.Find.Infrastructure.Services;
 
 namespace SUI.Find.Infrastructure.UnitTests.Services;
 
 public class MockAuthStoreServiceTests
 {
-    private readonly MockAuthStoreService _sut;
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
+    private readonly MockAuthStoreService _sut;
+    private readonly string _realStoreFilePath;
 
     public MockAuthStoreServiceTests()
     {
         _sut = new MockAuthStoreService(_mockFileSystem);
-    }
-
-    [Fact]
-    public async Task GetAuthClient_ShouldReturnClient_WhenIdAndSecretMatch()
-    {
-        // Arrange
-        var realFilePath = Path.Combine(
+        _realStoreFilePath = Path.Combine(
             AppContext.BaseDirectory,
             "Data",
             "auth-clients-inbound.json"
         );
-        var fileContent = await File.ReadAllTextAsync(realFilePath);
-        _mockFileSystem.File.ReadAllTextAsync(Arg.Any<string>()).Returns(fileContent);
+    }
+
+    [Fact]
+    public async Task GetAuthStoreAsync_MapsJsonToStoreDefinitionCorrectly()
+    {
+        // Arrange
+        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
+
+        // Act
+        var store = await _sut.GetAuthStoreAsync();
+
+        // Assert
+        Assert.NotNull(store);
+        Assert.Equal("https://sandbox.api.example.gov.uk/find-a-record/auth", store.Issuer);
+        Assert.Equal("find-a-record-api", store.Audience);
+        Assert.Equal(
+            "Wc8Kq1ZyR4hNfD0uVx3mS9JpA6eLrT2bG7wQvY5sCjP8kF1nH0tUoMzBiXaEdRl",
+            store.SigningKey
+        );
+        Assert.NotNull(store.Clients);
+        Assert.NotEmpty(store.Clients);
+
+        // Verify structure of an active client
+        var sampleClient = store.Clients.FirstOrDefault(c => c.ClientId == "LOCAL-AUTHORITY-01");
+        Assert.NotNull(sampleClient);
+        Assert.True(sampleClient.Enabled);
+        Assert.Equal("SUIProject", sampleClient.ClientSecret);
+        Assert.Contains("match-record.read", sampleClient.AllowedScopes!);
+    }
+
+    [Fact]
+    public async Task GetClientByCredentials_ShouldReturnClient_WhenIdAndSecretMatch()
+    {
+        // Arrange
+        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
         var result = await _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "SUIProject");
 
         // Assert
         Assert.True(result.Success);
+        Assert.NotNull(result.Value);
+        Assert.Equal("LOCAL-AUTHORITY-01", result.Value.ClientId);
+    }
+
+    [Fact]
+    public async Task GetClientByCredentials_ShouldReturnFailure_WhenCredentialsAreInvalid()
+    {
+        // Arrange
+        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
+
+        // Act
+        var result = await _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "WRONG-PASSWORD-XYZ");
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("Unauthorized", result.Error);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public async Task GetClientByCredentials_ShouldThrowInvalidOperationException_WhenFileHeaderIsMissingMetadata()
+    {
+        // Arrange
+        var badStore = new AuthStore
+        {
+            Issuer = "", // Missing
+            Audience = "some-audience",
+            SigningKey = "some-key",
+            DefaultTokenLifetimeMinutes = 60,
+        };
+        var badJson = JsonSerializer.Serialize(badStore, JsonSerializerOptions.Web);
+
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(badJson);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "SUIProject")
+        );
+
+        Assert.Equal("Auth store file is missing issuer, audience, or signingKey.", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadStore_ShouldThrowInvalidOperationException_WhenFileDoesNotExist()
+    {
+        // Arrange
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(false);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.GetAuthStoreAsync()
+        );
+        Assert.Contains("Auth store file not found at", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadStore_ShouldThrowInvalidOperationException_WhenJsonIsCorrupt()
+    {
+        // Arrange
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem
+            .File.ReadAllText(Arg.Any<string>())
+            .Returns("{ invalid-json-payload : true ");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<JsonException>(() => _sut.GetAuthStoreAsync());
     }
 }

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -15,7 +15,7 @@ public class MockAuthStoreServiceTests
     public MockAuthStoreServiceTests()
     {
         _sut = new MockAuthStoreService(_mockFileSystem);
-        _realStoreFilePath = Path.Combine(
+        _realStoreFilePath = Path.Join(
             AppContext.BaseDirectory,
             "Data",
             "auth-clients-inbound.json"


### PR DESCRIPTION
## Summary

Cache the loaded auth-clients-inbound.json in MockAuthStoreService, so that the frequently called polling endpoints do not unnecessarily slow down the system

## Changes

- Cache in memory the loaded AuthStore (which has been loaded from auth-clients-inbound.json)
- Memory caching should be a straight forward hold in an lazy in-memory list, following the pattern in the Stub’s FindApiAuthClientProvider:
> The logic to load the ‘Auth Store’ is moved in to a Lazy<AuthStore> that is initialised in the class constructor
> The classes methods are refactored to use that in-memory list
- Update unit tests as necessary

## Validation

Successful Unit test runs