### PR TITLE
feat(find): SUI-1800 - Include ClientId when auditing access to HTTP endpoints

### DIFF
--- a/Apps/Find/src/SUI.Find.AuditProcessor/Functions/QueueAuditAccessTrigger.cs
+++ b/Apps/Find/src/SUI.Find.AuditProcessor/Functions/QueueAuditAccessTrigger.cs
@@ -19,7 +19,7 @@ public class QueueAuditAccessTrigger(
     )
     {
         logger.LogInformation(
-            "C# Queue trigger function processed: {EventType} for ClientId: {ClientId} at {Timestamp}",
+            "C# Queue trigger function processed: {EventType} for Organisation: {OrgId} at {Timestamp}",
             auditMessage.EventName,
             auditMessage.Actor.ActorId,
             auditMessage.Timestamp

--- a/Apps/Find/src/SUI.Find.Domain/Events/Audit/AuditAccessMessage.cs
+++ b/Apps/Find/src/SUI.Find.Domain/Events/Audit/AuditAccessMessage.cs
@@ -4,5 +4,6 @@ public record AuditAccessMessage
 {
     public required string Method { get; init; }
     public required string Path { get; init; }
+    public required string ClientId { get; init; }
     public string Suid { get; init; } = string.Empty;
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/AuditMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/AuditMiddleware.cs
@@ -63,6 +63,7 @@ public class AuditMiddleware(ILogger<AuditMiddleware> logger, IAuditQueueClient 
             {
                 Path = httpReq.Url.AbsolutePath,
                 Method = httpReq.Method,
+                ClientId = authContext.ClientId,
             };
 
             var isSearchRequest =

--- a/Apps/Find/tests/SUI.Find.AuditProcessor.UnitTests/AuditAccessFunctionTests.cs
+++ b/Apps/Find/tests/SUI.Find.AuditProcessor.UnitTests/AuditAccessFunctionTests.cs
@@ -10,7 +10,7 @@ namespace SUI.Find.AuditProcessor.UnitTests;
 public class AuditAccessFunctionTests
 {
     [Fact]
-    public async Task ShouldCalAuditService_WhenValidModel()
+    public async Task ShouldCallAuditService_WhenValidModel()
     {
         // Arrange
         var loggerMock = Substitute.For<ILogger<QueueAuditAccessTrigger>>();
@@ -19,6 +19,7 @@ public class AuditAccessFunctionTests
             Method = "GET",
             Path = "/test/path",
             Suid = "suid-67890",
+            ClientId = "client_id",
         };
         var auditServiceMock = Substitute.For<IAuditService>();
         var auditEvent = new AuditEvent


### PR DESCRIPTION
## Summary

As part of the work to separate Client IDs from Organisation IDs, Client IDs were replaced by Organisation IDs in the auditing process. 

This PR is to include the Client IDs specifically when auditing access to HTTP endpoints, so that we can still build a clear picture of HTTP access events.

## Changes

- Add Client ID to AuditAccessMessage.cs
- Fill this value with the Client ID from the audit context in AuditMiddleware.cs
- Update tests
- Fix another missing ClientId/OrgId swap

## Validation

- Unit / integration / E2E tests run and passing
