### PR TITLE
feat(find): sui-1778 - Add OIDC Discovery and RSA signature verification in Find

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,6 +14,7 @@ paths = [
   '''^Apps/Find/tests/SUI\.Find\.E2ETests/StartANewSearchTests\.cs$''',
   '''^Apps/Find/tests/SUI\.Find\.E2ETests/TestOutboundAuthService\.cs$''',
   '''^Apps/Find/tests/SUI\.Find\.FindApi\.UnitTests/FunctionTests/AuthTokenFunctionTests\.cs$''',
+  '''^Apps/Find/tests/SUI\.Find\.FindApi\.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests\.cs$''',
   '''^Apps/Find/tests/SUI\.Find\.Infrastructure\.UnitTests/Data/auth-clients-inbound\.json$''',
   '''^Apps/Find/tests/SUI\.Find\.Infrastructure\.UnitTests/Data/org-directory\.json$''',
   '''^Apps/Find/tests/SUI\.Find\.Infrastructure\.UnitTests/Services/MockAuthStoreServiceTests\.cs$''',

--- a/Apps/Find/Directory.Packages.props
+++ b/Apps/Find/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/Apps/Find/src/SUI.Find.FindApi/Configurations/AuthSettings.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Configurations/AuthSettings.cs
@@ -1,0 +1,13 @@
+namespace SUI.Find.FindApi.Configurations;
+
+public class AuthSettings
+{
+    public const string SectionName = "AuthSettings";
+
+    // OIDC Discovery configuration properties
+    public string Issuer { get; set; } =
+        "https://sandbox.api.example.gov.uk/sui-find-a-record/auth";
+    public string Audience { get; set; } = "sui-find-a-record-api";
+    public string OidcDiscoveryUrl { get; set; } =
+        "https://sandbox.api.example.gov.uk/sui-find-a-record/auth/.well-known/openid-configuration";
+}

--- a/Apps/Find/src/SUI.Find.FindApi/Configurations/AuthSettings.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Configurations/AuthSettings.cs
@@ -9,5 +9,5 @@ public class AuthSettings
         "https://sandbox.api.example.gov.uk/sui-find-a-record/auth";
     public string Audience { get; set; } = "sui-find-a-record-api";
     public string OidcDiscoveryUrl { get; set; } =
-        "https://sandbox.api.example.gov.uk/sui-find-a-record/auth/.well-known/openid-configuration";
+        "https://localhost:7250/api/v1/.well-known/openid-configuration";
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -21,7 +22,8 @@ public class JwtAuthMiddleware(
     IAuthStoreService authStoreService,
     IAuthContextFactory authContextFactory,
     IConfigurationManager<OpenIdConnectConfiguration> oidcConfigManager,
-    IOptions<AuthSettings> authSettings
+    IOptions<AuthSettings> authSettings,
+    ILogger<JwtAuthMiddleware> logger
 ) : IFunctionsWorkerMiddleware
 {
     // One concrete handler with no interfaces, no injection mocks.
@@ -125,16 +127,18 @@ public class JwtAuthMiddleware(
         }
         catch (SecurityTokenException ex)
         {
+            logger.LogWarning(ex, "Token validation failed");
             context.GetInvocationResult().Value = await HttpResponseUtility.ProblemResponse(
                 req,
                 HttpStatusCode.Unauthorized,
                 nameof(HttpStatusCode.Unauthorized),
-                ex.Message
+                "Token validation failed."
             );
             return;
         }
-        catch
+        catch (Exception ex)
         {
+            logger.LogWarning(ex, "Invalid bearer token");
             context.GetInvocationResult().Value = await HttpResponseUtility.ProblemResponse(
                 req,
                 HttpStatusCode.Unauthorized,

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
@@ -4,22 +4,29 @@ using System.Reflection;
 using System.Text;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using SUI.Find.Application.Constants;
 using SUI.Find.FindApi.Attributes;
+using SUI.Find.FindApi.Configurations;
 using SUI.Find.FindApi.Models;
 using SUI.Find.FindApi.Utility;
 using SUI.Find.Infrastructure.Services;
 
 namespace SUI.Find.FindApi.Middleware;
 
-// ReSharper disable once ClassNeverInstantiated.Global
 public class JwtAuthMiddleware(
     IAuthStoreService authStoreService,
     IAuthContextFactory authContextFactory,
-    ISecurityTokenValidator handler
+    IConfigurationManager<OpenIdConnectConfiguration> oidcConfigManager,
+    IOptions<AuthSettings> authSettings
 ) : IFunctionsWorkerMiddleware
 {
+    // One concrete handler with no interfaces, no injection mocks.
+    private static readonly JwtSecurityTokenHandler TokenHandler = new();
+
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
         var req = await context.GetHttpRequestDataAsync();
@@ -68,25 +75,53 @@ public class JwtAuthMiddleware(
         var token = bearer["Bearer ".Length..].Trim();
 
         var store = await authStoreService.GetAuthStoreAsync();
-
-        var validationParameters = new TokenValidationParameters
-        {
-            ValidateIssuer = true,
-            ValidIssuer = store.Issuer,
-            ValidateAudience = true,
-            ValidAudience = store.Audience,
-            ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(store.SigningKey)),
-            ValidateLifetime = true,
-            ClockSkew = TimeSpan.FromMinutes(2),
-        };
-
         JwtSecurityToken jwt;
 
         try
         {
-            handler.ValidateToken(token, validationParameters, out var validated);
-            jwt = (JwtSecurityToken)validated;
+            var unverifiedToken = TokenHandler.ReadJwtToken(token);
+            var algorithm = unverifiedToken.Header.Alg;
+            SecurityToken validatedToken;
+
+            if (algorithm == SecurityAlgorithms.RsaSha256)
+            {
+                validatedToken = await ValidateAsymmetricTokenAsync(
+                    token,
+                    unverifiedToken,
+                    context.CancellationToken
+                );
+            }
+            else if (algorithm == SecurityAlgorithms.HmacSha256)
+            {
+                var validationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidIssuer = store.Issuer,
+                    ValidateAudience = true,
+                    ValidAudience = store.Audience,
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = new SymmetricSecurityKey(
+                        Encoding.UTF8.GetBytes(store.SigningKey)
+                    ),
+                    ValidateLifetime = true,
+                    ClockSkew = TimeSpan.FromMinutes(2),
+                };
+
+                // Uses the concrete .NET framework validation engine directly
+                TokenHandler.ValidateToken(token, validationParameters, out validatedToken);
+            }
+            else
+            {
+                context.GetInvocationResult().Value = await HttpResponseUtility.ProblemResponse(
+                    req,
+                    HttpStatusCode.Unauthorized,
+                    nameof(HttpStatusCode.Unauthorized),
+                    $"Unsupported signing algorithm '{algorithm}'."
+                );
+                return;
+            }
+
+            jwt = (JwtSecurityToken)validatedToken;
         }
         catch (SecurityTokenException ex)
         {
@@ -129,10 +164,57 @@ public class JwtAuthMiddleware(
         await next(context);
     }
 
+    private async Task<SecurityToken> ValidateAsymmetricTokenAsync(
+        string token,
+        JwtSecurityToken unverifiedToken,
+        CancellationToken cancellationToken,
+        bool allowRetry = true
+    )
+    {
+        var oidcConfig = await oidcConfigManager.GetConfigurationAsync(cancellationToken);
+        var configValues = authSettings.Value;
+
+        var validationParameters = new TokenValidationParameters
+        {
+            RequireSignedTokens = true,
+            ValidateIssuer = true,
+            ValidIssuer = configValues.Issuer,
+            ValidateAudience = true,
+            ValidAudience = configValues.Audience,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = oidcConfig.SigningKeys,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.FromMinutes(2),
+        };
+
+        try
+        {
+            TokenHandler.ValidateToken(token, validationParameters, out var validatedToken);
+            return validatedToken;
+        }
+        catch (SecurityTokenSignatureKeyNotFoundException)
+        {
+            if (
+                allowRetry
+                && unverifiedToken.Issuer == configValues.Issuer
+                && unverifiedToken.Audiences.Contains(configValues.Audience)
+            )
+            {
+                oidcConfigManager.RequestRefresh();
+                return await ValidateAsymmetricTokenAsync(
+                    token,
+                    unverifiedToken,
+                    cancellationToken,
+                    allowRetry: false
+                );
+            }
+            throw;
+        }
+    }
+
     private static string[] GetRequiredScopes(FunctionContext context)
     {
         var entryPoint = context.FunctionDefinition.EntryPoint;
-
         if (string.IsNullOrWhiteSpace(entryPoint))
         {
             return [];
@@ -169,10 +251,5 @@ public class JwtAuthMiddleware(
     private static bool HasAnyRequiredScope(
         AuthContext caller,
         IReadOnlyList<string> requiredScopes
-    )
-    {
-        return requiredScopes.Any(rs =>
-            caller.Scopes.Contains(rs, StringComparer.OrdinalIgnoreCase)
-        );
-    }
+    ) => requiredScopes.Any(rs => caller.Scopes.Contains(rs, StringComparer.OrdinalIgnoreCase));
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
@@ -106,7 +106,6 @@ public class JwtAuthMiddleware(
                         Encoding.UTF8.GetBytes(store.SigningKey)
                     ),
                     ValidateLifetime = true,
-                    ClockSkew = TimeSpan.FromMinutes(2),
                 };
 
                 // Uses the concrete .NET framework validation engine directly
@@ -188,7 +187,6 @@ public class JwtAuthMiddleware(
             ValidateIssuerSigningKey = true,
             IssuerSigningKeys = oidcConfig.SigningKeys,
             ValidateLifetime = true,
-            ClockSkew = TimeSpan.FromMinutes(2),
         };
 
         try
@@ -255,5 +253,10 @@ public class JwtAuthMiddleware(
     private static bool HasAnyRequiredScope(
         AuthContext caller,
         IReadOnlyList<string> requiredScopes
-    ) => requiredScopes.Any(rs => caller.Scopes.Contains(rs, StringComparer.OrdinalIgnoreCase));
+    )
+    {
+        return requiredScopes.Any(rs =>
+            caller.Scopes.Contains(rs, StringComparer.OrdinalIgnoreCase)
+        );
+    }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Program.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Program.cs
@@ -1,4 +1,3 @@
-using System.IdentityModel.Tokens.Jwt;
 using System.IO.Abstractions;
 using System.Net;
 using Azure.Data.Tables;
@@ -8,7 +7,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Polly;
 using Polly.Extensions.Http;
 using SUI.Find.Application.Constants;
@@ -36,6 +37,11 @@ builder.Services.Configure<AuthTokenServiceConfig>(
     builder.Configuration.GetSection(AuthTokenServiceConfig.SectionName)
 );
 
+// Bind AuthSettings to configuration
+builder.Services.Configure<AuthSettings>(
+    builder.Configuration.GetSection(AuthSettings.SectionName)
+);
+
 builder
     .Services.AddOptions<MatchFunctionConfiguration>()
     .BindConfiguration(MatchFunctionConfiguration.SectionName)
@@ -43,6 +49,17 @@ builder
 
 // .NET services
 builder.Services.AddSingleton(TimeProvider.System);
+
+// Register ConfigurationManager as a Singleton to cache public keys across function invocations
+builder.Services.AddSingleton<IConfigurationManager<OpenIdConnectConfiguration>>(sp =>
+{
+    var settings = sp.GetRequiredService<IOptions<AuthSettings>>().Value;
+    return new ConfigurationManager<OpenIdConnectConfiguration>(
+        settings.OidcDiscoveryUrl,
+        new OpenIdConnectConfigurationRetriever(),
+        new HttpDocumentRetriever { RequireHttps = true }
+    );
+});
 
 // Third-party and framework services
 builder.Services.AddHealthChecks();
@@ -54,7 +71,6 @@ builder.Services.AddInfrastructureServices();
 
 // Middleware services
 builder.Services.AddSingleton<IAuthContextFactory, AuthContextFactory>();
-builder.Services.AddSingleton<ISecurityTokenValidator, JwtSecurityTokenHandler>();
 
 // Application services
 builder.Services.AddSingleton<IMaskUrlService, MaskUrlService>();

--- a/Apps/Find/src/SUI.Find.FindApi/Program.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Program.cs
@@ -50,7 +50,7 @@ builder
 // .NET services
 builder.Services.AddSingleton(TimeProvider.System);
 
-// Register ConfigurationManager as a Singleton to cache public keys across function invocations
+// Register OpenID Connect ConfigurationManager as a Singleton to cache public keys across function invocations
 builder.Services.AddSingleton<IConfigurationManager<OpenIdConnectConfiguration>>(sp =>
 {
     var settings = sp.GetRequiredService<IOptions<AuthSettings>>().Value;

--- a/Apps/Find/src/SUI.Find.FindApi/SUI.Find.FindApi.csproj
+++ b/Apps/Find/src/SUI.Find.FindApi/SUI.Find.FindApi.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
     <PackageReference Include="OneOf" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/Apps/Find/src/SUI.Find.FindApi/example.local.settings.json
+++ b/Apps/Find/src/SUI.Find.FindApi/example.local.settings.json
@@ -15,6 +15,9 @@
     "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=Development,service.namespace=SUI",
     "OTEL_SERVICE_NAME": "SUI.Find.FindApi",
     "MatchFunction:XApiKey": "local-dev-key-change-me",
-    "StorageRetentionDays": 1
+    "StorageRetentionDays": 1,
+    "AuthSettings__Issuer": "https://sandbox.api.example.gov.uk/sui-find-a-record/auth",
+    "AuthSettings__Audience": "sui-find-a-record-api",
+    "AuthSettings__OidcDiscoveryUrl": "https://localhost:7250/api/v1/.well-known/openid-configuration"
   }
 }

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -1,16 +1,21 @@
+using System.Collections.Concurrent;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using SUI.Find.Application.Constants;
+using SUI.Find.FindApi.Configurations;
 using SUI.Find.FindApi.Middleware;
 using SUI.Find.FindApi.Models;
-using SUI.Find.FindApi.UnitTests.Mocks;
 using SUI.Find.Infrastructure.Models;
 using SUI.Find.Infrastructure.Services;
 
@@ -18,296 +23,719 @@ namespace SUI.Find.FindApi.UnitTests.MiddlewareTests;
 
 public class JwtAuthMiddlewareTests
 {
-    private readonly FunctionContext _context = Substitute.For<FunctionContext>();
-    private readonly IAuthStoreService _authStoreService = Substitute.For<IAuthStoreService>();
-    private readonly IAuthContextFactory _authContextFactory =
+    private readonly IAuthStoreService _mockAuthStore = Substitute.For<IAuthStoreService>();
+    private readonly IAuthContextFactory _mockAuthContextFactory =
         Substitute.For<IAuthContextFactory>();
-    private readonly JwtSecurityTokenHandler _handler = Substitute.For<JwtSecurityTokenHandler>();
+    private readonly IConfigurationManager<OpenIdConnectConfiguration> _mockConfigManager =
+        Substitute.For<IConfigurationManager<OpenIdConnectConfiguration>>();
+    private readonly IOptions<AuthSettings> _mockOptions = Substitute.For<IOptions<AuthSettings>>();
 
-    [Theory]
-    [InlineData("swagger")]
-    [InlineData("openapi")]
-    [InlineData("v1/auth/token")]
-    [InlineData("health")]
-    public async Task TestInvoke_WithNoAuthEndpoints_SkipsMethod(string endpoint)
+    private readonly AuthSettings _authSettings;
+    private readonly RSA _genuineRsa;
+    private readonly string _genuineKid = "kid-genuine-01";
+
+    protected JwtAuthMiddlewareTests()
     {
-        // Arrange
-        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
-        var request = Substitute.For<HttpRequestData>(_context);
-        request.Url.Returns(new Uri("https://mock.gov.uk/api/" + endpoint));
-        _context.GetHttpRequestDataAsync().Returns(request);
-
-        // Act
-        await sut.Invoke(_context, Next);
-
-        // Assert
-        await _authStoreService.DidNotReceive().GetAuthStoreAsync();
-        _handler
-            .DidNotReceive()
-            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
-        _authContextFactory
-            .DidNotReceive()
-            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+        _genuineRsa = RSA.Create(2048);
+        _authSettings = new AuthSettings
+        {
+            Issuer = "https://sandbox.api.example.gov.uk/find-a-record/auth",
+            Audience = "sui-find-a-record-api",
+        };
+        _mockOptions.Value.Returns(_authSettings);
     }
 
-    [Fact]
-    public async Task TestInvoke_WithNoAuthHeaders_ReturnsProblemResponse()
+    #region Shared Helpers
+
+    private string GenerateSymmetricToken(
+        string issuer,
+        string audience,
+        string signingKey,
+        string clientId,
+        string scope = "fetch-record.read"
+    )
     {
-        // Arrange
-        InitialiseRequest([]);
-        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var claims = new[] { new Claim("client_id", clientId), new Claim("scp", scope) };
 
-        // Act
-        await sut.Invoke(_context, Next);
-
-        // Assert
-        var invocationResult = Assert.IsType<HttpResponseData>(
-            _context.GetInvocationResult().Value,
-            exactMatch: false
+        var token = new JwtSecurityToken(
+            issuer,
+            audience,
+            claims,
+            expires: DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: credentials
         );
-        Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
-
-        await _authStoreService.DidNotReceive().GetAuthStoreAsync();
-        _handler
-            .DidNotReceive()
-            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
-        _authContextFactory
-            .DidNotReceive()
-            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+        return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
-    [Fact]
-    public async Task TestInvoke_WithInvalidAuthHeaders_ReturnsProblemResponse()
+    private string GenerateAsymmetricToken(
+        RSA rsaKey,
+        string kid,
+        string? issuer = null,
+        string? audience = null,
+        DateTime? notBefore = null,
+        DateTime? expires = null,
+        bool stripSignature = false,
+        bool modifyPayload = false,
+        bool modifyHeader = false
+    )
     {
-        // Arrange
-        InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Invalid" } });
-        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+        var key = new RsaSecurityKey(rsaKey) { KeyId = kid };
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
+        var claims = new[]
+        {
+            new Claim("client_id", "clientId"),
+            new Claim("scp", "fetch-record.read"),
+        };
 
-        // Act
-        await sut.Invoke(_context, Next);
-
-        // Assert
-        var invocationResult = Assert.IsType<HttpResponseData>(
-            _context.GetInvocationResult().Value,
-            exactMatch: false
+        var jwtToken = new JwtSecurityToken(
+            issuer: issuer ?? _authSettings.Issuer,
+            audience: audience ?? _authSettings.Audience,
+            claims: claims,
+            notBefore: notBefore ?? DateTime.UtcNow.AddMinutes(-5),
+            expires: expires ?? DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: credentials
         );
-        Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
 
-        await _authStoreService.DidNotReceive().GetAuthStoreAsync();
-        _handler
-            .DidNotReceive()
-            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
-        _authContextFactory
-            .DidNotReceive()
-            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+        var tokenString = new JwtSecurityTokenHandler().WriteToken(jwtToken);
+
+        if (stripSignature)
+        {
+            return $"{tokenString.Split('.')[0]}.{tokenString.Split('.')[1]}.";
+        }
+
+        if (modifyPayload)
+        {
+            return $"{tokenString.Split('.')[0]}.eyJhY3VfYmFkIjp0cnVlfQ==.{tokenString.Split('.')[2]}";
+        }
+
+        if (modifyHeader)
+        {
+            return $"eyJh bGciOiJSUzI1NiIsImtpZCI6ImJhZCJ9.{tokenString.Split('.')[1]}.{tokenString.Split('.')[2]}";
+        }
+
+        return tokenString;
     }
 
-    [Fact]
-    public async Task TestInvoke_HandlesErrorsFromTokenHandler()
+    private OpenIdConnectConfiguration CreateOidcConfig(RSA rsaKey, string kid)
     {
-        // Arrange
-        InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
+        var config = new OpenIdConnectConfiguration();
+        config.SigningKeys.Add(new RsaSecurityKey(rsaKey) { KeyId = kid });
+        return config;
+    }
 
-        var clients = new List<AuthClient>
-        {
-            new()
-            {
-                ClientId = "clientId",
-                ClientSecret = "clientSecret",
-                AllowedScopes = ["file.read", "file.write"],
-                Enabled = true,
-                OrganisationId = "organisationId",
-            },
-        };
+    private FunctionContext CreateMockFunctionContext(string? authHeaderValue)
+    {
+        var context = Substitute.For<FunctionContext>();
+        var features = Substitute.For<IInvocationFeatures>();
+        var requestFeature = Substitute.For<IHttpRequestDataFeature>();
 
-        var store = new AuthStore
-        {
-            Audience = "Audience",
-            Issuer = "Issuer",
-            Clients = clients,
-            DefaultTokenLifetimeMinutes = 60,
-            SigningKey = "SigningKey",
-        };
-
-        _authStoreService.GetAuthStoreAsync().Returns(store);
-
-        _handler
-            .ValidateToken(
-                Arg.Any<string>(),
-                Arg.Any<TokenValidationParameters>(),
-                out Arg.Any<SecurityToken>()
-            )
-            .Throws<SecurityTokenException>();
-
-        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
-
-        // Act
-        await sut.Invoke(_context, Next);
-
-        // Assert
-        var invocationResult = Assert.IsType<HttpResponseData>(
-            _context.GetInvocationResult().Value,
-            exactMatch: false
+        var requestData = Substitute.For<Microsoft.Azure.Functions.Worker.Http.HttpRequestData>(
+            context
         );
-        Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
+        var responseData = Substitute.For<HttpResponseData>(context);
 
-        await _authStoreService.Received(1).GetAuthStoreAsync();
-        _handler
-            .Received(1)
-            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
-        _authContextFactory
-            .DidNotReceive()
-            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
-    }
+        var requestHeaders = new HttpHeadersCollection();
+        if (authHeaderValue != null)
+            requestHeaders.Add("Authorization", authHeaderValue);
+        requestData.Headers.Returns(requestHeaders);
 
-    [Fact]
-    public async Task TestInvoke_WhenScopesIncorrect_ReturnsProblemResponse()
-    {
-        // Arrange
-        InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
+        var responseHeaders = new HttpHeadersCollection();
+        responseData.Headers.Returns(responseHeaders);
 
-        var clients = new List<AuthClient>
-        {
-            new()
-            {
-                ClientId = "clientId",
-                ClientSecret = "clientSecret",
-                AllowedScopes = ["file.read"],
-                Enabled = true,
-                OrganisationId = "organisationId",
-            },
-        };
+        requestData.Url.Returns(new Uri("https://mock.gov.uk/api/v1/searches"));
+        requestData.CreateResponse().Returns(responseData);
+        responseData.Body.Returns(new MemoryStream());
 
-        var store = new AuthStore
-        {
-            Audience = "Audience",
-            Issuer = "Issuer",
-            Clients = clients,
-            DefaultTokenLifetimeMinutes = 60,
-            SigningKey = "SigningKey",
-        };
+        var invocationResult = Substitute.For<InvocationResult>();
+        context.GetInvocationResult().Returns(invocationResult);
 
-        _authStoreService.GetAuthStoreAsync().Returns(store);
+        requestFeature
+            .GetHttpRequestDataAsync(context)
+            .Returns(
+                ValueTask.FromResult<Microsoft.Azure.Functions.Worker.Http.HttpRequestData?>(
+                    requestData
+                )
+            );
+        features.Get<IHttpRequestDataFeature>().Returns(requestFeature);
+        context.Features.Returns(features);
 
-        _handler
-            .ValidateToken(
-                Arg.Any<string>(),
-                Arg.Any<TokenValidationParameters>(),
-                out Arg.Any<SecurityToken>()
-            )
-            .Returns(x =>
-            {
-                x[2] = new JwtSecurityToken();
-                return new ClaimsPrincipal();
-            });
-
-        _authContextFactory
-            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
-            .Returns(new AuthContext("clientId", "organisationId", ["file.write"]));
-
-        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
-
-        _context.FunctionDefinition.EntryPoint.Returns(
+        var items = new ConcurrentDictionary<object, object>();
+        context.Items.Returns(items);
+        context.FunctionDefinition.EntryPoint.Returns(
             "SUI.Find.FindApi.Functions.HttpFunctions.FetchRecordFunction.FetchRecord"
         );
 
-        // Act
-        await sut.Invoke(_context, Next);
-
-        // Assert
-        var invocationResult = Assert.IsType<HttpResponseData>(
-            _context.GetInvocationResult().Value,
-            exactMatch: false
-        );
-        Assert.Equal(HttpStatusCode.Unauthorized, invocationResult.StatusCode);
-
-        await _authStoreService.Received(1).GetAuthStoreAsync();
-        _handler
-            .Received(1)
-            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
-        _authContextFactory.Received(1).FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
-    }
-
-    [Fact]
-    public async Task TestInvoke_WithValidInputs_ReturnsAuthContext()
-    {
-        // Arrange
-        InitialiseRequest(new HttpHeadersCollection { { "Authorization", "Bearer token" } });
-
-        var clients = new List<AuthClient>
-        {
-            new()
-            {
-                ClientId = "clientId",
-                ClientSecret = "clientSecret",
-                AllowedScopes = ["fetch-record.read"],
-                Enabled = true,
-                OrganisationId = "organisationId",
-            },
-        };
-
-        var store = new AuthStore
-        {
-            Audience = "Audience",
-            Issuer = "Issuer",
-            Clients = clients,
-            DefaultTokenLifetimeMinutes = 60,
-            SigningKey = "SigningKey",
-        };
-
-        _authStoreService.GetAuthStoreAsync().Returns(store);
-
-        _handler
-            .ValidateToken(
-                Arg.Any<string>(),
-                Arg.Any<TokenValidationParameters>(),
-                out Arg.Any<SecurityToken>()
+        var mockSerializer = Substitute.For<Azure.Core.Serialization.ObjectSerializer>();
+        mockSerializer
+            .When(x =>
+                x.SerializeAsync(
+                    Arg.Any<Stream>(),
+                    Arg.Any<object>(),
+                    Arg.Any<Type>(),
+                    Arg.Any<CancellationToken>()
+                )
             )
-            .Returns(x =>
+            .Do(callInfo =>
+                JsonSerializer.Serialize(
+                    callInfo.Arg<Stream>(),
+                    callInfo.Arg<object>(),
+                    new JsonSerializerOptions(JsonSerializerDefaults.Web)
+                )
+            );
+
+        var workerOptions = new WorkerOptions { Serializer = mockSerializer };
+        var mockWorkerOptionsContainer = Substitute.For<IOptions<WorkerOptions>>();
+        mockWorkerOptionsContainer.Value.Returns(workerOptions);
+
+        var mockServiceProvider = Substitute.For<IServiceProvider>();
+        mockServiceProvider
+            .GetService(typeof(IOptions<WorkerOptions>))
+            .Returns(mockWorkerOptionsContainer);
+        context.InstanceServices.Returns(mockServiceProvider);
+
+        return context;
+    }
+
+    protected static Task Next(FunctionContext context) => Task.CompletedTask;
+
+    #endregion
+
+    public class SymmetricTests : JwtAuthMiddlewareTests
+    {
+        [Theory]
+        [InlineData("swagger")]
+        [InlineData("openapi")]
+        [InlineData("v1/auth/token")]
+        [InlineData("health")]
+        public async Task TestInvoke_WithNoAuthEndpoints_SkipsMethod(string endpoint)
+        {
+            // Arrange
+            var context = CreateMockFunctionContext(null);
+            var req = await context.GetHttpRequestDataAsync();
+            req!.Url.Returns(new Uri("https://mock.gov.uk/api/" + endpoint));
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            await _mockAuthStore.DidNotReceive().GetAuthStoreAsync();
+        }
+
+        [Fact]
+        public async Task TestInvoke_WithNoAuthHeaders_ReturnsProblemResponse()
+        {
+            // Arrange
+            var context = CreateMockFunctionContext(null);
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.Equal(
+                HttpStatusCode.Unauthorized,
+                ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
+            );
+        }
+
+        [Fact]
+        public async Task TestInvoke_WithInvalidAuthHeaders_ReturnsProblemResponse()
+        {
+            // Arrange
+            var context = CreateMockFunctionContext("Invalid");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.Equal(
+                HttpStatusCode.Unauthorized,
+                ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
+            );
+        }
+
+        [Fact]
+        public async Task TestInvoke_HandlesErrorsFromTokenHandler()
+        {
+            // Arrange
+            var store = new AuthStore
             {
-                x[2] = new JwtSecurityToken();
-                return new ClaimsPrincipal();
-            });
+                Audience = "Audience",
+                Issuer = "Issuer",
+                SigningKey = "SecretKeyShouldBeLongEnoughToPass12345!",
+                DefaultTokenLifetimeMinutes = 60,
+            };
+            _mockAuthStore.GetAuthStoreAsync().Returns(store);
+            var context = CreateMockFunctionContext(
+                "Bearer eyJobGciOiJIUzI1NiJ9.eyJpc3MiOiJJc3N1ZXIifQ.badsignature"
+            );
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
 
-        var authContext = new AuthContext("clientId", "organisationId", ["fetch-record.read"]);
+            // Act
+            await sut.Invoke(context, Next);
 
-        _authContextFactory
-            .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
-            .Returns(authContext);
+            // Assert
+            Assert.Equal(
+                HttpStatusCode.Unauthorized,
+                ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
+            );
+        }
 
-        var sut = new JwtAuthMiddleware(_authStoreService, _authContextFactory, _handler);
+        [Fact]
+        public async Task TestInvoke_WhenScopesIncorrect_ReturnsProblemResponse()
+        {
+            // Arrange
+            var store = new AuthStore
+            {
+                Audience = "Audience",
+                Issuer = "Issuer",
+                SigningKey = "SecretKeyShouldBeLongEnoughToPass12345!",
+                DefaultTokenLifetimeMinutes = 60,
+            };
+            _mockAuthStore.GetAuthStoreAsync().Returns(store);
+            var token = GenerateSymmetricToken(
+                store.Issuer,
+                store.Audience,
+                store.SigningKey,
+                "clientId",
+                "wrong.scope"
+            );
+            var context = CreateMockFunctionContext($"Bearer {token}");
 
-        _context.FunctionDefinition.EntryPoint.Returns(
-            "SUI.Find.FindApi.Functions.HttpFunctions.FetchRecordFunction.FetchRecord"
-        );
+            _mockAuthContextFactory
+                .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
+                .Returns(new AuthContext("clientId", "organisationId", ["wrong.scope"]));
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
 
-        // Act
-        await sut.Invoke(_context, Next);
+            // Act
+            await sut.Invoke(context, Next);
 
-        // Assert
-        await _authStoreService.Received(1).GetAuthStoreAsync();
-        _handler
-            .Received(1)
-            .ValidateToken(Arg.Any<string>(), Arg.Any<TokenValidationParameters>(), out _);
-        _authContextFactory.Received(1).FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>());
+            // Assert
+            Assert.Equal(
+                HttpStatusCode.Unauthorized,
+                ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
+            );
+        }
 
-        Assert.Equal(authContext, _context.Items[ApplicationConstants.Auth.AuthContextKey]);
+        [Fact]
+        public async Task TestInvoke_WithValidInputs_ReturnsAuthContext()
+        {
+            // Arrange
+            var store = new AuthStore
+            {
+                Audience = "Audience",
+                Issuer = "Issuer",
+                SigningKey = "SecretKeyShouldBeLongEnoughToPass12345!",
+                DefaultTokenLifetimeMinutes = 60,
+            };
+            _mockAuthStore.GetAuthStoreAsync().Returns(store);
+            var token = GenerateSymmetricToken(
+                store.Issuer,
+                store.Audience,
+                store.SigningKey,
+                "clientId"
+            );
+            var context = CreateMockFunctionContext($"Bearer {token}");
+
+            var authContext = new AuthContext("clientId", "organisationId", ["fetch-record.read"]);
+            _mockAuthContextFactory
+                .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
+                .Returns(authContext);
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.Equal(authContext, context.Items[ApplicationConstants.Auth.AuthContextKey]);
+        }
     }
 
-    private void InitialiseRequest(HttpHeadersCollection headers)
+    public class AsymmetricOidcTests : JwtAuthMiddlewareTests
     {
-        var request = Substitute.For<HttpRequestData>(_context);
-        request.Url.Returns(new Uri("https://mock.gov.uk/api/v1/searches"));
-        request.Headers.Returns(headers);
-        request.CreateResponse().Returns(new MockHttpResponseData(_context));
-        _context.GetHttpRequestDataAsync().Returns(request);
-        var serviceCollection = new ServiceCollection();
-        serviceCollection.AddFunctionsWorkerDefaults();
-        _context.InstanceServices.Returns(serviceCollection.BuildServiceProvider());
-    }
+        [Fact]
+        public async Task Scenario1_ValidToken_ShouldAllowAccessAndPopulateAuthContext()
+        {
+            // Scenario: Valid token, should Allow access, and the auth context should be set as expected
+            // Arrange
+            var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid);
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
-    private static Task Next(FunctionContext context)
-    {
-        return Task.CompletedTask;
+            var authContext = new AuthContext("clientId", "organisationId", ["fetch-record.read"]);
+            _mockAuthContextFactory
+                .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
+                .Returns(authContext);
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+            var nextExecuted = false;
+
+            // Act
+            await sut.Invoke(
+                context,
+                _ =>
+                {
+                    nextExecuted = true;
+                    return Task.CompletedTask;
+                }
+            );
+
+            // Assert
+            Assert.True(nextExecuted);
+            Assert.Null(context.GetInvocationResult().Value);
+            Assert.Equal(authContext, context.Items[ApplicationConstants.Auth.AuthContextKey]);
+        }
+
+        [Fact]
+        public async Task Scenario2_KidMissingInitially_ShouldForceRefreshAndSucceedOnRetry()
+        {
+            // Scenario: Valid token, except for kid is missing in our OIDC Config, so force refresh should happen, and the final result should Allow access
+            // Arrange
+            var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid);
+            var emptyConfig = new OpenIdConnectConfiguration();
+            var refreshedConfig = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager
+                .GetConfigurationAsync(Arg.Any<CancellationToken>())
+                .Returns(emptyConfig, refreshedConfig);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var authContext = new AuthContext("clientId", "organisationId", ["fetch-record.read"]);
+            _mockAuthContextFactory
+                .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
+                .Returns(authContext);
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+            var nextExecuted = false;
+
+            // Act
+            await sut.Invoke(
+                context,
+                _ =>
+                {
+                    nextExecuted = true;
+                    return Task.CompletedTask;
+                }
+            );
+
+            // Assert
+            _mockConfigManager.Received(1).RequestRefresh();
+            Assert.True(nextExecuted);
+        }
+
+        [Fact]
+        public async Task Scenario3_KidMissingEvenAfterForceRefresh_ShouldDenyAccess()
+        {
+            // Scenario: Valid token, except for kid is missing in our oidcConfig, so force refresh should happen, and after force refresh the kid is still missing, then should Deny access
+            // Arrange
+            var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid);
+            var emptyConfig = new OpenIdConnectConfiguration();
+            _mockConfigManager
+                .GetConfigurationAsync(Arg.Any<CancellationToken>())
+                .Returns(emptyConfig);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            _mockConfigManager.Received(1).RequestRefresh();
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
+
+        [Fact]
+        public async Task Scenario4_ModifiedPayload_ShouldDenyAccess()
+        {
+            // Scenario: Invalid signature due to modified token payload, should Deny access
+            // Arrange
+            var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid, modifyPayload: true);
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
+
+        [Fact]
+        public async Task Scenario5_ModifiedHeader_ShouldDenyAccess()
+        {
+            // Scenario: Invalid signature due to modified token header, should Deny access
+            // Arrange
+            var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid, modifyHeader: true);
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
+
+        [Fact]
+        public async Task Scenario6_TokenNotActiveYet_ShouldDenyAccess()
+        {
+            // Scenario: Invalid due to use of token before valid time range (i.e. not-before), should Deny access
+            // Arrange
+            var token = GenerateAsymmetricToken(
+                _genuineRsa,
+                _genuineKid,
+                notBefore: DateTime.UtcNow.AddHours(2),
+                expires: DateTime.UtcNow.AddHours(3)
+            );
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
+
+        [Fact]
+        public async Task Scenario7_TokenExpired_ShouldDenyAccess()
+        {
+            // Scenario: Invalid due to use of token after valid time range (i.e. expiration), should Deny access
+            // Arrange
+            var token = GenerateAsymmetricToken(
+                _genuineRsa,
+                _genuineKid,
+                notBefore: DateTime.UtcNow.AddHours(-3),
+                expires: DateTime.UtcNow.AddHours(-2)
+            );
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
+
+        [Fact]
+        public async Task Scenario8_StrippedSignature_ShouldDenyAccess()
+        {
+            // Scenario: Invalid signature due to signature removal, should Deny access
+            // Arrange
+            var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid, stripSignature: true);
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
+
+        [Fact]
+        public async Task Scenario9_ForgedPrivateKeySignature_ShouldDenyAccess()
+        {
+            // Scenario: Invalid signature due to non-genuine private key, should Deny access
+            // Arrange
+            using var forgedRsaKey = RSA.Create(2048);
+            var token = GenerateAsymmetricToken(forgedRsaKey, _genuineKid);
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
+
+        [Fact]
+        public async Task Scenario10_InvalidIssuer_ShouldDenyAccess()
+        {
+            // Scenario: Invalid source (i.e. issuer), should Deny access
+            // Arrange
+            var token = GenerateAsymmetricToken(
+                _genuineRsa,
+                _genuineKid,
+                issuer: "https://untrusted-issuer.com"
+            );
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
+
+        [Fact]
+        public async Task Scenario11_InvalidAudience_ShouldDenyAccess()
+        {
+            // Scenario: Invalid target (i.e. audience), should Deny access
+            // Arrange
+            var token = GenerateAsymmetricToken(
+                _genuineRsa,
+                _genuineKid,
+                audience: "malicious-intercept-audience"
+            );
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            Assert.NotNull(context.GetInvocationResult().Value);
+        }
     }
 }

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -30,6 +30,10 @@ public class JwtAuthMiddlewareTests
         Substitute.For<IConfigurationManager<OpenIdConnectConfiguration>>();
     private readonly IOptions<AuthSettings> _mockOptions = Substitute.For<IOptions<AuthSettings>>();
 
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(
+        JsonSerializerDefaults.Web
+    );
+
     private readonly AuthSettings _authSettings;
     private readonly RSA _genuineRsa;
     private readonly string _genuineKid = "kid-genuine-01";
@@ -181,7 +185,7 @@ public class JwtAuthMiddlewareTests
                 JsonSerializer.Serialize(
                     callInfo.Arg<Stream>(),
                     callInfo.Arg<object>(),
-                    new JsonSerializerOptions(JsonSerializerDefaults.Web)
+                    JsonSerializerOptions
                 )
             );
 

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -202,7 +202,7 @@ public class JwtAuthMiddlewareTests
 
         requestData.Url.Returns(new Uri("https://mock.gov.uk/api/v1/searches"));
         requestData.CreateResponse().Returns(responseData);
-        responseData.Body.Returns(Stream.Null);
+        responseData.Body.Returns(new MemoryStream());
 
         var invocationResult = Substitute.For<InvocationResult>();
         context.GetInvocationResult().Returns(invocationResult);

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -47,7 +47,7 @@ public class JwtAuthMiddlewareTests
 
     #region Shared Helpers
 
-    private string GenerateSymmetricToken(
+    private static string GenerateSymmetricToken(
         string issuer,
         string audience,
         string signingKey,
@@ -118,14 +118,14 @@ public class JwtAuthMiddlewareTests
         return tokenString;
     }
 
-    private OpenIdConnectConfiguration CreateOidcConfig(RSA rsaKey, string kid)
+    private static OpenIdConnectConfiguration CreateOidcConfig(RSA rsaKey, string kid)
     {
         var config = new OpenIdConnectConfiguration();
         config.SigningKeys.Add(new RsaSecurityKey(rsaKey) { KeyId = kid });
         return config;
     }
 
-    private FunctionContext CreateMockFunctionContext(string? authHeaderValue)
+    private static FunctionContext CreateMockFunctionContext(string? authHeaderValue)
     {
         var context = Substitute.For<FunctionContext>();
         var features = Substitute.For<IInvocationFeatures>();
@@ -198,7 +198,7 @@ public class JwtAuthMiddlewareTests
         return context;
     }
 
-    protected static Task Next(FunctionContext context) => Task.CompletedTask;
+    private static Task Next(FunctionContext context) => Task.CompletedTask;
 
     #endregion
 

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -4,14 +4,15 @@ using System.Net;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using NSubstitute;
+using Shouldly;
 using SUI.Find.Application.Constants;
 using SUI.Find.FindApi.Configurations;
 using SUI.Find.FindApi.Middleware;
@@ -29,16 +30,17 @@ public class JwtAuthMiddlewareTests
     private readonly IConfigurationManager<OpenIdConnectConfiguration> _mockConfigManager =
         Substitute.For<IConfigurationManager<OpenIdConnectConfiguration>>();
     private readonly IOptions<AuthSettings> _mockOptions = Substitute.For<IOptions<AuthSettings>>();
-
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new(
-        JsonSerializerDefaults.Web
-    );
+    private readonly ILogger<JwtAuthMiddleware> _mockLogger = Substitute.For<
+        ILogger<JwtAuthMiddleware>
+    >();
 
     private readonly AuthSettings _authSettings;
     private readonly RSA _genuineRsa;
     private readonly string _genuineKid = "kid-genuine-01";
 
-    protected JwtAuthMiddlewareTests()
+    private bool _nextExecuted;
+
+    private JwtAuthMiddlewareTests()
     {
         _genuineRsa = RSA.Create(2048);
         _authSettings = new AuthSettings
@@ -50,6 +52,56 @@ public class JwtAuthMiddlewareTests
     }
 
     #region Shared Helpers
+
+    private void AssertAccessAllowed(FunctionContext context, AuthContext expectedAuthContext)
+    {
+        Assert.True(_nextExecuted);
+        Assert.True(context.Items.ContainsKey(ApplicationConstants.Auth.AuthContextKey));
+
+        Assert.Null(context.GetInvocationResult().Value);
+
+        Assert.Equal(expectedAuthContext, context.Items[ApplicationConstants.Auth.AuthContextKey]);
+    }
+
+    private void AssertAccessDenied(
+        FunctionContext context,
+        string expectedResponseContains,
+        string? expectedSecurityErrorContains = null
+    )
+    {
+        Assert.False(_nextExecuted);
+        Assert.False(context.Items.ContainsKey(ApplicationConstants.Auth.AuthContextKey));
+
+        Assert.NotNull(context.GetInvocationResult().Value);
+
+        var responseData = Assert.IsType<HttpResponseData>(
+            context.GetInvocationResult().Value,
+            exactMatch: false
+        );
+
+        Assert.Equal(HttpStatusCode.Unauthorized, responseData.StatusCode);
+
+        responseData.Body.Seek(0, SeekOrigin.Begin);
+        using var streamReader = new StreamReader(responseData.Body);
+        var responseBody = streamReader.ReadToEnd();
+
+        responseBody.ShouldContain(expectedResponseContains);
+
+        if (expectedSecurityErrorContains != null)
+        {
+            _mockLogger
+                .Received(1)
+                .Log(
+                    LogLevel.Warning,
+                    0,
+                    Arg.Any<object>(),
+                    Arg.Is<SecurityTokenException>(e =>
+                        e.Message.Contains(expectedSecurityErrorContains)
+                    ),
+                    Arg.Any<Func<object, Exception?, string>>()
+                );
+        }
+    }
 
     private static string GenerateSymmetricToken(
         string issuer,
@@ -82,16 +134,13 @@ public class JwtAuthMiddlewareTests
         DateTime? expires = null,
         bool stripSignature = false,
         bool modifyPayload = false,
-        bool modifyHeader = false
+        bool modifyHeader = false,
+        string scope = "fetch-record.read"
     )
     {
         var key = new RsaSecurityKey(rsaKey) { KeyId = kid };
         var credentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
-        var claims = new[]
-        {
-            new Claim("client_id", "clientId"),
-            new Claim("scp", "fetch-record.read"),
-        };
+        var claims = new[] { new Claim("client_id", "clientId"), new Claim("scp", scope) };
 
         var jwtToken = new JwtSecurityToken(
             issuer: issuer ?? _authSettings.Issuer,
@@ -111,12 +160,15 @@ public class JwtAuthMiddlewareTests
 
         if (modifyPayload)
         {
-            return $"{tokenString.Split('.')[0]}.eyJhY3VfYmFkIjp0cnVlfQ==.{tokenString.Split('.')[2]}";
+            return $"{tokenString.Split('.')[0]}.{Base64UrlEncoder.Encode("{\"acu_bad\":\"true\"}")}.{tokenString.Split('.')[2]}";
         }
 
         if (modifyHeader)
         {
-            return $"eyJh bGciOiJSUzI1NiIsImtpZCI6ImJhZCJ9.{tokenString.Split('.')[1]}.{tokenString.Split('.')[2]}";
+            var badHeader = Base64UrlEncoder.Encode(
+                Base64UrlEncoder.Decode(tokenString.Split('.')[0]).Replace("JWT", "BAD")
+            );
+            return $"{badHeader}.{tokenString.Split('.')[1]}.{tokenString.Split('.')[2]}";
         }
 
         return tokenString;
@@ -150,7 +202,7 @@ public class JwtAuthMiddlewareTests
 
         requestData.Url.Returns(new Uri("https://mock.gov.uk/api/v1/searches"));
         requestData.CreateResponse().Returns(responseData);
-        responseData.Body.Returns(Stream.Null);
+        responseData.Body.Returns(new MemoryStream());
 
         var invocationResult = Substitute.For<InvocationResult>();
         context.GetInvocationResult().Returns(invocationResult);
@@ -171,25 +223,10 @@ public class JwtAuthMiddlewareTests
             "SUI.Find.FindApi.Functions.HttpFunctions.FetchRecordFunction.FetchRecord"
         );
 
-        var mockSerializer = Substitute.For<Azure.Core.Serialization.ObjectSerializer>();
-        mockSerializer
-            .When(x =>
-                x.SerializeAsync(
-                    Arg.Any<Stream>(),
-                    Arg.Any<object>(),
-                    Arg.Any<Type>(),
-                    Arg.Any<CancellationToken>()
-                )
-            )
-            .Do(callInfo =>
-                JsonSerializer.Serialize(
-                    callInfo.Arg<Stream>(),
-                    callInfo.Arg<object>(),
-                    JsonSerializerOptions
-                )
-            );
-
-        var workerOptions = new WorkerOptions { Serializer = mockSerializer };
+        var workerOptions = new WorkerOptions
+        {
+            Serializer = Azure.Core.Serialization.JsonObjectSerializer.Default,
+        };
         var mockWorkerOptionsContainer = Substitute.For<IOptions<WorkerOptions>>();
         mockWorkerOptionsContainer.Value.Returns(workerOptions);
 
@@ -202,11 +239,15 @@ public class JwtAuthMiddlewareTests
         return context;
     }
 
-    private static Task Next(FunctionContext context) => Task.CompletedTask;
+    private Task Next(FunctionContext context)
+    {
+        _nextExecuted = true;
+        return Task.CompletedTask;
+    }
 
     #endregion
 
-    public class SymmetricTests : JwtAuthMiddlewareTests
+    public class GeneralVerificationTests : JwtAuthMiddlewareTests
     {
         [Theory]
         [InlineData("swagger")]
@@ -223,13 +264,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
+            Assert.True(_nextExecuted);
             await _mockAuthStore.DidNotReceive().GetAuthStoreAsync();
         }
 
@@ -242,17 +285,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.Equal(
-                HttpStatusCode.Unauthorized,
-                ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
-            );
+            AssertAccessDenied(context, "Missing Authorization header");
         }
 
         [Fact]
@@ -264,7 +305,8 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
@@ -275,10 +317,11 @@ public class JwtAuthMiddlewareTests
                 HttpStatusCode.Unauthorized,
                 ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
             );
+            AssertAccessDenied(context, "Invalid Authorization header");
         }
 
         [Fact]
-        public async Task TestInvoke_HandlesErrorsFromTokenHandler()
+        public async Task TestInvoke_Handles_UnsupportedSigningAlgorithms()
         {
             // Arrange
             var store = new AuthStore
@@ -296,7 +339,8 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
@@ -307,8 +351,12 @@ public class JwtAuthMiddlewareTests
                 HttpStatusCode.Unauthorized,
                 ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
             );
+            AssertAccessDenied(context, "Unsupported signing algorithm");
         }
+    }
 
+    public class SymmetricVerificationTests : JwtAuthMiddlewareTests
+    {
         [Fact]
         public async Task TestInvoke_WhenScopesIncorrect_ReturnsProblemResponse()
         {
@@ -337,17 +385,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.Equal(
-                HttpStatusCode.Unauthorized,
-                ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
-            );
+            AssertAccessDenied(context, "Insufficient scope for this operation");
         }
 
         [Fact]
@@ -378,19 +424,52 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.Equal(authContext, context.Items[ApplicationConstants.Auth.AuthContextKey]);
+            AssertAccessAllowed(context, authContext);
         }
     }
 
-    public class AsymmetricOidcTests : JwtAuthMiddlewareTests
+    public class AsymmetricVerificationTests : JwtAuthMiddlewareTests
     {
+        [Fact]
+        public async Task Scenario0_ValidToken_WhenScopesIncorrect_ShouldDenyAccess()
+        {
+            // Arrange
+            var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid, scope: "wrong.scope");
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+            _mockAuthStore
+                .GetAuthStoreAsync()
+                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
+
+            var authContext = new AuthContext("clientId", "organisationId", ["wrong.scope"]);
+            _mockAuthContextFactory
+                .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<AuthStore>())
+                .Returns(authContext);
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+            var sut = new JwtAuthMiddleware(
+                _mockAuthStore,
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions,
+                _mockLogger
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            AssertAccessDenied(context, "Insufficient scope for this operation");
+        }
+
         [Fact]
         public async Task Scenario1_ValidToken_ShouldAllowAccessAndPopulateAuthContext()
         {
@@ -413,24 +492,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
-            var nextExecuted = false;
 
             // Act
-            await sut.Invoke(
-                context,
-                _ =>
-                {
-                    nextExecuted = true;
-                    return Task.CompletedTask;
-                }
-            );
+            await sut.Invoke(context, Next);
 
             // Assert
-            Assert.True(nextExecuted);
-            Assert.Null(context.GetInvocationResult().Value);
-            Assert.Equal(authContext, context.Items[ApplicationConstants.Auth.AuthContextKey]);
+            AssertAccessAllowed(context, authContext);
         }
 
         [Fact]
@@ -458,23 +528,16 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
-            var nextExecuted = false;
 
             // Act
-            await sut.Invoke(
-                context,
-                _ =>
-                {
-                    nextExecuted = true;
-                    return Task.CompletedTask;
-                }
-            );
+            await sut.Invoke(context, Next);
 
             // Assert
             _mockConfigManager.Received(1).RequestRefresh();
-            Assert.True(nextExecuted);
+            AssertAccessAllowed(context, authContext);
         }
 
         [Fact]
@@ -496,7 +559,8 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
@@ -504,7 +568,7 @@ public class JwtAuthMiddlewareTests
 
             // Assert
             _mockConfigManager.Received(1).RequestRefresh();
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(context, "Token validation failed", "No security keys");
         }
 
         [Fact]
@@ -524,14 +588,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(context, "Token validation failed", "Signature validation failed");
         }
 
         [Fact]
@@ -551,14 +616,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(context, "Token validation failed", "Signature validation failed");
         }
 
         [Fact]
@@ -583,14 +649,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(context, "Token validation failed", "The token is not yet valid");
         }
 
         [Fact]
