### PR TITLE
infra: SUI-1805 - Terraform environment provisioning improvements

### DIFF
--- a/terraform/auth-emulator/main.tf
+++ b/terraform/auth-emulator/main.tf
@@ -55,3 +55,8 @@ module "web_app" {
   )
   tags           = var.tags
 }
+
+moved {
+  from = module.web_app
+  to   = module.web_app[0]
+}

--- a/terraform/auth-emulator/main.tf
+++ b/terraform/auth-emulator/main.tf
@@ -28,6 +28,7 @@ data "terraform_remote_state" "core" {
 }
 
 module "web_app" {
+  count   = var.use_auth_emulator ? 1 : 0
   source = "../modules/linux_web_app"
 
   name                = local.web_app_name

--- a/terraform/auth-emulator/outputs.tf
+++ b/terraform/auth-emulator/outputs.tf
@@ -2,19 +2,18 @@ output "service_state_key" {
   value       = local.service_state_key
   description = "state key for the AuthEmulator Service"
 }
+
 output "web_app_name" {
-  value       = module.web_app.name
+  value       = one(module.web_app[*].name)
   description = "Name of the AuthEmulator web app."
 }
 
 output "web_app_id" {
-  value       = module.web_app.id
+  value       = one(module.web_app[*].id)
   description = "ID of the AuthEmulator web app."
 }
 
 output "web_app_default_hostname" {
-  value       = module.web_app.default_hostname
+  value       = one(module.web_app[*].default_hostname)
   description = "Default hostname of the AuthEmulator web app."
 }
-
-

--- a/terraform/auth-emulator/variables.tf
+++ b/terraform/auth-emulator/variables.tf
@@ -73,3 +73,9 @@ variable "app_service_plan_worker_count" {
   type        = number
   default     = null
 }
+
+variable "use_auth_emulator" {
+  description = "Set to true to deploy the Auth Emulator web app infrastructure."
+  type        = bool
+  default     = false
+}

--- a/terraform/custodians/main.tf
+++ b/terraform/custodians/main.tf
@@ -28,6 +28,7 @@ data "terraform_remote_state" "core" {
 }
 
 module "web_app" {
+  count   = var.use_stub_custodians ? 1 : 0
   source = "../modules/linux_web_app"
 
   name                = local.web_app_name

--- a/terraform/custodians/main.tf
+++ b/terraform/custodians/main.tf
@@ -46,6 +46,9 @@ module "web_app" {
     {
       APPLICATIONINSIGHTS_CONNECTION_STRING = data.terraform_remote_state.core.outputs.app_insights_connection_string
       OTEL_RESOURCE_ATTRIBUTES = local.otel_resource_attributes
+
+      FindApi__BaseUrl = format("https://%s%sfunc-%s-find01.azurewebsites.net", var.subscription_prefix, var.environment_id, var.region_short)
+      StubCustodians__BaseUrl = format("https://%s%sapp-%s-custodians01.azurewebsites.net", var.subscription_prefix, var.environment_id, var.region_short)
     },
     var.custodian_app_settings,
   )

--- a/terraform/custodians/main.tf
+++ b/terraform/custodians/main.tf
@@ -55,3 +55,8 @@ module "web_app" {
   )
   tags           = var.tags
 }
+
+moved {
+  from = module.web_app
+  to   = module.web_app[0]
+}

--- a/terraform/custodians/outputs.tf
+++ b/terraform/custodians/outputs.tf
@@ -2,19 +2,18 @@ output "service_state_key" {
   value       = local.service_state_key
   description = "state key for the Custodians Service"
 }
+
 output "web_app_name" {
-  value       = module.web_app.name
+  value       = one(module.web_app[*].name)
   description = "Name of the Custodians web app."
 }
 
 output "web_app_id" {
-  value       = module.web_app.id
+  value       = one(module.web_app[*].id)
   description = "ID of the Custodians web app."
 }
 
 output "web_app_default_hostname" {
-  value       = module.web_app.default_hostname
+  value       = one(module.web_app[*].default_hostname)
   description = "Default hostname of the Custodians web app."
 }
-
-

--- a/terraform/custodians/variables.tf
+++ b/terraform/custodians/variables.tf
@@ -73,3 +73,9 @@ variable "app_service_plan_worker_count" {
   type        = number
   default     = null
 }
+
+variable "use_stub_custodians" {
+  description = "Set to true to deploy the Stub Custodians web app infrastructure."
+  type        = bool
+  default     = false
+}

--- a/terraform/environments/d01.tfvars
+++ b/terraform/environments/d01.tfvars
@@ -25,8 +25,6 @@ find_app_settings = {
 }
 
 custodian_app_settings = {
-  FindApi__BaseUrl = "https://s270d01func-ukw-find01.azurewebsites.net"
-  StubCustodians__BaseUrl = "https://s270d01app-ukw-custodians01.azurewebsites.net"
 }
 
 tags = {

--- a/terraform/environments/d01.tfvars
+++ b/terraform/environments/d01.tfvars
@@ -12,6 +12,7 @@ app_service_plan_worker_count = 1
 function_dotnet_version       = "10.0"
 webapp_dotnet_version         = "10.0"
 use_stub_custodians           = true
+use_auth_emulator             = true
 use_auxiliary_asp                       = true
 auxiliary_app_service_plan_sku          = "B1"
 auxiliary_app_service_plan_os_type      = "Linux"

--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -25,8 +25,6 @@ find_app_settings = {
 }
 
 custodian_app_settings = {
-  FindApi__BaseUrl = "https://s270d02func-ukw-find01.azurewebsites.net"
-  StubCustodians__BaseUrl = "https://s270d02app-ukw-custodians01.azurewebsites.net"
   RandomDelayMinSeconds = 1,
   RandomDelayMaxSeconds = 5,
   CustodianWorkerRandomIntervalMinSeconds = 3,

--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -25,9 +25,9 @@ find_app_settings = {
 }
 
 custodian_app_settings = {
-  RandomDelayMinSeconds = 1,
-  RandomDelayMaxSeconds = 5,
-  CustodianWorkerRandomIntervalMinSeconds = 3,
+  RandomDelayMinSeconds = 1
+  RandomDelayMaxSeconds = 5
+  CustodianWorkerRandomIntervalMinSeconds = 3
   CustodianWorkerRandomIntervalMaxSeconds = 8
 }
 

--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -12,6 +12,7 @@ app_service_plan_worker_count = 1
 function_dotnet_version       = "10.0"
 webapp_dotnet_version         = "10.0"
 use_stub_custodians           = true
+use_auth_emulator             = true
 use_auxiliary_asp                       = true
 auxiliary_app_service_plan_sku          = "B1"
 auxiliary_app_service_plan_os_type      = "Linux"

--- a/terraform/find/main.tf
+++ b/terraform/find/main.tf
@@ -178,18 +178,6 @@ resource "azurerm_key_vault_secret" "nhs_digital_client_id" {
   ]
 }
 
-data "terraform_remote_state" "stub_custodians" {
-  count   = var.use_stub_custodians ? 1 : 0
-  backend = "azurerm"
-
-  config = {
-    resource_group_name  = local.state_rg
-    storage_account_name = local.state_storage
-    container_name       = local.state_container
-    key                  = local.custodians_service_state_key
-  }
-}
-
 module "function_app" {
   source = "../modules/linux_function_app"
 
@@ -219,9 +207,10 @@ module "function_app" {
 
       StorageRetentionDays = "1"
 
-      StubCustodiansBaseUrl = try(
-        "https://${data.terraform_remote_state.stub_custodians[0].outputs.web_app_default_hostname}",
-        null
+      StubCustodiansBaseUrl = (
+        var.use_stub_custodians
+          ? format("https://%s%sapp-%s-custodians01.azurewebsites.net", var.subscription_prefix, var.environment_id, var.region_short)
+          : null
       )
 
       MatchFunction__XApiKey                 = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.find_match_api_key.name}/)"


### PR DESCRIPTION
## Summary

This PR contains Terraform environment provisioning improvements, as we move towards support for Alpha and Prod-like environments.

## Changes

- Updated the Base URL variables in the Terraform to be dynamically built, to reduce repetition, to reduce the chance of misconfiguration, to keep the approach consistent throughout the Terraform, and to make provisioning new environments more straight forward.
- Expanded the existing `use_stub_custodians` boolean in the Terraform to toggle whether the Stub Custodians infrastructure gets deployed.
- Add a new `use_auth_emulator` boolean in the Terraform to toggle whether the Auth Emulator infrastructure gets deployed.

Also includes:
- code tidy: update to standard Terraform style by omitting commas on multi-line maps

## Validation

- IDE linting.
- Terraform plans ran to see that the Terraform is valid, and that there are no actual changes.

