### PR TITLE
Update Auth Middleware to Map ClientId to OrganisationId

### DIFF
--- a/Apps/Find/src/SUI.Find.Application/Interfaces/IMatchPersonOrchestrationService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Interfaces/IMatchPersonOrchestrationService.cs
@@ -13,7 +13,7 @@ public interface IMatchPersonOrchestrationService
 {
     Task<OneOf<string, DataQualityResult, NotFound, Error>> FindPersonIdAsync(
         PersonSpecification specification,
-        string clientId,
+        string organisationId,
         CancellationToken ct
     );
 }

--- a/Apps/Find/src/SUI.Find.Application/Models/PolicyContext.cs
+++ b/Apps/Find/src/SUI.Find.Application/Models/PolicyContext.cs
@@ -1,3 +1,3 @@
 namespace SUI.Find.Application.Models;
 
-public sealed record PolicyContext(string ClientId, string Purpose, string OrgType);
+public sealed record PolicyContext(string OrganisationId, string Purpose, string OrgType);

--- a/Apps/Find/src/SUI.Find.Application/Services/MatchPersonOrchestrationService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/MatchPersonOrchestrationService.cs
@@ -17,7 +17,7 @@ public class MatchPersonOrchestrationService(
 {
     public async Task<OneOf<string, DataQualityResult, NotFound, Error>> FindPersonIdAsync(
         PersonSpecification specification,
-        string clientId,
+        string organisationId,
         CancellationToken ct
     )
     {
@@ -25,7 +25,10 @@ public class MatchPersonOrchestrationService(
 
         if (matchResult.TryPickT0(out var personId, out var remainder))
         {
-            var getPersonIdResult = await HandlePersonIdRepresentationAsync(personId, clientId);
+            var getPersonIdResult = await HandlePersonIdRepresentationAsync(
+                personId,
+                organisationId
+            );
             return getPersonIdResult.Match<OneOf<string, DataQualityResult, NotFound, Error>>(
                 plainId => plainId,
                 error => error
@@ -41,13 +44,16 @@ public class MatchPersonOrchestrationService(
 
     private async Task<OneOf<string, Error>> HandlePersonIdRepresentationAsync(
         NhsPersonId nhsPersonId,
-        string clientId
+        string organisationId
     )
     {
-        var client = await custodianService.GetCustodianAsync(clientId);
-        if (!client.Success || client.Value is null)
+        var organisation = await custodianService.GetCustodianAsync(organisationId);
+        if (!organisation.Success || organisation.Value is null)
         {
-            logger.LogError("Custodian organisation not found for client ID: {ClientId}", clientId);
+            logger.LogError(
+                "Custodian organisation not found for organisation ID: {OrganisationId}",
+                organisationId
+            );
             return new Error();
         }
 

--- a/Apps/Find/src/SUI.Find.Application/Services/SearchService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/SearchService.cs
@@ -18,7 +18,7 @@ public interface ISearchService
 {
     Task<OneOf<SearchJobDto, Error>> StartSearchAsync(
         string inputPersonId,
-        string clientId,
+        string organisationId,
         DurableTaskClient client,
         string correlationId,
         CancellationToken cancellationToken
@@ -26,21 +26,21 @@ public interface ISearchService
 
     Task<OneOf<SearchJobDto, NotFound, Forbidden, Error>> CancelSearchAsync(
         string jobId,
-        string clientId,
+        string organisationId,
         DurableTaskClient client,
         CancellationToken cancellationToken
     );
 
     Task<OneOf<SearchResultsDto, NotFound, Forbidden, Error>> GetSearchResultsAsync(
         string jobId,
-        string clientId,
+        string organisationId,
         DurableTaskClient client,
         CancellationToken cancellationToken
     );
 
     Task<OneOf<SearchJobDto, Forbidden, NotFound, Error>> GetSearchStatusAsync(
         string jobId,
-        string clientId,
+        string organisationId,
         DurableTaskClient client,
         CancellationToken cancellationToken
     );
@@ -56,13 +56,13 @@ public class SearchService(
 {
     public async Task<OneOf<SearchJobDto, Error>> StartSearchAsync(
         string inputPersonId,
-        string clientId,
+        string organisationId,
         DurableTaskClient client,
         string correlationId,
         CancellationToken cancellationToken
     )
     {
-        var instanceId = $"{inputPersonId}-{clientId}";
+        var instanceId = $"{inputPersonId}-{organisationId}";
         var hashedInstanceId = hashService.HmacSha256Hash(instanceId);
 
         var existingInstance = await client.GetInstanceAsync(
@@ -103,12 +103,12 @@ public class SearchService(
             return originalJob;
         }
 
-        var providerDefinition = await custodianService.GetCustodianAsync(clientId);
+        var providerDefinition = await custodianService.GetCustodianAsync(organisationId);
         if (!providerDefinition.Success || providerDefinition.Value is null)
         {
             logger.LogWarning(
-                "No custodian configuration found for ClientId: {ClientId}.",
-                clientId
+                "No custodian configuration found for OrganisationId: {OrganisationId}.",
+                organisationId
             );
             return new Error();
         }
@@ -116,7 +116,7 @@ public class SearchService(
         var metaData = new SearchJobMetadata(inputPersonId, DateTime.UtcNow, correlationId);
 
         var policyContext = new PolicyContext(
-            clientId,
+            organisationId,
             ApplicationConstants.PolicyEnforcementPurposes.Safeguarding,
             providerDefinition.Value.OrgType
         );
@@ -144,7 +144,7 @@ public class SearchService(
 
     public async Task<OneOf<SearchJobDto, NotFound, Forbidden, Error>> CancelSearchAsync(
         string jobId,
-        string clientId,
+        string organisationId,
         DurableTaskClient client,
         CancellationToken cancellationToken
     )
@@ -164,7 +164,7 @@ public class SearchService(
 
             // Check if the job belongs to the requesting client
             var input = ReadOrchestratorInput<SearchOrchestratorInput>(metaData);
-            if (input is null || input.PolicyContext.ClientId != clientId)
+            if (input is null || input.PolicyContext.ClientId != organisationId)
             {
                 return new Forbidden();
             }
@@ -204,7 +204,7 @@ public class SearchService(
 
     public async Task<OneOf<SearchResultsDto, NotFound, Forbidden, Error>> GetSearchResultsAsync(
         string jobId,
-        string clientId,
+        string organisationId,
         DurableTaskClient client,
         CancellationToken cancellationToken
     )
@@ -230,12 +230,12 @@ public class SearchService(
                 return new Error();
             }
 
-            if (meta.PolicyContext.ClientId != clientId)
+            if (meta.PolicyContext.ClientId != organisationId)
             {
                 logger.LogWarning(
-                    "Unauthorized access attempt to search job {JobId} by client {ClientId}.",
+                    "Unauthorized access attempt to search job {JobId} by organisation {OrganisationId}.",
                     jobId,
-                    clientId
+                    organisationId
                 );
                 return new Forbidden();
             }
@@ -247,7 +247,7 @@ public class SearchService(
             {
                 var persistedItems = await searchResultEntryRepository.GetByWorkItemIdAsync(
                     jobId,
-                    clientId,
+                    organisationId,
                     cancellationToken
                 );
 
@@ -300,7 +300,7 @@ public class SearchService(
 
     public async Task<OneOf<SearchJobDto, Forbidden, NotFound, Error>> GetSearchStatusAsync(
         string jobId,
-        string clientId,
+        string organisationId,
         DurableTaskClient client,
         CancellationToken cancellationToken
     )
@@ -314,7 +314,7 @@ public class SearchService(
             }
 
             var input = ReadOrchestratorInput<SearchOrchestratorInput>(jobStatus);
-            if (input is null || input.PolicyContext.ClientId != clientId)
+            if (input is null || input.PolicyContext.ClientId != organisationId)
             {
                 return new Forbidden();
             }

--- a/Apps/Find/src/SUI.Find.Application/Services/SearchService.cs
+++ b/Apps/Find/src/SUI.Find.Application/Services/SearchService.cs
@@ -164,7 +164,7 @@ public class SearchService(
 
             // Check if the job belongs to the requesting client
             var input = ReadOrchestratorInput<SearchOrchestratorInput>(metaData);
-            if (input is null || input.PolicyContext.ClientId != organisationId)
+            if (input is null || input.PolicyContext.OrganisationId != organisationId)
             {
                 return new Forbidden();
             }
@@ -230,7 +230,7 @@ public class SearchService(
                 return new Error();
             }
 
-            if (meta.PolicyContext.ClientId != organisationId)
+            if (meta.PolicyContext.OrganisationId != organisationId)
             {
                 logger.LogWarning(
                     "Unauthorized access attempt to search job {JobId} by organisation {OrganisationId}.",
@@ -314,7 +314,7 @@ public class SearchService(
             }
 
             var input = ReadOrchestratorInput<SearchOrchestratorInput>(jobStatus);
-            if (input is null || input.PolicyContext.ClientId != organisationId)
+            if (input is null || input.PolicyContext.OrganisationId != organisationId)
             {
                 return new Forbidden();
             }

--- a/Apps/Find/src/SUI.Find.Domain/Events/Audit/AuditActor.cs
+++ b/Apps/Find/src/SUI.Find.Domain/Events/Audit/AuditActor.cs
@@ -2,6 +2,6 @@ namespace SUI.Find.Domain.Events.Audit;
 
 public sealed class AuditActor
 {
-    public required string ActorId { get; set; } // e.g. clientId
+    public required string ActorId { get; set; } // e.g. organisationId
     public required string ActorRole { get; set; } = "Organisation"; // e.g. Organisation
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/ActivityFunctions/PersistSearchResultsFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/ActivityFunctions/PersistSearchResultsFunction.cs
@@ -11,7 +11,7 @@ public sealed record PersistSearchResultsInput(
     string WorkItemId,
     string JobId,
     string InvocationId,
-    string RequestingOrdId,
+    string RequestingOrgId,
     string SourceOrgId
 );
 
@@ -35,7 +35,7 @@ public class PersistSearchResultsFunction(
             {
                 input.WorkItemId,
                 input.JobId,
-                input.RequestingOrdId,
+                input.RequestingOrgId,
                 input.SourceOrgId,
             }
         );

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/CancelSearchFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/CancelSearchFunction.cs
@@ -6,7 +6,6 @@ using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using SUI.Find.Application.Constants;
-using SUI.Find.Application.Models;
 using SUI.Find.Application.Services;
 using SUI.Find.FindApi.Attributes;
 using SUI.Find.FindApi.Models;
@@ -76,7 +75,7 @@ public class CancelSearchFunction(
 
         var result = await searchService.CancelSearchAsync(
             jobId,
-            authContext.ClientId,
+            authContext.OrganisationId,
             client,
             cancellationToken
         );

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/ClaimJobFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/ClaimJobFunction.cs
@@ -56,7 +56,7 @@ public class ClaimJobFunction(ILogger<ClaimJobFunction> logger, IJobClaimService
             );
         }
 
-        var submittingCustodianId = authContext.ClientId;
+        var submittingCustodianId = authContext.OrganisationId;
 
         using var scope = logger.BeginScope(
             new Dictionary<string, object>

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/FetchRecordFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/FetchRecordFunction.cs
@@ -72,7 +72,7 @@ public class FetchRecordFunction(
 
         var result = await fetchRecordService.FetchRecordAsync(
             recordId,
-            authContext.ClientId,
+            authContext.OrganisationId,
             cancellationToken
         );
 

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/MatchFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/MatchFunction.cs
@@ -5,7 +5,6 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
 using SUI.Find.Application.Constants;
 using SUI.Find.Application.Interfaces;
 using SUI.Find.Application.Models.Matching;
@@ -136,7 +135,7 @@ public class MatchFunction(
 
         var personMatch = await matchOrchestrationService.FindPersonIdAsync(
             request.PersonSpecification,
-            authContext.ClientId,
+            authContext.OrganisationId,
             cancellationToken
         );
 
@@ -151,7 +150,7 @@ public class MatchFunction(
                             new IdRegisterEntry
                             {
                                 Sui = id,
-                                CustodianId = authContext.ClientId,
+                                CustodianId = authContext.OrganisationId,
                                 RecordType = entry.RecordType,
                                 SystemId = entry.SystemId,
                                 CustodianSubjectId = entry.RecordId,

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/RenewLeaseFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/RenewLeaseFunction.cs
@@ -80,7 +80,7 @@ public class RenewLeaseFunction(
         using var scope = logger.BeginScope(
             new Dictionary<string, object>
             {
-                { "SubmittingCustodianId", authContext.ClientId },
+                { "SubmittingCustodianId", authContext.OrganisationId },
                 { "TraceParent", context.TraceContext.TraceParent },
                 { "TraceId", Activity.Current?.TraceId.ToString() ?? string.Empty },
                 { "InvocationId", context.InvocationId },
@@ -96,7 +96,7 @@ public class RenewLeaseFunction(
         );
 
         var jobInfo = await jobClaimService.ExtendJobLeaseAsync(
-            authContext.ClientId,
+            authContext.OrganisationId,
             request.JobId,
             request.LeaseId,
             cancellationToken

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchFunction.cs
@@ -88,7 +88,7 @@ public class SearchFunction(ILogger<SearchFunction> logger, ISearchService searc
 
         var searchJob = await searchService.StartSearchAsync(
             personId,
-            authContext.ClientId,
+            authContext.OrganisationId,
             client,
             context.InvocationId,
             cancellationToken

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchFunctionV2.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchFunctionV2.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
 using SUI.Find.Application.Constants;
-using SUI.Find.Domain.ValueObjects;
 using SUI.Find.FindApi.Attributes;
 using SUI.Find.FindApi.Models;
 using SUI.Find.FindApi.Utility;
@@ -76,7 +75,7 @@ public class SearchFunctionV2(ILogger<SearchFunctionV2> logger, IJobQueueService
             {
                 { "WorkItemId", workItemId },
                 { "PersonId", searchRequest?.Suid ?? string.Empty },
-                { "RequestingOrganisationId", authContext.ClientId },
+                { "RequestingOrganisationId", authContext.OrganisationId },
                 { "TraceParent", context.TraceContext.TraceParent },
                 { "TraceId", Activity.Current?.TraceId.ToString() ?? string.Empty },
                 { "InvocationId", context.InvocationId },
@@ -101,7 +100,7 @@ public class SearchFunctionV2(ILogger<SearchFunctionV2> logger, IJobQueueService
         {
             WorkItemId = workItemId,
             PersonId = personId,
-            RequestingOrganisationId = authContext.ClientId,
+            RequestingOrganisationId = authContext.OrganisationId,
             TraceParent = context.TraceContext.TraceParent,
             TraceId = Activity.Current?.TraceId.ToString() ?? string.Empty,
             InvocationId = context.InvocationId,

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsFunction.cs
@@ -6,7 +6,6 @@ using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using SUI.Find.Application.Constants;
-using SUI.Find.Application.Models;
 using SUI.Find.Application.Services;
 using SUI.Find.FindApi.Attributes;
 using SUI.Find.FindApi.Models;
@@ -87,7 +86,7 @@ public class SearchResultsFunction(
 
         var result = await searchService.GetSearchResultsAsync(
             jobId,
-            authContext.ClientId,
+            authContext.OrganisationId,
             client,
             cancellationToken
         );

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsV2Function.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchResultsV2Function.cs
@@ -7,7 +7,6 @@ using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using SUI.Find.Application.Constants;
-using SUI.Find.Application.Models;
 using SUI.Find.FindApi.Attributes;
 using SUI.Find.FindApi.Models;
 using SUI.Find.FindApi.Utility;
@@ -88,7 +87,7 @@ public class SearchResultsV2Function(
             {
                 ["InvocationId"] = context.InvocationId,
                 ["WorkItemId"] = workItemId,
-                ["RequestingOrganisationId"] = authContext.ClientId,
+                ["RequestingOrganisationId"] = authContext.OrganisationId,
                 ["TraceId"] = Activity.Current?.TraceId.ToString() ?? string.Empty,
                 ["TraceParent"] = context.TraceContext.TraceParent,
             }
@@ -96,7 +95,7 @@ public class SearchResultsV2Function(
 
         var result = await jobSearchService.GetSearchResultsAsync(
             workItemId,
-            authContext.ClientId,
+            authContext.OrganisationId,
             cancellationToken
         );
 

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchStatusFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SearchStatusFunction.cs
@@ -6,7 +6,6 @@ using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using SUI.Find.Application.Constants;
-using SUI.Find.Application.Models;
 using SUI.Find.Application.Services;
 using SUI.Find.FindApi.Attributes;
 using SUI.Find.FindApi.Models;
@@ -89,7 +88,7 @@ public class SearchStatusFunction(
         }
         var jobStatus = await searchService.GetSearchStatusAsync(
             jobId,
-            authContext.ClientId,
+            authContext.OrganisationId,
             client,
             cancellationToken
         );

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SubmitJobResultsFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/SubmitJobResultsFunction.cs
@@ -66,7 +66,7 @@ public class SubmitJobResultsFunction(
             );
         }
 
-        var custodianId = authContext.ClientId;
+        var custodianId = authContext.OrganisationId;
 
         var job = await jobService.ValidateLeaseAsync(
             request.JobId,

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/HttpFunctions/WorkAvailableFunction.cs
@@ -59,7 +59,7 @@ public class WorkAvailableFunction(
         using var scope = logger.BeginScope(
             new Dictionary<string, object>
             {
-                { "SubmittingCustodianId", authContext.ClientId },
+                { "SubmittingCustodianId", authContext.OrganisationId },
                 { "TraceParent", context.TraceContext.TraceParent },
                 { "TraceId", Activity.Current?.TraceId.ToString() ?? string.Empty },
                 { "InvocationId", context.InvocationId },
@@ -68,11 +68,11 @@ public class WorkAvailableFunction(
 
         logger.LogInformation(
             "Checking if work is available for custodian: {SubmittingCustodianId}",
-            authContext.ClientId
+            authContext.OrganisationId
         );
 
         var hasJobs = await jobClaimService.DoesCustodianHaveJobs(
-            authContext.ClientId,
+            authContext.OrganisationId,
             cancellationToken
         );
 

--- a/Apps/Find/src/SUI.Find.FindApi/Functions/OrchestratorFunctions/SearchOrchestrator.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Functions/OrchestratorFunctions/SearchOrchestrator.cs
@@ -22,7 +22,7 @@ public class SearchOrchestrator(ILogger<SearchOrchestrator> logger)
             data is null
             || string.IsNullOrWhiteSpace(data.Suid)
             || string.IsNullOrWhiteSpace(data.Metadata.PersonId)
-            || string.IsNullOrWhiteSpace(data.PolicyContext.ClientId)
+            || string.IsNullOrWhiteSpace(data.PolicyContext.OrganisationId)
         )
         {
             throw new ArgumentException("Invalid input in Search Orchestrator");
@@ -85,14 +85,14 @@ public class SearchOrchestrator(ILogger<SearchOrchestrator> logger)
         ArgumentNullException.ThrowIfNull(input);
 
         var (jobId, data, provider) = input;
-        var requestingOrdId = data.PolicyContext.ClientId;
+        var requestingOrgId = data.PolicyContext.OrganisationId;
         var sourceOrgId = provider.OrgId;
 
         using var logScope = logger.BeginScope(
-            "CorrelationId: {CorrelationId}, JobId: {JobId}, RequestingOrdId: {RequestingOrdId}, SourceOrgId: {SourceOrgId}",
+            "CorrelationId: {CorrelationId}, JobId: {JobId}, RequestingOrgId: {RequestingOrgId}, SourceOrgId: {SourceOrgId}",
             input.SearchInput.Metadata.InvocationId,
             jobId,
-            requestingOrdId,
+            requestingOrgId,
             sourceOrgId
         );
 
@@ -104,7 +104,7 @@ public class SearchOrchestrator(ILogger<SearchOrchestrator> logger)
         >(
             nameof(QueryProvidersFunction),
             new QueryProviderInput(
-                requestingOrdId,
+                requestingOrgId,
                 jobId,
                 data.Metadata.InvocationId,
                 data.Suid,
@@ -118,7 +118,7 @@ public class SearchOrchestrator(ILogger<SearchOrchestrator> logger)
         // Activity Two: filter the provider's results based on the requesting provider's data sharing policies (PEP Policy Enforcement Point)
         var filterInput = new PepFilterInput<CustodianSearchResultItem>(
             sourceOrgId,
-            requestingOrdId,
+            requestingOrgId,
             data.PolicyContext.OrgType,
             providerResults,
             provider.DsaPolicy,
@@ -146,7 +146,7 @@ public class SearchOrchestrator(ILogger<SearchOrchestrator> logger)
                 WorkItemId: jobId, // In this context (fan-out architecture), WorkItemId is the same as JobId.
                 InvocationId: data.Metadata.InvocationId,
                 JobId: jobId,
-                RequestingOrdId: requestingOrdId,
+                RequestingOrgId: requestingOrgId,
                 SourceOrgId: sourceOrgId
             ),
             options

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/AuditMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/AuditMiddleware.cs
@@ -57,7 +57,7 @@ public class AuditMiddleware(ILogger<AuditMiddleware> logger, IAuditQueueClient 
 
         if (authContext is not null)
         {
-            var clientId = authContext.ClientId;
+            var organisationId = authContext.OrganisationId;
 
             var payload = new AuditAccessMessage
             {
@@ -89,7 +89,7 @@ public class AuditMiddleware(ILogger<AuditMiddleware> logger, IAuditQueueClient 
                 CorrelationId = context.InvocationId,
                 ServiceName = "AuditMiddleware",
                 EventName = ApplicationConstants.Audit.HttpRequest.EventName,
-                Actor = new AuditActor { ActorId = clientId, ActorRole = "Organisation" },
+                Actor = new AuditActor { ActorId = organisationId, ActorRole = "Organisation" },
                 Payload = JsonSerializer.SerializeToElement(payload),
             };
 

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/AuthContextFactory.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/AuthContextFactory.cs
@@ -17,13 +17,11 @@ public class AuthContextFactory : IAuthContextFactory
 
         var client = store.Clients?.FirstOrDefault(c => c.ClientId == clientId);
         if (client == null)
-            throw new InvalidOperationException(
-                $"Client could not be found in auth store. ClientId: {clientId}"
-            );
+            throw new InvalidOperationException("Client could not be found in auth store.");
 
         if (string.IsNullOrWhiteSpace(client.OrganisationId))
             throw new InvalidOperationException(
-                $"No Organisation ID found for client in auth store. ClientId: {clientId}"
+                "No Organisation ID found for client in auth store."
             );
 
         var scopes = jwt

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/AuthContextFactory.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/AuthContextFactory.cs
@@ -1,0 +1,45 @@
+using System.IdentityModel.Tokens.Jwt;
+using SUI.Find.FindApi.Models;
+using SUI.Find.Infrastructure.Models;
+
+namespace SUI.Find.FindApi.Middleware;
+
+public class AuthContextFactory : IAuthContextFactory
+{
+    public AuthContext FromJwt(JwtSecurityToken jwt, AuthStore store)
+    {
+        var clientId = Get(jwt, "client_id");
+        if (string.IsNullOrWhiteSpace(clientId))
+            clientId = Get(jwt, "sub");
+
+        if (string.IsNullOrWhiteSpace(clientId))
+            throw new InvalidOperationException("Token did not contain client_id or sub.");
+
+        var client = store.Clients?.FirstOrDefault(c => c.ClientId == clientId);
+        if (client == null)
+            throw new InvalidOperationException(
+                $"Client could not be found in auth store. ClientId: {clientId}"
+            );
+
+        if (string.IsNullOrWhiteSpace(client.OrganisationId))
+            throw new InvalidOperationException(
+                $"No Organisation ID found for client in auth store. ClientId: {clientId}"
+            );
+
+        var scopes = jwt
+            .Claims.Where(c => c.Type is "scp" or "scope" or "roles" or "role")
+            .SelectMany(c =>
+                c.Value.Split(
+                    ' ',
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                )
+            )
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new AuthContext(clientId, client.OrganisationId, scopes);
+
+        static string Get(JwtSecurityToken t, string type) =>
+            t.Claims.FirstOrDefault(c => c.Type == type)?.Value ?? string.Empty;
+    }
+}

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/IAuthContextFactory.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/IAuthContextFactory.cs
@@ -1,0 +1,10 @@
+using System.IdentityModel.Tokens.Jwt;
+using SUI.Find.FindApi.Models;
+using SUI.Find.Infrastructure.Models;
+
+namespace SUI.Find.FindApi.Middleware;
+
+public interface IAuthContextFactory
+{
+    AuthContext FromJwt(JwtSecurityToken jwt, AuthStore store);
+}

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Reflection;
@@ -14,17 +13,13 @@ using SUI.Find.Infrastructure.Services;
 
 namespace SUI.Find.FindApi.Middleware;
 
-[ExcludeFromCodeCoverage(
-    Justification = "Waiting on Integration tests to cover middleware functionality."
-)]
 // ReSharper disable once ClassNeverInstantiated.Global
 public class JwtAuthMiddleware(
     IAuthStoreService authStoreService,
-    IAuthContextFactory authContextFactory
+    IAuthContextFactory authContextFactory,
+    ISecurityTokenValidator handler
 ) : IFunctionsWorkerMiddleware
 {
-    private static readonly JwtSecurityTokenHandler Handler = new();
-
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
         var req = await context.GetHttpRequestDataAsync();
@@ -90,7 +85,7 @@ public class JwtAuthMiddleware(
 
         try
         {
-            Handler.ValidateToken(token, validationParameters, out var validated);
+            handler.ValidateToken(token, validationParameters, out var validated);
             jwt = (JwtSecurityToken)validated;
         }
         catch (SecurityTokenException ex)

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
@@ -18,7 +18,10 @@ namespace SUI.Find.FindApi.Middleware;
     Justification = "Waiting on Integration tests to cover middleware functionality."
 )]
 // ReSharper disable once ClassNeverInstantiated.Global
-public class JwtAuthMiddleware(IAuthStoreService authStoreService) : IFunctionsWorkerMiddleware
+public class JwtAuthMiddleware(
+    IAuthStoreService authStoreService,
+    IAuthContextFactory authContextFactory
+) : IFunctionsWorkerMiddleware
 {
     private static readonly JwtSecurityTokenHandler Handler = new();
 
@@ -111,7 +114,7 @@ public class JwtAuthMiddleware(IAuthStoreService authStoreService) : IFunctionsW
             return;
         }
 
-        var authContext = AuthContextFactory.FromJwt(jwt);
+        var authContext = authContextFactory.FromJwt(jwt, store);
 
         var requiredScopes = GetRequiredScopes(context);
 
@@ -176,41 +179,5 @@ public class JwtAuthMiddleware(IAuthStoreService authStoreService) : IFunctionsW
         return requiredScopes.Any(rs =>
             caller.Scopes.Contains(rs, StringComparer.OrdinalIgnoreCase)
         );
-    }
-}
-
-[ExcludeFromCodeCoverage(
-    Justification = "Waiting on Integration tests to cover middleware functionality."
-)]
-public static class AuthContextFactory
-{
-    public static AuthContext FromJwt(JwtSecurityToken jwt)
-    {
-        static string Get(JwtSecurityToken t, string type) =>
-            t.Claims.FirstOrDefault(c => c.Type == type)?.Value ?? string.Empty;
-
-        var clientId = Get(jwt, "client_id");
-        if (string.IsNullOrWhiteSpace(clientId))
-        {
-            clientId = Get(jwt, "sub");
-        }
-
-        if (string.IsNullOrWhiteSpace(clientId))
-        {
-            throw new InvalidOperationException("Token did not contain client_id or sub.");
-        }
-
-        var scopes = jwt
-            .Claims.Where(c => c.Type is "scp" or "scope" or "roles" or "role")
-            .SelectMany(c =>
-                c.Value.Split(
-                    ' ',
-                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
-                )
-            )
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        return new AuthContext(clientId, scopes);
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Models/AuthContext.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Models/AuthContext.cs
@@ -1,8 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace SUI.Find.FindApi.Models;
 
-[ExcludeFromCodeCoverage(Justification = "Will be tested with integration tests.")]
 public sealed record AuthContext(
     string ClientId,
     string OrganisationId,

--- a/Apps/Find/src/SUI.Find.FindApi/Models/AuthContext.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Models/AuthContext.cs
@@ -3,4 +3,8 @@ using System.Diagnostics.CodeAnalysis;
 namespace SUI.Find.FindApi.Models;
 
 [ExcludeFromCodeCoverage(Justification = "Will be tested with integration tests.")]
-public sealed record AuthContext(string ClientId, IReadOnlyList<string> Scopes);
+public sealed record AuthContext(
+    string ClientId,
+    string OrganisationId,
+    IReadOnlyList<string> Scopes
+);

--- a/Apps/Find/src/SUI.Find.FindApi/Program.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Program.cs
@@ -50,6 +50,9 @@ builder.Services.AddSingleton<IFileSystem, FileSystem>();
 // Infrastructure services
 builder.Services.AddInfrastructureServices();
 
+// Middleware services
+builder.Services.AddSingleton<IAuthContextFactory, AuthContextFactory>();
+
 // Application services
 builder.Services.AddSingleton<IMaskUrlService, MaskUrlService>();
 builder.Services.AddSingleton<ISearchService, SearchService>();

--- a/Apps/Find/src/SUI.Find.FindApi/Program.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Program.cs
@@ -1,3 +1,4 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.IO.Abstractions;
 using System.Net;
 using Azure.Data.Tables;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 using Polly;
 using Polly.Extensions.Http;
 using SUI.Find.Application.Constants;
@@ -52,6 +54,7 @@ builder.Services.AddInfrastructureServices();
 
 // Middleware services
 builder.Services.AddSingleton<IAuthContextFactory, AuthContextFactory>();
+builder.Services.AddSingleton<ISecurityTokenValidator, JwtSecurityTokenHandler>();
 
 // Application services
 builder.Services.AddSingleton<IMaskUrlService, MaskUrlService>();

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/PersonIdRepresentationServiceTests/FindPersonIdAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/PersonIdRepresentationServiceTests/FindPersonIdAsyncTests.cs
@@ -45,7 +45,7 @@ public class FindPersonIdAsyncTests
         // Act
         var result = await _sut.FindPersonIdAsync(
             specification: personSpec,
-            clientId: "test-client-id",
+            organisationId: "test-client-id",
             CancellationToken.None
         );
 
@@ -75,7 +75,7 @@ public class FindPersonIdAsyncTests
         // Act
         var result = await _sut.FindPersonIdAsync(
             specification: personSpec,
-            clientId: "test-client-id",
+            organisationId: "test-client-id",
             CancellationToken.None
         );
 
@@ -99,7 +99,7 @@ public class FindPersonIdAsyncTests
         // Act
         var result = await _sut.FindPersonIdAsync(
             specification: personSpec,
-            clientId: "test-client-id",
+            organisationId: "test-client-id",
             CancellationToken.None
         );
 
@@ -121,7 +121,7 @@ public class FindPersonIdAsyncTests
         // Act
         var result = await _sut.FindPersonIdAsync(
             specification: personSpec,
-            clientId: "test-client-id",
+            organisationId: "test-client-id",
             CancellationToken.None
         );
 

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/PersonIdRepresentationServiceTests/FindPersonIdAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/PersonIdRepresentationServiceTests/FindPersonIdAsyncTests.cs
@@ -31,7 +31,7 @@ public class FindPersonIdAsyncTests
         // Arrange
         var personSpec = CreateMinimalValidPersonSpec();
         _custodianService
-            .GetCustodianAsync("test-client-id")
+            .GetCustodianAsync("test-org-id")
             .Returns(Domain.Models.Result<ProviderDefinition>.Ok(new ProviderDefinition()));
         var nhsPersonId = NhsPersonId.Create("9999999999").Value;
         _matchingService
@@ -45,7 +45,7 @@ public class FindPersonIdAsyncTests
         // Act
         var result = await _sut.FindPersonIdAsync(
             specification: personSpec,
-            organisationId: "test-client-id",
+            organisationId: "test-org-id",
             CancellationToken.None
         );
 
@@ -75,7 +75,7 @@ public class FindPersonIdAsyncTests
         // Act
         var result = await _sut.FindPersonIdAsync(
             specification: personSpec,
-            organisationId: "test-client-id",
+            organisationId: "test-org-id",
             CancellationToken.None
         );
 
@@ -99,7 +99,7 @@ public class FindPersonIdAsyncTests
         // Act
         var result = await _sut.FindPersonIdAsync(
             specification: personSpec,
-            organisationId: "test-client-id",
+            organisationId: "test-org-id",
             CancellationToken.None
         );
 
@@ -121,7 +121,7 @@ public class FindPersonIdAsyncTests
         // Act
         var result = await _sut.FindPersonIdAsync(
             specification: personSpec,
-            organisationId: "test-client-id",
+            organisationId: "test-org-id",
             CancellationToken.None
         );
 

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/BaseSearchServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/BaseSearchServiceTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 using SUI.Find.Application.Dtos;
 using SUI.Find.Application.Interfaces;
@@ -27,7 +26,7 @@ public class BaseSearchServiceTests
             SearchResultEntryRepository
         );
         var metaData = new SearchJobMetadata("test-person-id", DateTime.UtcNow, "invocation-id");
-        var policyData = new PolicyContext("test-client-id", "SAFEGUARDING", "LOCAL_AUTHORITY");
+        var policyData = new PolicyContext("test-org-id", "SAFEGUARDING", "LOCAL_AUTHORITY");
         Sut.ReadOrchestratorInput<SearchOrchestratorInput>(Arg.Any<OrchestrationMetadata>())
             .Returns(new SearchOrchestratorInput("test-suid", metaData, policyData));
     }

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/CancelSearchAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/CancelSearchAsyncTests.cs
@@ -13,12 +13,12 @@ namespace SUI.Find.Application.UnitTests.Services.SearchServiceTests;
 public class CancelSearchAsyncTests : BaseSearchServiceTests
 {
     private readonly DurableTaskClient _client = Substitute.For<DurableTaskClient>("name");
-    private const string ClientId = "test-client-id";
+    private const string OrganisationId = "test-org-id";
 
     public CancelSearchAsyncTests()
     {
         var metaData = new SearchJobMetadata("test-person-id", DateTime.UtcNow, "invocation-id");
-        var policyData = new PolicyContext("test-client-id", "SAFEGUARDING", "LOCAL_AUTHORITY");
+        var policyData = new PolicyContext(OrganisationId, "SAFEGUARDING", "LOCAL_AUTHORITY");
         Sut.ReadOrchestratorInput<SearchOrchestratorInput>(Arg.Any<OrchestrationMetadata>())
             .Returns(new SearchOrchestratorInput("test-suid", metaData, policyData));
     }
@@ -36,7 +36,7 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.CancelSearchAsync(
             "not-found-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -61,7 +61,7 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.CancelSearchAsync(
             "completed-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -87,7 +87,7 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.CancelSearchAsync(
             "non-cancellable-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -110,7 +110,7 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.CancelSearchAsync(
             "cancel-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -129,7 +129,7 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.CancelSearchAsync(
             "fail-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -150,17 +150,13 @@ public class CancelSearchAsyncTests : BaseSearchServiceTests
 
         // Mock the ReadOrchestratorInput to return a different clientId
         var metaData = new SearchJobMetadata("test-person-id", DateTime.UtcNow, "invocation-id");
-        var policyData = new PolicyContext(
-            "different-client-id",
-            "SAFEGUARDING",
-            "LOCAL_AUTHORITY"
-        );
+        var policyData = new PolicyContext("different-org-id", "SAFEGUARDING", "LOCAL_AUTHORITY");
         Sut.ReadOrchestratorInput<SearchOrchestratorInput>(meta)
             .Returns(new SearchOrchestratorInput("test-suid", metaData, policyData));
 
         var result = await Sut.CancelSearchAsync(
             "unauth-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/GetSearchResultsAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/GetSearchResultsAsyncTests.cs
@@ -12,7 +12,7 @@ namespace SUI.Find.Application.UnitTests.Services.SearchServiceTests;
 public class GetSearchResultsAsyncTests : BaseSearchServiceTests
 {
     private readonly DurableTaskClient _client = Substitute.For<DurableTaskClient>("name");
-    private const string ClientId = "test-client-id";
+    private const string OrganisationId = "test-org-id";
 
     [Fact]
     public async Task ShouldReturnNotFound_WhenJobDoesNotExist()
@@ -23,7 +23,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.GetSearchResultsAsync(
             "not-found-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -42,17 +42,13 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
 
         // Mock the ReadOrchestratorInput to return a different clientId
         var metaData = new SearchJobMetadata("test-person-id", DateTime.UtcNow, "invocation-id");
-        var policyData = new PolicyContext(
-            "different-client-id",
-            "SAFEGUARDING",
-            "LOCAL_AUTHORITY"
-        );
+        var policyData = new PolicyContext("different-org-id", "SAFEGUARDING", "LOCAL_AUTHORITY");
         Sut.ReadOrchestratorInput<SearchOrchestratorInput>(meta)
             .Returns(new SearchOrchestratorInput("test-suid", metaData, policyData));
 
         var result = await Sut.GetSearchResultsAsync(
             "unauth-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -69,7 +65,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.GetSearchResultsAsync(
             "fail-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -88,7 +84,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.GetSearchResultsAsync(
             "running-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -110,7 +106,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.GetSearchResultsAsync(
             "empty-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -150,7 +146,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.GetSearchResultsAsync(
             "success-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -172,7 +168,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
         _client.GetInstanceAsync("running-job", true, Arg.Any<CancellationToken>()).Returns(meta);
 
         SearchResultEntryRepository
-            .GetByWorkItemIdAsync("running-job", ClientId, Arg.Any<CancellationToken>())
+            .GetByWorkItemIdAsync("running-job", OrganisationId, Arg.Any<CancellationToken>())
             .Returns(
                 new[]
                 {
@@ -187,14 +183,14 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
                         JobId = "running-job",
                         SubmittedAtUtc = DateTimeOffset.UtcNow,
                         WorkItemId = "running-job",
-                        RequestingOrganisationId = ClientId,
+                        RequestingOrganisationId = OrganisationId,
                     },
                 }
             );
 
         var result = await Sut.GetSearchResultsAsync(
             "running-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -223,7 +219,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
         _client.GetInstanceAsync("running-job", true, Arg.Any<CancellationToken>()).Returns(meta);
 
         SearchResultEntryRepository
-            .GetByWorkItemIdAsync("running-job", ClientId, Arg.Any<CancellationToken>())
+            .GetByWorkItemIdAsync("running-job", OrganisationId, Arg.Any<CancellationToken>())
             .Returns([
                 new SearchResultEntry
                 {
@@ -235,7 +231,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
                     RecordType = "",
                     JobId = "running-job",
                     WorkItemId = "running-job",
-                    RequestingOrganisationId = ClientId,
+                    RequestingOrganisationId = OrganisationId,
                 },
                 new SearchResultEntry
                 {
@@ -247,14 +243,14 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
                     RecordType = "",
                     JobId = "running-job",
                     WorkItemId = "running-job",
-                    RequestingOrganisationId = ClientId,
+                    RequestingOrganisationId = OrganisationId,
                 },
             ]);
 
         // ACT
         var result = await Sut.GetSearchResultsAsync(
             "running-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -289,7 +285,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
         _client.GetInstanceAsync("completed-job", true, Arg.Any<CancellationToken>()).Returns(meta);
 
         SearchResultEntryRepository
-            .GetByWorkItemIdAsync("completed-job", ClientId, Arg.Any<CancellationToken>())
+            .GetByWorkItemIdAsync("completed-job", OrganisationId, Arg.Any<CancellationToken>())
             .Returns(
                 new[]
                 {
@@ -304,14 +300,14 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
                         JobId = "completed-job",
                         SubmittedAtUtc = DateTimeOffset.UtcNow,
                         WorkItemId = "completed-job",
-                        RequestingOrganisationId = ClientId,
+                        RequestingOrganisationId = OrganisationId,
                     },
                 }
             );
 
         var result = await Sut.GetSearchResultsAsync(
             "completed-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -336,7 +332,7 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
         _client.GetInstanceAsync("running-job", true, Arg.Any<CancellationToken>()).Returns(meta);
 
         SearchResultEntryRepository
-            .GetByWorkItemIdAsync("running-job", ClientId, Arg.Any<CancellationToken>())
+            .GetByWorkItemIdAsync("running-job", OrganisationId, Arg.Any<CancellationToken>())
             .Returns(
                 new[]
                 {
@@ -351,14 +347,14 @@ public class GetSearchResultsAsyncTests : BaseSearchServiceTests
                         JobId = "running-job",
                         SubmittedAtUtc = DateTimeOffset.UtcNow,
                         WorkItemId = "running-job",
-                        RequestingOrganisationId = ClientId,
+                        RequestingOrganisationId = OrganisationId,
                     },
                 }
             );
 
         var result = await Sut.GetSearchResultsAsync(
             "running-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/GetSearchStatusAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/GetSearchStatusAsyncTests.cs
@@ -1,19 +1,17 @@
 using Microsoft.DurableTask.Client;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using OneOf.Types;
 using SUI.Find.Application.Dtos;
 using SUI.Find.Application.Enums;
 using SUI.Find.Application.Models;
-using SUI.Find.Application.Services;
 
 namespace SUI.Find.Application.UnitTests.Services.SearchServiceTests;
 
 public class GetSearchStatusAsyncTests : BaseSearchServiceTests
 {
     private readonly DurableTaskClient _client = Substitute.For<DurableTaskClient>("name");
-    private const string ClientId = "test-client-id";
+    private const string OrganisationId = "test-org-id";
 
     [Fact]
     public async Task ShouldReturnNotFound_WhenJobDoesNotExist()
@@ -24,7 +22,7 @@ public class GetSearchStatusAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.GetSearchStatusAsync(
             "not-found-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -42,17 +40,13 @@ public class GetSearchStatusAsyncTests : BaseSearchServiceTests
         _client.GetInstanceAsync("unauth-job", true, Arg.Any<CancellationToken>()).Returns(meta);
         // Mock the ReadOrchestratorInput to return a different clientId
         var metaData = new SearchJobMetadata("test-person-id", DateTime.UtcNow, "invocation-id");
-        var policyData = new PolicyContext(
-            "different-client-id",
-            "SAFEGUARDING",
-            "LOCAL_AUTHORITY"
-        );
+        var policyData = new PolicyContext("different-org-id", "SAFEGUARDING", "LOCAL_AUTHORITY");
         Sut.ReadOrchestratorInput<SearchOrchestratorInput>(meta)
             .Returns(new SearchOrchestratorInput("test-suid", metaData, policyData));
 
         var result = await Sut.GetSearchStatusAsync(
             "unauth-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -69,13 +63,13 @@ public class GetSearchStatusAsyncTests : BaseSearchServiceTests
         };
         _client.GetInstanceAsync("auth-job", true, Arg.Any<CancellationToken>()).Returns(meta);
         var metaData = new SearchJobMetadata("test-person-id", DateTime.UtcNow, "invocation-id");
-        var policyData = new PolicyContext(ClientId, "SAFEGUARDING", "LOCAL_AUTHORITY");
+        var policyData = new PolicyContext(OrganisationId, "SAFEGUARDING", "LOCAL_AUTHORITY");
         Sut.ReadOrchestratorInput<SearchOrchestratorInput>(meta)
             .Returns(new SearchOrchestratorInput("test-suid", metaData, policyData));
 
         var result = await Sut.GetSearchStatusAsync(
             "auth-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );
@@ -95,7 +89,7 @@ public class GetSearchStatusAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.GetSearchStatusAsync(
             "error-job",
-            ClientId,
+            OrganisationId,
             _client,
             CancellationToken.None
         );

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/StartSearchAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/StartSearchAsyncTests.cs
@@ -13,7 +13,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
 {
     private readonly DurableTaskClient _client = Substitute.For<DurableTaskClient>("name");
 
-    private const string ClientId = "test-client-id";
+    private const string OrganisationId = "test-org-id";
     private const string CorrelationId = "corr-id";
     private readonly CancellationToken _cancellationToken = CancellationToken.None;
     private readonly NhsPersonId _personId = NhsPersonId.Create("9999999999").Value!;
@@ -21,7 +21,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
     [Fact]
     public async Task ShouldReturnExistingJob_WhenDuplicateRequest()
     {
-        var instanceId = $"{_personId.Value}-{ClientId}";
+        var instanceId = $"{_personId.Value}-{OrganisationId}";
         HashService.HmacSha256Hash(instanceId).Returns("hashed-id");
 
         var orchestrationMeta = new OrchestrationMetadata("SearchOrchestrator", "hashed-id")
@@ -34,7 +34,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.StartSearchAsync(
             _personId.Value,
-            ClientId,
+            OrganisationId,
             _client,
             CorrelationId,
             _cancellationToken
@@ -50,19 +50,19 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
     [Fact]
     public async Task ShouldReturnFailed_WhenCustodianNotFound()
     {
-        var instanceId = $"{_personId}-{ClientId}";
+        var instanceId = $"{_personId}-{OrganisationId}";
         HashService.HmacSha256Hash(instanceId).Returns("hashed-id");
         _client
             .GetInstanceAsync("hashed-id", Arg.Any<CancellationToken>())
             .Returns((OrchestrationMetadata?)null);
 
         CustodianService
-            .GetCustodianAsync(ClientId)
+            .GetCustodianAsync(OrganisationId)
             .Returns(Domain.Models.Result<ProviderDefinition>.Fail("Custodian not found"));
 
         var result = await Sut.StartSearchAsync(
             _personId.Value,
-            ClientId,
+            OrganisationId,
             _client,
             CorrelationId,
             _cancellationToken
@@ -74,14 +74,14 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
     [Fact]
     public async Task ShouldReturnSuccess_WhenCustodianExists()
     {
-        var instanceId = $"{_personId}-{ClientId}";
+        var instanceId = $"{_personId}-{OrganisationId}";
         HashService.HmacSha256Hash(instanceId).Returns("hashed-id");
         _client
             .GetInstanceAsync("hashed-id", Arg.Any<CancellationToken>())
             .Returns((OrchestrationMetadata?)null);
 
         CustodianService
-            .GetCustodianAsync(ClientId)
+            .GetCustodianAsync(OrganisationId)
             .Returns(Domain.Models.Result<ProviderDefinition>.Ok(new ProviderDefinition()));
 
         _client
@@ -95,7 +95,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.StartSearchAsync(
             _personId.Value,
-            ClientId,
+            OrganisationId,
             _client,
             CorrelationId,
             _cancellationToken
@@ -110,7 +110,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
     [Fact]
     public async Task ShouldReturnSuccess_WhenNewJobScheduled()
     {
-        var instanceId = $"{_personId}-{ClientId}";
+        var instanceId = $"{_personId}-{OrganisationId}";
         HashService.HmacSha256Hash(instanceId).Returns("hashed-id");
         _client
             .GetInstanceAsync("hashed-id", Arg.Any<CancellationToken>())
@@ -118,7 +118,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
 
         var custodianDef = new ProviderDefinition();
         CustodianService
-            .GetCustodianAsync(ClientId)
+            .GetCustodianAsync(OrganisationId)
             .Returns(Domain.Models.Result<ProviderDefinition>.Ok(custodianDef));
 
         _client
@@ -132,7 +132,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
 
         var result = await Sut.StartSearchAsync(
             _personId.Value,
-            ClientId,
+            OrganisationId,
             _client,
             CorrelationId,
             _cancellationToken

--- a/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/StartSearchAsyncTests.cs
+++ b/Apps/Find/tests/SUI.Find.Application.UnitTests/Services/SearchServiceTests/StartSearchAsyncTests.cs
@@ -50,7 +50,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
     [Fact]
     public async Task ShouldReturnFailed_WhenCustodianNotFound()
     {
-        var instanceId = $"{_personId}-{OrganisationId}";
+        var instanceId = $"{_personId.Value}-{OrganisationId}";
         HashService.HmacSha256Hash(instanceId).Returns("hashed-id");
         _client
             .GetInstanceAsync("hashed-id", Arg.Any<CancellationToken>())
@@ -74,7 +74,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
     [Fact]
     public async Task ShouldReturnSuccess_WhenCustodianExists()
     {
-        var instanceId = $"{_personId}-{OrganisationId}";
+        var instanceId = $"{_personId.Value}-{OrganisationId}";
         HashService.HmacSha256Hash(instanceId).Returns("hashed-id");
         _client
             .GetInstanceAsync("hashed-id", Arg.Any<CancellationToken>())
@@ -110,7 +110,7 @@ public class StartSearchAsyncTests : BaseSearchServiceTests
     [Fact]
     public async Task ShouldReturnSuccess_WhenNewJobScheduled()
     {
-        var instanceId = $"{_personId}-{OrganisationId}";
+        var instanceId = $"{_personId.Value}-{OrganisationId}";
         HashService.HmacSha256Hash(instanceId).Returns("hashed-id");
         _client
             .GetInstanceAsync("hashed-id", Arg.Any<CancellationToken>())

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/CancelSearchFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/CancelSearchFunctionTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Primitives;
 using NSubstitute;
 using OneOf.Types;
 using SUI.Find.Application.Constants;
-using SUI.Find.Application.Dtos;
 using SUI.Find.Application.Enums;
 using SUI.Find.Application.Models;
 using SUI.Find.Application.Services;
@@ -23,7 +22,7 @@ public class CancelSearchFunctionTests
     private readonly DurableTaskClient _client = Substitute.For<DurableTaskClient>("name");
     private readonly FunctionContext _context = Substitute.For<FunctionContext>();
     private const string JobId = "test-job-id";
-    private const string ClientId = "test-client-id";
+    private const string OrganisationId = "test-org-id";
 
     public CancelSearchFunctionTests()
     {
@@ -35,7 +34,11 @@ public class CancelSearchFunctionTests
         // Setup AuthContext in FunctionContext.Items
         var items = new Dictionary<object, object>
         {
-            [ApplicationConstants.Auth.AuthContextKey] = new AuthContext(ClientId, ClientId, []),
+            [ApplicationConstants.Auth.AuthContextKey] = new AuthContext(
+                Guid.NewGuid().ToString(),
+                OrganisationId,
+                []
+            ),
         };
         _context.Items.Returns(items);
     }
@@ -48,7 +51,7 @@ public class CancelSearchFunctionTests
             new Dictionary<string, StringValues> { { "jobId", JobId } }
         );
         _searchService
-            .CancelSearchAsync(JobId, ClientId, _client, CancellationToken.None)
+            .CancelSearchAsync(JobId, OrganisationId, _client, CancellationToken.None)
             .Returns(
                 new SearchJobDto
                 {
@@ -81,7 +84,7 @@ public class CancelSearchFunctionTests
             new Dictionary<string, StringValues> { { "jobId", JobId } }
         );
         _searchService
-            .CancelSearchAsync(JobId, ClientId, _client, CancellationToken.None)
+            .CancelSearchAsync(JobId, OrganisationId, _client, CancellationToken.None)
             .Returns(new NotFound());
 
         // Act
@@ -108,7 +111,7 @@ public class CancelSearchFunctionTests
             new Dictionary<string, StringValues> { { "jobId", JobId } }
         );
         _searchService
-            .CancelSearchAsync(JobId, ClientId, _client, CancellationToken.None)
+            .CancelSearchAsync(JobId, OrganisationId, _client, CancellationToken.None)
             .Returns(
                 new SearchJobDto
                 {
@@ -145,7 +148,7 @@ public class CancelSearchFunctionTests
             new Dictionary<string, StringValues> { { "jobId", JobId } }
         );
         _searchService
-            .CancelSearchAsync(JobId, ClientId, _client, CancellationToken.None)
+            .CancelSearchAsync(JobId, OrganisationId, _client, CancellationToken.None)
             .Returns(new Error());
 
         // Act
@@ -198,7 +201,7 @@ public class CancelSearchFunctionTests
             new Dictionary<string, StringValues> { { "jobId", JobId } }
         );
         _searchService
-            .CancelSearchAsync(JobId, ClientId, _client, CancellationToken.None)
+            .CancelSearchAsync(JobId, OrganisationId, _client, CancellationToken.None)
             .Returns(new Forbidden());
 
         // Act

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/CancelSearchFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/CancelSearchFunctionTests.cs
@@ -35,7 +35,7 @@ public class CancelSearchFunctionTests
         // Setup AuthContext in FunctionContext.Items
         var items = new Dictionary<object, object>
         {
-            [ApplicationConstants.Auth.AuthContextKey] = new AuthContext(ClientId, []),
+            [ApplicationConstants.Auth.AuthContextKey] = new AuthContext(ClientId, ClientId, []),
         };
         _context.Items.Returns(items);
     }

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
@@ -114,10 +114,14 @@ public class ClaimJobFunctionTests
             .ShouldBe(ApplicationConstants.Http.DefaultRetryAfterSeconds);
     }
 
-    private static FunctionContext CreateContextWithAuth(string clientId)
+    private static FunctionContext CreateContextWithAuth(string organisationId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, clientId, ["work-item.write"]);
+        var authContext = new AuthContext(
+            Guid.NewGuid().ToString(),
+            organisationId,
+            ["work-item.write"]
+        );
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/ClaimJobFunctionTests.cs
@@ -117,7 +117,7 @@ public class ClaimJobFunctionTests
     private static FunctionContext CreateContextWithAuth(string clientId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, ["work-item.write"]);
+        var authContext = new AuthContext(clientId, clientId, ["work-item.write"]);
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/FetchRecordFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/FetchRecordFunctionTests.cs
@@ -4,7 +4,6 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using OneOf.Types;
-using SUI.Find.Application.Constants;
 using SUI.Find.Application.Interfaces;
 using SUI.Find.Application.Models;
 using SUI.Find.FindApi.Functions.HttpFunctions;
@@ -26,13 +25,13 @@ public class FetchRecordFunctionTests
         _sut = new FetchRecordFunction(_mockLogger, _mockService);
     }
 
-    private static FunctionContext CreateContextWithAuth(string clientId = "test-client-id")
+    private static FunctionContext CreateContextWithAuth(string organisationId = "test-org-id")
     {
         var context = Substitute.For<FunctionContext>();
         context.Items.Returns(
             new Dictionary<object, object>
             {
-                { "AuthContext", new AuthContext(clientId, clientId, []) },
+                { "AuthContext", new AuthContext(Guid.NewGuid().ToString(), organisationId, []) },
             }
         );
         context.InvocationId.Returns(Guid.NewGuid().ToString());

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/FetchRecordFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/FetchRecordFunctionTests.cs
@@ -30,7 +30,10 @@ public class FetchRecordFunctionTests
     {
         var context = Substitute.For<FunctionContext>();
         context.Items.Returns(
-            new Dictionary<object, object> { { "AuthContext", new AuthContext(clientId, []) } }
+            new Dictionary<object, object>
+            {
+                { "AuthContext", new AuthContext(clientId, clientId, []) },
+            }
         );
         context.InvocationId.Returns(Guid.NewGuid().ToString());
         return context;

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/MatchFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/MatchFunctionTests.cs
@@ -9,7 +9,6 @@ using OneOf.Types;
 using SUI.Find.Application.Constants;
 using SUI.Find.Application.Enums.Matching;
 using SUI.Find.Application.Interfaces;
-using SUI.Find.Application.Models;
 using SUI.Find.Application.Models.Matching;
 using SUI.Find.FindApi.Configurations;
 using SUI.Find.FindApi.Functions.HttpFunctions;
@@ -38,13 +37,13 @@ public class MatchFunctionTests
     private MatchFunction CreateFunction() =>
         new(_logger, _matchPersonOrchestrationService, _idRegisterRepository, _matchFunctionConfig);
 
-    private static FunctionContext CreateContextWithAuth(string clientId = "test-client-id")
+    private static FunctionContext CreateContextWithAuth(string organisationId = "test-org-id")
     {
         var context = Substitute.For<FunctionContext>();
         context.Items.Returns(
             new Dictionary<object, object>
             {
-                { "AuthContext", new AuthContext(clientId, clientId, []) },
+                { "AuthContext", new AuthContext(Guid.NewGuid().ToString(), organisationId, []) },
             }
         );
         context.InvocationId.Returns(Guid.NewGuid().ToString());
@@ -115,7 +114,7 @@ public class MatchFunctionTests
                     e.RecordType == "Test RecordType"
                     && e.CustodianSubjectId == "9999999999"
                     && e.SystemId == "Test System"
-                    && e.CustodianId == "test-client-id"
+                    && e.CustodianId == "test-org-id"
                 ),
                 Arg.Any<CancellationToken>()
             );

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/MatchFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/MatchFunctionTests.cs
@@ -42,7 +42,10 @@ public class MatchFunctionTests
     {
         var context = Substitute.For<FunctionContext>();
         context.Items.Returns(
-            new Dictionary<object, object> { { "AuthContext", new AuthContext(clientId, []) } }
+            new Dictionary<object, object>
+            {
+                { "AuthContext", new AuthContext(clientId, clientId, []) },
+            }
         );
         context.InvocationId.Returns(Guid.NewGuid().ToString());
         return context;

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/RenewLeaseFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/RenewLeaseFunctionTests.cs
@@ -49,7 +49,7 @@ public class RenewLeaseFunctionTests
     {
         // ARRANGE
         var request = MockHttpRequestData.Create(); // Empty body
-        var context = CreateContextWithAuth("test-client-id");
+        var context = CreateContextWithAuth("test-org-id");
 
         // ACT
         var result = await _sut.RenewLease(request, context, CancellationToken.None);
@@ -62,23 +62,23 @@ public class RenewLeaseFunctionTests
     public async Task RenewLease_ShouldReturn_Ok_WhenLeaseIsRenewedSuccessfully()
     {
         // ARRANGE
-        const string testClientId = "test-client-id";
+        const string testOrganisationId = "test-org-id";
         var requestBody = new RenewJobLeaseRequest { JobId = "job123", LeaseId = "lease456" };
         var request = CreateHttpRequestData(requestBody);
-        var context = CreateContextWithAuth(testClientId);
+        var context = CreateContextWithAuth(testOrganisationId);
 
         var expectedJobInfo = new JobInfo
         {
             JobId = requestBody.JobId,
             LeaseId = requestBody.LeaseId,
-            CustodianId = testClientId,
+            CustodianId = testOrganisationId,
             WorkItemId = "workItem789",
             LeaseExpiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(30),
         };
 
         _mockJobClaimService
             .ExtendJobLeaseAsync(
-                testClientId,
+                testOrganisationId,
                 requestBody.JobId,
                 requestBody.LeaseId,
                 Arg.Any<CancellationToken>()
@@ -93,7 +93,7 @@ public class RenewLeaseFunctionTests
         await _mockJobClaimService
             .Received(1)
             .ExtendJobLeaseAsync(
-                testClientId,
+                testOrganisationId,
                 requestBody.JobId,
                 requestBody.LeaseId,
                 Arg.Any<CancellationToken>()
@@ -115,14 +115,14 @@ public class RenewLeaseFunctionTests
     public async Task RenewLease_ShouldReturn_NoContent_WhenJobInfoIsNull()
     {
         // ARRANGE
-        const string testClientId = "test-client-id";
+        const string testOrganisationId = "test-org-id";
         var requestBody = new RenewJobLeaseRequest { JobId = "job123", LeaseId = "lease456" };
         var request = CreateHttpRequestData(requestBody);
-        var context = CreateContextWithAuth(testClientId);
+        var context = CreateContextWithAuth(testOrganisationId);
 
         _mockJobClaimService
             .ExtendJobLeaseAsync(
-                testClientId,
+                testOrganisationId,
                 requestBody.JobId,
                 requestBody.LeaseId,
                 Arg.Any<CancellationToken>()
@@ -137,7 +137,7 @@ public class RenewLeaseFunctionTests
         await _mockJobClaimService
             .Received(1)
             .ExtendJobLeaseAsync(
-                testClientId,
+                testOrganisationId,
                 requestBody.JobId,
                 requestBody.LeaseId,
                 Arg.Any<CancellationToken>()
@@ -145,10 +145,14 @@ public class RenewLeaseFunctionTests
         result.Body.Length.ShouldBe(0);
     }
 
-    private static FunctionContext CreateContextWithAuth(string clientId)
+    private static FunctionContext CreateContextWithAuth(string organisationId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, clientId, ["work-item.write"]);
+        var authContext = new AuthContext(
+            Guid.NewGuid().ToString(),
+            organisationId,
+            ["work-item.write"]
+        );
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/RenewLeaseFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/RenewLeaseFunctionTests.cs
@@ -148,7 +148,7 @@ public class RenewLeaseFunctionTests
     private static FunctionContext CreateContextWithAuth(string clientId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, ["work-item.write"]);
+        var authContext = new AuthContext(clientId, clientId, ["work-item.write"]);
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchEndpointTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchEndpointTests.cs
@@ -31,7 +31,11 @@ public class SearchEndpointTests
         _context.InvocationId.Returns(Guid.NewGuid().ToString());
         var items = new Dictionary<object, object>
         {
-            [ApplicationConstants.Auth.AuthContextKey] = new AuthContext(TestClientId, []),
+            [ApplicationConstants.Auth.AuthContextKey] = new AuthContext(
+                TestClientId,
+                TestClientId,
+                []
+            ),
         };
         _context.Items.Returns(items);
         var logger = Substitute.For<ILogger<SearchFunction>>();

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchEndpointTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchEndpointTests.cs
@@ -24,7 +24,7 @@ public class SearchEndpointTests
 
     private const string ValidSuid = "9999999999";
     private const string InvalidSuid = "invalid-suid";
-    private const string TestClientId = "test-client-id";
+    private const string TestOrganisationId = "test-org-id";
 
     public SearchEndpointTests()
     {
@@ -32,8 +32,8 @@ public class SearchEndpointTests
         var items = new Dictionary<object, object>
         {
             [ApplicationConstants.Auth.AuthContextKey] = new AuthContext(
-                TestClientId,
-                TestClientId,
+                Guid.NewGuid().ToString(),
+                TestOrganisationId,
                 []
             ),
         };

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchFunctionV2Tests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchFunctionV2Tests.cs
@@ -107,7 +107,7 @@ public class SearchFunctionV2Tests
     private static FunctionContext CreateContextWithAuth(string clientId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, ["find-record.write"]);
+        var authContext = new AuthContext(clientId, clientId, ["find-record.write"]);
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchFunctionV2Tests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchFunctionV2Tests.cs
@@ -104,10 +104,14 @@ public class SearchFunctionV2Tests
         Assert.Equal(searchJobDto.PersonId, searchJob.Suid);
     }
 
-    private static FunctionContext CreateContextWithAuth(string clientId)
+    private static FunctionContext CreateContextWithAuth(string organisationId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, clientId, ["find-record.write"]);
+        var authContext = new AuthContext(
+            Guid.NewGuid().ToString(),
+            organisationId,
+            ["find-record.write"]
+        );
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchOrchestratorFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchOrchestratorFunctionTests.cs
@@ -132,7 +132,7 @@ public class SearchOrchestratorFunctionsTests
                 Arg.Is<PersistSearchResultsInput>(x =>
                     x.WorkItemId == "instance-123"
                     && x.JobId == "instance-123"
-                    && x.RequestingOrdId == DestOrgId
+                    && x.RequestingOrgId == DestOrgId
                     && x.SourceOrgId == SourceOrgId1
                 ),
                 Arg.Any<TaskOptions>()

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsFunctionTests.cs
@@ -37,7 +37,7 @@ public class SearchResultsFunctionTests
         _sut = new SearchResultsFunction(_logger, _searchService);
     }
 
-    private static FunctionContext CreateContextWithAuth(string clientId = "test-client-id")
+    private static FunctionContext CreateContextWithAuth(string organisationId = "test-org-id")
     {
         var context = Substitute.For<FunctionContext>();
         context.Items.Returns(
@@ -45,7 +45,7 @@ public class SearchResultsFunctionTests
             {
                 {
                     Application.Constants.ApplicationConstants.Auth.AuthContextKey,
-                    new AuthContext(clientId, clientId, [])
+                    new AuthContext(Guid.NewGuid().ToString(), organisationId, [])
                 },
             }
         );
@@ -75,7 +75,7 @@ public class SearchResultsFunctionTests
             Items = [CreateSearchResultItem()],
         };
         _searchService
-            .GetSearchResultsAsync("job-1", "test-client-id", _client, Arg.Any<CancellationToken>())
+            .GetSearchResultsAsync("job-1", "test-org-id", _client, Arg.Any<CancellationToken>())
             .Returns(dto);
 
         var response = await _sut.SearchResultsTrigger(
@@ -93,7 +93,7 @@ public class SearchResultsFunctionTests
     public async Task ReturnsNotFound_WhenJobNotFound()
     {
         _searchService
-            .GetSearchResultsAsync("job-2", "test-client-id", _client, Arg.Any<CancellationToken>())
+            .GetSearchResultsAsync("job-2", "test-org-id", _client, Arg.Any<CancellationToken>())
             .Returns(new NotFound());
 
         var response = await _sut.SearchResultsTrigger(
@@ -111,7 +111,7 @@ public class SearchResultsFunctionTests
     public async Task ReturnsForbidden_WhenUserDoesNotHaveAccessTo_SearchResults()
     {
         _searchService
-            .GetSearchResultsAsync("job-3", "test-client-id", _client, Arg.Any<CancellationToken>())
+            .GetSearchResultsAsync("job-3", "test-org-id", _client, Arg.Any<CancellationToken>())
             .Returns(new Forbidden());
 
         var response = await _sut.SearchResultsTrigger(
@@ -129,7 +129,7 @@ public class SearchResultsFunctionTests
     public async Task ReturnsInternalServerError_OnError()
     {
         _searchService
-            .GetSearchResultsAsync("job-4", "test-client-id", _client, Arg.Any<CancellationToken>())
+            .GetSearchResultsAsync("job-4", "test-org-id", _client, Arg.Any<CancellationToken>())
             .Returns(new Error());
 
         var response = await _sut.SearchResultsTrigger(

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsFunctionTests.cs
@@ -45,7 +45,7 @@ public class SearchResultsFunctionTests
             {
                 {
                     Application.Constants.ApplicationConstants.Auth.AuthContextKey,
-                    new AuthContext(clientId, [])
+                    new AuthContext(clientId, clientId, [])
                 },
             }
         );

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsV2FunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsV2FunctionTests.cs
@@ -46,7 +46,7 @@ public class SearchResultsV2FunctionTests
             {
                 {
                     Application.Constants.ApplicationConstants.Auth.AuthContextKey,
-                    new AuthContext(clientId, [])
+                    new AuthContext(clientId, clientId, [])
                 },
             }
         );

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsV2FunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchResultsV2FunctionTests.cs
@@ -38,7 +38,7 @@ public class SearchResultsV2FunctionTests
         _sut = new SearchResultsV2Function(_logger, _jobSearchService);
     }
 
-    private static FunctionContext CreateContextWithAuth(string clientId = "test-client-id")
+    private static FunctionContext CreateContextWithAuth(string organisationId = "test-org-id")
     {
         var context = Substitute.For<FunctionContext>();
         context.Items.Returns(
@@ -46,7 +46,7 @@ public class SearchResultsV2FunctionTests
             {
                 {
                     Application.Constants.ApplicationConstants.Auth.AuthContextKey,
-                    new AuthContext(clientId, clientId, [])
+                    new AuthContext(Guid.NewGuid().ToString(), organisationId, [])
                 },
             }
         );

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchStatusFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchStatusFunctionTests.cs
@@ -28,7 +28,7 @@ public class SearchStatusFunctionTests
         _sut = new SearchStatusFunction(Logger, _searchService);
     }
 
-    private static FunctionContext CreateContextWithAuth(string clientId = "test-client-id")
+    private static FunctionContext CreateContextWithAuth(string organisationId = "test-org-id")
     {
         var context = Substitute.For<FunctionContext>();
         context.Items.Returns(
@@ -36,7 +36,7 @@ public class SearchStatusFunctionTests
             {
                 {
                     Application.Constants.ApplicationConstants.Auth.AuthContextKey,
-                    new AuthContext(clientId, clientId, [])
+                    new AuthContext(Guid.NewGuid().ToString(), organisationId, [])
                 },
             }
         );
@@ -73,7 +73,7 @@ public class SearchStatusFunctionTests
         var context = CreateContextWithAuth();
         var req = MockHttpRequestData.Create();
         _searchService
-            .GetSearchStatusAsync("job-2", "test-client-id", _client, Arg.Any<CancellationToken>())
+            .GetSearchStatusAsync("job-2", "test-org-id", _client, Arg.Any<CancellationToken>())
             .Returns(new Error());
 
         // Act
@@ -96,7 +96,7 @@ public class SearchStatusFunctionTests
         var context = CreateContextWithAuth();
         var req = MockHttpRequestData.Create();
         _searchService
-            .GetSearchStatusAsync("job-3", "test-client-id", _client, Arg.Any<CancellationToken>())
+            .GetSearchStatusAsync("job-3", "test-org-id", _client, Arg.Any<CancellationToken>())
             .Returns(new NotFound());
 
         // Act
@@ -119,7 +119,7 @@ public class SearchStatusFunctionTests
         var context = CreateContextWithAuth();
         var req = MockHttpRequestData.Create();
         _searchService
-            .GetSearchStatusAsync("job-4", "test-client-id", _client, Arg.Any<CancellationToken>())
+            .GetSearchStatusAsync("job-4", "test-org-id", _client, Arg.Any<CancellationToken>())
             .Returns(new Forbidden());
 
         // Act
@@ -150,7 +150,7 @@ public class SearchStatusFunctionTests
             LastUpdatedAt = DateTime.UtcNow,
         };
         _searchService
-            .GetSearchStatusAsync("job-5", "test-client-id", _client, Arg.Any<CancellationToken>())
+            .GetSearchStatusAsync("job-5", "test-org-id", _client, Arg.Any<CancellationToken>())
             .Returns(dto);
 
         // Act

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchStatusFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SearchStatusFunctionTests.cs
@@ -36,7 +36,7 @@ public class SearchStatusFunctionTests
             {
                 {
                     Application.Constants.ApplicationConstants.Auth.AuthContextKey,
-                    new AuthContext(clientId, [])
+                    new AuthContext(clientId, clientId, [])
                 },
             }
         );

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SubmitJobResultsFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SubmitJobResultsFunctionTests.cs
@@ -265,7 +265,7 @@ public class SubmitJobResultsFunctionTests
     private static FunctionContext CreateContextWithAuth(string clientId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, ["work-item.write"]);
+        var authContext = new AuthContext(clientId, clientId, ["work-item.write"]);
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SubmitJobResultsFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/SubmitJobResultsFunctionTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -24,11 +23,6 @@ public class SubmitJobResultsFunctionTests
     private readonly IJobResultsQueueClient _queueClient = Substitute.For<IJobResultsQueueClient>();
 
     private readonly SubmitJobResultsFunction _function;
-
-    private readonly JsonSerializerOptions _jsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
 
     public SubmitJobResultsFunctionTests()
     {
@@ -262,10 +256,14 @@ public class SubmitJobResultsFunctionTests
             JobTraceParent = jobTraceParent ?? "00-defaulttraceparent",
         };
 
-    private static FunctionContext CreateContextWithAuth(string clientId)
+    private static FunctionContext CreateContextWithAuth(string organisationId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, clientId, ["work-item.write"]);
+        var authContext = new AuthContext(
+            Guid.NewGuid().ToString(),
+            organisationId,
+            ["work-item.write"]
+        );
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
@@ -91,7 +91,7 @@ public class WorkAvailableFunctionTests
     private static FunctionContext CreateContextWithAuth(string clientId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, ["work-item.read"]);
+        var authContext = new AuthContext(clientId, clientId, ["work-item.read"]);
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/FunctionTests/WorkAvailableFunctionTests.cs
@@ -42,10 +42,10 @@ public class WorkAvailableFunctionTests
     {
         // Arrange
         var request = MockHttpRequestData.Create();
-        var context = CreateContextWithAuth("test-client");
+        var context = CreateContextWithAuth("test-org-id");
 
         _jobClaimService
-            .DoesCustodianHaveJobs("test-client", Arg.Any<CancellationToken>())
+            .DoesCustodianHaveJobs("test-org-id", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true));
 
         // Act
@@ -55,7 +55,7 @@ public class WorkAvailableFunctionTests
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         await _jobClaimService
             .Received(1)
-            .DoesCustodianHaveJobs("test-client", Arg.Any<CancellationToken>());
+            .DoesCustodianHaveJobs("test-org-id", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -63,10 +63,10 @@ public class WorkAvailableFunctionTests
     {
         // Arrange
         var request = MockHttpRequestData.Create();
-        var context = CreateContextWithAuth("test-client");
+        var context = CreateContextWithAuth("test-org-id");
 
         _jobClaimService
-            .DoesCustodianHaveJobs("test-client", Arg.Any<CancellationToken>())
+            .DoesCustodianHaveJobs("test-org-id", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(false));
 
         // Act
@@ -76,7 +76,7 @@ public class WorkAvailableFunctionTests
         Assert.Equal(HttpStatusCode.NoContent, result.StatusCode);
         await _jobClaimService
             .Received(1)
-            .DoesCustodianHaveJobs("test-client", Arg.Any<CancellationToken>());
+            .DoesCustodianHaveJobs("test-org-id", Arg.Any<CancellationToken>());
 
         var hasRetryHeader = result.Headers.TryGetValues(
             ApplicationConstants.Http.RetryAfterHeaderName,
@@ -88,10 +88,14 @@ public class WorkAvailableFunctionTests
         Assert.Equal(ApplicationConstants.Http.DefaultRetryAfterSeconds, retryValue);
     }
 
-    private static FunctionContext CreateContextWithAuth(string clientId)
+    private static FunctionContext CreateContextWithAuth(string organisationId)
     {
         var context = Substitute.For<FunctionContext>();
-        var authContext = new AuthContext(clientId, clientId, ["work-item.read"]);
+        var authContext = new AuthContext(
+            Guid.NewGuid().ToString(),
+            organisationId,
+            ["work-item.read"]
+        );
 
         var items = new Dictionary<object, object>
         {

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/AuthContextFactoryTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/AuthContextFactoryTests.cs
@@ -1,0 +1,114 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using SUI.Find.FindApi.Middleware;
+using SUI.Find.Infrastructure.Models;
+
+namespace SUI.Find.FindApi.UnitTests.MiddlewareTests;
+
+public class AuthContextFactoryTests
+{
+    private readonly AuthContextFactory _sut = new();
+
+    [Fact]
+    public void TestFromJwt_WhenClientIdAndSubEmpty_ShouldThrowException()
+    {
+        var claims = new List<Claim> { new("client_id", ""), new("sub", "") };
+
+        var jwt = new JwtSecurityToken(claims: claims);
+        var store = new AuthStore { DefaultTokenLifetimeMinutes = 60 };
+
+        Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, store));
+    }
+
+    [Fact]
+    public void TestFromJwt_WhenNoClientIdOrSub_ShouldThrowException()
+    {
+        var jwt = new JwtSecurityToken();
+        var store = new AuthStore { DefaultTokenLifetimeMinutes = 60 };
+
+        Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, store));
+    }
+
+    [Fact]
+    public void TestFromJwt_WhenNoClientIdInAuthStore_ShouldThrowException()
+    {
+        var claims = new List<Claim> { new("client_id", "EDUCATION-01") };
+
+        var jwt = new JwtSecurityToken(claims: claims);
+
+        var clients = new List<AuthClient>
+        {
+            new()
+            {
+                ClientId = "POLICE-01",
+                Enabled = true,
+                OrganisationId = "POL-ORG-01",
+                ClientSecret = "secret",
+                AllowedScopes = ["file.read", "file.write"],
+            },
+        };
+
+        var store = new AuthStore { Clients = clients, DefaultTokenLifetimeMinutes = 60 };
+
+        Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, store));
+    }
+
+    [Fact]
+    public void TestFromJwt_WhenNoOrganisationIdForClientId_ShouldThrowException()
+    {
+        var claims = new List<Claim> { new("client_id", "EDUCATION-01") };
+
+        var jwt = new JwtSecurityToken(claims: claims);
+
+        var clients = new List<AuthClient>
+        {
+            new()
+            {
+                ClientId = "EDUCATION-01",
+                Enabled = true,
+                OrganisationId = "",
+                ClientSecret = "secret",
+                AllowedScopes = ["file.read", "file.write"],
+            },
+        };
+
+        var store = new AuthStore { Clients = clients, DefaultTokenLifetimeMinutes = 60 };
+
+        Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, store));
+    }
+
+    [Fact]
+    public void TestFromJwt_WithValidInputs_ReturnsAuthContext()
+    {
+        const string clientId = "EDUCATION-01";
+        const string organisationId = "Edu-ORG-01";
+        List<string> scopesList = ["file.read", "file.write"];
+
+        var claims = new List<Claim>
+        {
+            new("client_id", clientId),
+            new("scope", "file.read file.write"),
+        };
+        var jwt = new JwtSecurityToken(claims: claims);
+
+        var clients = new List<AuthClient>
+        {
+            new()
+            {
+                ClientId = clientId,
+                Enabled = true,
+                OrganisationId = organisationId,
+                ClientSecret = "secret",
+                AllowedScopes = ["file.read", "file.write", "record.read"],
+            },
+        };
+
+        var store = new AuthStore { Clients = clients, DefaultTokenLifetimeMinutes = 60 };
+
+        var result = _sut.FromJwt(jwt, store);
+
+        Assert.Equal(clientId, result.ClientId);
+        Assert.Equal(organisationId, result.OrganisationId);
+        Assert.Equal(scopesList, result.Scopes);
+    }
+}

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -129,8 +129,10 @@ public class JwtAuthMiddlewareTests
 
         await sut.Invoke(_context, Next);
 
-        var invocationResult = _context.GetInvocationResult().Value as HttpResponseData;
-        Assert.NotNull(invocationResult);
+        var invocationResult = Assert.IsType<HttpResponseData>(
+            _context.GetInvocationResult().Value,
+            exactMatch: false
+        );
         Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
 
         await _authStoreService.Received(1).GetAuthStoreAsync();
@@ -194,8 +196,10 @@ public class JwtAuthMiddlewareTests
 
         await sut.Invoke(_context, Next);
 
-        var invocationResult = _context.GetInvocationResult().Value as HttpResponseData;
-        Assert.NotNull(invocationResult);
+        var invocationResult = Assert.IsType<HttpResponseData>(
+            _context.GetInvocationResult().Value,
+            exactMatch: false
+        );
         Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
 
         await _authStoreService.Received(1).GetAuthStoreAsync();

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -33,7 +33,7 @@ public class JwtAuthMiddlewareTests
     {
         var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
         var request = Substitute.For<HttpRequestData>(_context);
-        request.Url.Returns(new Uri("/api/" + endpoint));
+        request.Url.Returns(new Uri("https://mock.gov.uk/api/" + endpoint));
         _context.GetHttpRequestDataAsync().Returns(request);
 
         await sut.Invoke(_context, Next);
@@ -279,7 +279,7 @@ public class JwtAuthMiddlewareTests
     private void InitialiseRequest(HttpHeadersCollection headers)
     {
         var request = Substitute.For<HttpRequestData>(_context);
-        request.Url.Returns(new Uri("/api/v1/searches"));
+        request.Url.Returns(new Uri("https://mock.gov.uk/api/v1/searches"));
         request.Headers.Returns(headers);
         request.CreateResponse().Returns(new MockHttpResponseData(_context));
         _context.GetHttpRequestDataAsync().Returns(request);

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -22,7 +22,7 @@ public class JwtAuthMiddlewareTests
     private readonly IAuthStoreService _authStoreService = Substitute.For<IAuthStoreService>();
     private readonly IAuthContextFactory _authContextFactory =
         Substitute.For<IAuthContextFactory>();
-    private readonly ISecurityTokenValidator _handler = Substitute.For<JwtSecurityTokenHandler>();
+    private readonly JwtSecurityTokenHandler _handler = Substitute.For<JwtSecurityTokenHandler>();
 
     [Theory]
     [InlineData("swagger")]

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -31,13 +31,16 @@ public class JwtAuthMiddlewareTests
     [InlineData("health")]
     public async Task TestInvoke_WithNoAuthEndpoints_SkipsMethod(string endpoint)
     {
+        // Arrange
         var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
         var request = Substitute.For<HttpRequestData>(_context);
         request.Url.Returns(new Uri("/api/" + endpoint));
         _context.GetHttpRequestDataAsync().Returns(request);
 
+        // Act
         await sut.Invoke(_context, Next);
 
+        // Assert
         await _authStoreService.DidNotReceive().GetAuthStoreAsync();
         _handler
             .DidNotReceive()
@@ -50,11 +53,14 @@ public class JwtAuthMiddlewareTests
     [Fact]
     public async Task TestInvoke_WithNoAuthHeaders_ReturnsProblemResponse()
     {
+        // Arrange
         InitialiseRequest([]);
         var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
 
+        // Act
         await sut.Invoke(_context, Next);
 
+        // Assert
         var invocationResult = Assert.IsType<HttpResponseData>(
             _context.GetInvocationResult().Value,
             exactMatch: false
@@ -73,11 +79,14 @@ public class JwtAuthMiddlewareTests
     [Fact]
     public async Task TestInvoke_WithInvalidAuthHeaders_ReturnsProblemResponse()
     {
+        // Arrange
         InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Invalid" } });
         var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
 
+        // Act
         await sut.Invoke(_context, Next);
 
+        // Assert
         var invocationResult = Assert.IsType<HttpResponseData>(
             _context.GetInvocationResult().Value,
             exactMatch: false
@@ -96,6 +105,7 @@ public class JwtAuthMiddlewareTests
     [Fact]
     public async Task TestInvoke_HandlesErrorsFromTokenHandler()
     {
+        // Arrange
         InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
 
         var clients = new List<AuthClient>
@@ -131,8 +141,10 @@ public class JwtAuthMiddlewareTests
 
         var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
 
+        // Act
         await sut.Invoke(_context, Next);
 
+        // Assert
         var invocationResult = Assert.IsType<HttpResponseData>(
             _context.GetInvocationResult().Value,
             exactMatch: false
@@ -151,6 +163,7 @@ public class JwtAuthMiddlewareTests
     [Fact]
     public async Task TestInvoke_WhenScopesIncorrect_ReturnsProblemResponse()
     {
+        // Arrange
         InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
 
         var clients = new List<AuthClient>
@@ -198,8 +211,10 @@ public class JwtAuthMiddlewareTests
             "SUI.Find.FindApi.Functions.HttpFunctions.FetchRecordFunction.FetchRecord"
         );
 
+        // Act
         await sut.Invoke(_context, Next);
 
+        // Assert
         var invocationResult = Assert.IsType<HttpResponseData>(
             _context.GetInvocationResult().Value,
             exactMatch: false
@@ -216,6 +231,7 @@ public class JwtAuthMiddlewareTests
     [Fact]
     public async Task TestInvoke_WithValidInputs_ReturnsAuthContext()
     {
+        // Arrange
         InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
 
         var clients = new List<AuthClient>
@@ -265,8 +281,10 @@ public class JwtAuthMiddlewareTests
             "SUI.Find.FindApi.Functions.HttpFunctions.FetchRecordFunction.FetchRecord"
         );
 
+        // Act
         await sut.Invoke(_context, Next);
 
+        // Assert
         await _authStoreService.Received(1).GetAuthStoreAsync();
         _handler
             .Received(1)

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -1,0 +1,287 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using SUI.Find.Application.Constants;
+using SUI.Find.FindApi.Middleware;
+using SUI.Find.FindApi.Models;
+using SUI.Find.FindApi.UnitTests.Mocks;
+using SUI.Find.Infrastructure.Models;
+using SUI.Find.Infrastructure.Services;
+
+namespace SUI.Find.FindApi.UnitTests.MiddlewareTests;
+
+public class JwtAuthMiddlewareTests
+{
+    private readonly FunctionContext _context = Substitute.For<FunctionContext>();
+    private readonly IAuthStoreService _authStoreService = Substitute.For<IAuthStoreService>();
+    private readonly IAuthContextFactory _authContextFactory =
+        Substitute.For<IAuthContextFactory>();
+    private readonly ISecurityTokenValidator _handler = Substitute.For<JwtSecurityTokenHandler>();
+
+    [Theory]
+    [InlineData("swagger")]
+    [InlineData("openapi")]
+    [InlineData("v1/auth/token")]
+    [InlineData("health")]
+    public async Task TestInvoke_WithNoAuthEndpoints_SkipsMethod(string endpoint)
+    {
+        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+        var request = Substitute.For<HttpRequestData>(_context);
+        request.Url.Returns(new Uri("/api/" + endpoint));
+        _context.GetHttpRequestDataAsync().Returns(request);
+
+        await sut.Invoke(_context, Next);
+
+        await _authStoreService.DidNotReceive().GetAuthStoreAsync();
+        _handler
+            .DidNotReceive()
+            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
+        _authContextFactory
+            .DidNotReceive()
+            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+    }
+
+    [Fact]
+    public async Task TestInvoke_WithNoAuthHeaders_ReturnsProblemResponse()
+    {
+        InitialiseRequest([]);
+        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+
+        await sut.Invoke(_context, Next);
+
+        var invocationResult = _context.GetInvocationResult().Value as HttpResponseData;
+        Assert.NotNull(invocationResult);
+        Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
+
+        await _authStoreService.DidNotReceive().GetAuthStoreAsync();
+        _handler
+            .DidNotReceive()
+            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
+        _authContextFactory
+            .DidNotReceive()
+            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+    }
+
+    [Fact]
+    public async Task TestInvoke_WithInvalidAuthHeaders_ReturnsProblemResponse()
+    {
+        InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Invalid" } });
+        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+
+        await sut.Invoke(_context, Next);
+
+        var invocationResult = _context.GetInvocationResult().Value as HttpResponseData;
+        Assert.NotNull(invocationResult);
+        Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
+
+        await _authStoreService.DidNotReceive().GetAuthStoreAsync();
+        _handler
+            .DidNotReceive()
+            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
+        _authContextFactory
+            .DidNotReceive()
+            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+    }
+
+    [Fact]
+    public async Task TestInvoke_HandlesErrorsFromTokenHandler()
+    {
+        InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
+
+        var clients = new List<AuthClient>
+        {
+            new()
+            {
+                ClientId = "clientId",
+                ClientSecret = "clientSecret",
+                AllowedScopes = ["file.read", "file.write"],
+                Enabled = true,
+                OrganisationId = "organisationId",
+            },
+        };
+
+        var store = new AuthStore
+        {
+            Audience = "Audience",
+            Issuer = "Issuer",
+            Clients = clients,
+            DefaultTokenLifetimeMinutes = 60,
+            SigningKey = "SigningKey",
+        };
+
+        _authStoreService.GetAuthStoreAsync().Returns(store);
+
+        _handler
+            .ValidateToken(
+                Arg.Any<string>(),
+                Arg.Any<TokenValidationParameters>(),
+                out Arg.Any<SecurityToken>()
+            )
+            .Throws<SecurityTokenException>();
+
+        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+
+        await sut.Invoke(_context, Next);
+
+        var invocationResult = _context.GetInvocationResult().Value as HttpResponseData;
+        Assert.NotNull(invocationResult);
+        Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
+
+        await _authStoreService.Received(1).GetAuthStoreAsync();
+        _handler
+            .Received(1)
+            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
+        _authContextFactory
+            .DidNotReceive()
+            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+    }
+
+    [Fact]
+    public async Task TestInvoke_WhenScopesIncorrect_ReturnsProblemResponse()
+    {
+        InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
+
+        var clients = new List<AuthClient>
+        {
+            new()
+            {
+                ClientId = "clientId",
+                ClientSecret = "clientSecret",
+                AllowedScopes = ["file.read"],
+                Enabled = true,
+                OrganisationId = "organisationId",
+            },
+        };
+
+        var store = new AuthStore
+        {
+            Audience = "Audience",
+            Issuer = "Issuer",
+            Clients = clients,
+            DefaultTokenLifetimeMinutes = 60,
+            SigningKey = "SigningKey",
+        };
+
+        _authStoreService.GetAuthStoreAsync().Returns(store);
+
+        _handler
+            .ValidateToken(
+                Arg.Any<string>(),
+                Arg.Any<TokenValidationParameters>(),
+                out Arg.Any<SecurityToken>()
+            )
+            .Returns(x =>
+            {
+                x[2] = new JwtSecurityToken();
+                return new ClaimsPrincipal();
+            });
+
+        _authContextFactory
+            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
+            .Returns(new AuthContext("clientId", "organisationId", ["file.write"]));
+
+        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+
+        _context.FunctionDefinition.EntryPoint.Returns(
+            "SUI.Find.FindApi.Functions.HttpFunctions.FetchRecordFunction.FetchRecord"
+        );
+
+        await sut.Invoke(_context, Next);
+
+        var invocationResult = _context.GetInvocationResult().Value as HttpResponseData;
+        Assert.NotNull(invocationResult);
+        Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
+
+        await _authStoreService.Received(1).GetAuthStoreAsync();
+        _handler
+            .Received(1)
+            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
+        _authContextFactory.Received(1).FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+    }
+
+    [Fact]
+    public async Task TestInvoke_WithValidInputs_ReturnsAuthContext()
+    {
+        InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
+
+        var clients = new List<AuthClient>
+        {
+            new()
+            {
+                ClientId = "clientId",
+                ClientSecret = "clientSecret",
+                AllowedScopes = ["fetch-record.read"],
+                Enabled = true,
+                OrganisationId = "organisationId",
+            },
+        };
+
+        var store = new AuthStore
+        {
+            Audience = "Audience",
+            Issuer = "Issuer",
+            Clients = clients,
+            DefaultTokenLifetimeMinutes = 60,
+            SigningKey = "SigningKey",
+        };
+
+        _authStoreService.GetAuthStoreAsync().Returns(store);
+
+        _handler
+            .ValidateToken(
+                Arg.Any<string>(),
+                Arg.Any<TokenValidationParameters>(),
+                out Arg.Any<SecurityToken>()
+            )
+            .Returns(x =>
+            {
+                x[2] = new JwtSecurityToken();
+                return new ClaimsPrincipal();
+            });
+
+        var authContext = new AuthContext("clientId", "organisationId", ["fetch-record.read"]);
+
+        _authContextFactory
+            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
+            .Returns(authContext);
+
+        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+
+        _context.FunctionDefinition.EntryPoint.Returns(
+            "SUI.Find.FindApi.Functions.HttpFunctions.FetchRecordFunction.FetchRecord"
+        );
+
+        await sut.Invoke(_context, Next);
+
+        await _authStoreService.Received(1).GetAuthStoreAsync();
+        _handler
+            .Received(1)
+            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
+        _authContextFactory.Received(1).FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+
+        Assert.Equal(authContext, _context.Items[ApplicationConstants.Auth.AuthContextKey]);
+    }
+
+    private void InitialiseRequest(HttpHeadersCollection headers)
+    {
+        var request = Substitute.For<HttpRequestData>(_context);
+        request.Url.Returns(new Uri("/api/v1/searches"));
+        request.Headers.Returns(headers);
+        request.CreateResponse().Returns(new MockHttpResponseData(_context));
+        _context.GetHttpRequestDataAsync().Returns(request);
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddFunctionsWorkerDefaults();
+        _context.InstanceServices.Returns(serviceCollection.BuildServiceProvider());
+    }
+
+    private static Task Next(FunctionContext context)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -55,8 +55,10 @@ public class JwtAuthMiddlewareTests
 
         await sut.Invoke(_context, Next);
 
-        var invocationResult = _context.GetInvocationResult().Value as HttpResponseData;
-        Assert.NotNull(invocationResult);
+        var invocationResult = Assert.IsType<HttpResponseData>(
+            _context.GetInvocationResult().Value,
+            exactMatch: false
+        );
         Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
 
         await _authStoreService.DidNotReceive().GetAuthStoreAsync();
@@ -76,8 +78,10 @@ public class JwtAuthMiddlewareTests
 
         await sut.Invoke(_context, Next);
 
-        var invocationResult = _context.GetInvocationResult().Value as HttpResponseData;
-        Assert.NotNull(invocationResult);
+        var invocationResult = Assert.IsType<HttpResponseData>(
+            _context.GetInvocationResult().Value,
+            exactMatch: false
+        );
         Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
 
         await _authStoreService.DidNotReceive().GetAuthStoreAsync();


### PR DESCRIPTION
## Summary

We want to eventually move to using the organisationId instead of the clientId in the auth mechanism in Find, because this is the ID we will have control over.

This PR takes a step in that direction. We have added OrganisationId to the AuditContext object, and replaced each usage of ClientId to use OrganisationId instead.

We have also added unit tests to the JwtAuthMiddleware class so that the more complex functionality can be covered.

## Changes

- Add OrganisationId to AuthContext
- Replace all usages of AuthContext.ClientId to AuthContext.OrganisationId
- Add unit tests to JwtAuthMiddleware, and refactor to allow testability

## Validation

- Unit / integration / E2E tests run and passing
- New unit tests added