@@ -615,14 +682,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(context, "Token validation failed", "The token is expired");
         }
 
         [Fact]
@@ -642,14 +710,19 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(
+                context,
+                "Token validation failed",
+                "token does not have a signature"
+            );
         }
 
         [Fact]
@@ -670,14 +743,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(context, "Token validation failed", "Signature validation failed");
         }
 
         [Fact]
@@ -701,14 +775,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(context, "Token validation failed", "Issuer validation failed");
         }
 
         [Fact]
@@ -732,14 +807,15 @@ public class JwtAuthMiddlewareTests
                 _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
-                _mockOptions
+                _mockOptions,
+                _mockLogger
             );
 
             // Act
             await sut.Invoke(context, Next);
 
             // Assert
-            Assert.NotNull(context.GetInvocationResult().Value);
+            AssertAccessDenied(context, "Token validation failed", "Audience validation failed");
         }
     }
 }

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -202,7 +202,7 @@ public class JwtAuthMiddlewareTests
 
         requestData.Url.Returns(new Uri("https://mock.gov.uk/api/v1/searches"));
         requestData.CreateResponse().Returns(responseData);
-        responseData.Body.Returns(new MemoryStream());
+        responseData.Body.Returns(Stream.Null);
 
         var invocationResult = Substitute.For<InvocationResult>();
         context.GetInvocationResult().Returns(invocationResult);

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -150,7 +150,7 @@ public class JwtAuthMiddlewareTests
 
         requestData.Url.Returns(new Uri("https://mock.gov.uk/api/v1/searches"));
         requestData.CreateResponse().Returns(responseData);
-        responseData.Body.Returns(new MemoryStream());
+        responseData.Body.Returns(Stream.Null);
 
         var invocationResult = Substitute.For<InvocationResult>();
         context.GetInvocationResult().Returns(invocationResult);

--- a/terraform/environments/d01.tfvars
+++ b/terraform/environments/d01.tfvars
@@ -22,6 +22,9 @@ find_app_settings = {
   NhsAuthConfig__NHS_DIGITAL_TOKEN_URL                       = "https://int.api.service.nhs.uk/oauth2/token"
   NhsAuthConfig__NHS_DIGITAL_FHIR_ENDPOINT                   = "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/"
   NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
+  AuthSettings__Issuer           = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth"
+  AuthSettings__Audience         = "sui-find-a-record-api"
+  AuthSettings__OidcDiscoveryUrl = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth/.well-known/openid-configuration"
 }
 
 custodian_app_settings = {

--- a/terraform/environments/d01.tfvars
+++ b/terraform/environments/d01.tfvars
@@ -24,7 +24,7 @@ find_app_settings = {
   NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
   AuthSettings__Issuer           = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth"
   AuthSettings__Audience         = "sui-find-a-record-api"
-  AuthSettings__OidcDiscoveryUrl = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth/.well-known/openid-configuration"
+  AuthSettings__OidcDiscoveryUrl = "https://s270d01app-ukw-authemulator01.azurewebsites.net/api/v1/.well-known/openid-configuration"
 }
 
 custodian_app_settings = {

--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -22,6 +22,9 @@ find_app_settings = {
   NhsAuthConfig__NHS_DIGITAL_TOKEN_URL                       = "https://int.api.service.nhs.uk/oauth2/token"
   NhsAuthConfig__NHS_DIGITAL_FHIR_ENDPOINT                   = "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/"
   NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
+  AuthSettings__Issuer           = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth"
+  AuthSettings__Audience         = "sui-find-a-record-api"
+  AuthSettings__OidcDiscoveryUrl = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth/.well-known/openid-configuration"
 }
 
 custodian_app_settings = {

--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -24,7 +24,7 @@ find_app_settings = {
   NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
   AuthSettings__Issuer           = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth"
   AuthSettings__Audience         = "sui-find-a-record-api"
-  AuthSettings__OidcDiscoveryUrl = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth/.well-known/openid-configuration"
+  AuthSettings__OidcDiscoveryUrl = "https://s270d02app-ukw-authemulator01.azurewebsites.net/api/v1/.well-known/openid-configuration"
 }
 
 custodian_app_settings = {


### PR DESCRIPTION
## Summary

Add OIDC Discovery and RSA signature verification to the Find API’s Authentication functionality, so that we can support integrating with common 3rd party identity providers.

## Changes

- OpenID Discovery included using the Microsoft.IdentityModel.Protocols.OpenIdConnect package
> OIDC Configuration Manager is registered in host services as a singleton, so it caches the public keys (JWKS) across function invocations

- Verify token signatures using RSA public key
> Use Microsoft.IdentityModel.Protocols.IConfigurationManager<OpenIdConnectConfiguration>
> Call GetConfiguration in every request (the .NET package deals with caching and expiry) var oidcConfig = await oidcConfigManager.GetConfigurationAsync(cancellationToken);
> Call JwtSecurityTokenHandler.ValidateToken and pass the specified Token Validation Parameters:
> The config values are loaded via a .NET Options Pattern object called AuthSettings

- Token validation handles keys not being found (edge case that the identity provider rotates keys within a cache window) - see attachment
> When the token validation throws a SecurityTokenSignatureKeyNotFoundException
> And the unverified token’s issuer matches the configured issuer
> And the unverified token’s audiences contains the configured audience
> And this retry logic has not yet been executed in this request
> Then the OIDC configuration manager should be forced refreshed: oidcConfigManager.RequestRefresh();
> And the token validation logic should be retried (suggestion is to a have a singularly recursive method, something like ValidateAsymmetricToken(bool retry) where retry is true first, and then false the second time)

- JwtAuthMiddleware for the general and asymmetric token validation logic covered with unit tests

- The existing Symmetric Key verification is kept and remains unchanged
> Which IssuerSigningKey gets used should be derived from the token’s alg header
> RS256 should use the new RsaSecurityKey verification
> HS256 should use the existing SymmetricSecurityKey verification
> Symmetric Key verification will be deleted at a later stage to avoid any breaking changes

## Validation

- Scenario: Valid token, should Allow access, and the auth context should be set as expected
> Given a valid token
> When the token is verified
> Then the result should Allow access
> And there should be no problem response
> And the auth context should be for the expected ClientId, OrganisationId and have the expected Scopes

- Scenario: Valid token, except for kid is missing in our OIDC Config, so force refresh should happen, and the final result should Allow access, and the auth context should be set as expected
> Given a valid token
> And the token’s public key is no longer available in the oidcConfig
> When the token is verified
> Then a refresh should happen
> And the token’s public key becomes available in the oidcConfig
> Then the result should Allow access
> And there should be no problem response

- Scenario: Valid token, except for kid is missing in our oidcConfig, so force refresh should happen, and after force refresh the kid is still missing, then should Deny access
> Given a valid token
> And the token’s public key is no longer available in the oidcConfig
> When the token is verified
> Then a refresh should happen
> And the token’s public key is still not available in the oidcConfig
> Then the result should Deny access with a problem response
> And the problem response should indicate the signature’s key was not found

- Scenario: Invalid signature due to modified token payload, should Deny access
> Given a valid token
> And the token's payload is changed
> When the token is verified
> Then the result should Deny access with a problem response
> And the problem response should indicate an invalid signature

- Scenario: Invalid signature due to modified token header, should Deny access
> Given a valid token
> And the token's header is changed
> When the token is verified
> Then the result should Deny access with a problem response
> And the problem response should indicate an invalid signature

- Scenario: Invalid due to use of token before valid time range (i.e. not-before), should Deny access
> Given a token that is valid between 2 hours and 3 hours
> When the token is verified
> Then the result should Deny access with a problem response
> And the problem response should indicate the jwt is not active

- Scenario: Invalid due to use of token after valid time range (i.e. expiration), should Deny access
> Given a token that is valid between -3 hours and -2 hours
> When the token is verified
> Then the result should Deny access with a problem response
> And the problem response should indicate the jwt is expired

- Scenario: Invalid signature due to signature removal, should Deny access
> Given a valid token
> And the token's signature is removed
> When the token is verified
> Then the result should Deny access with a problem response
> And the problem response should indicate the jwt signature is required

- Scenario: Invalid signature due to non-genuine private key, should Deny access
> Given a valid token except for being signed with a different RSA private key
> When the token is verified
> Then the result should Deny access with a problem response
> And the problem response should indicate an invalid signature

- Scenario: Invalid source (i.e. issuer), should Deny access
> Given a valid token but from a different issuer
> When the token is verified
> Then the result should Deny access with a problem response
> And the problem response should indicate that the jwt issuer is invalid

- Scenario: Invalid target (i.e. audience), should Deny access
> Given a valid token but intended for different audience
> When the token is verified
> Then the result should Deny access with a problem response
> And the problem response should indicate that the jwt audience is invalid