### PR TITLE
fix: SUI-1710 - corrected OIDC URLs in Auth Emulator

### DIFF
--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Configurations/AuthSettings.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Configurations/AuthSettings.cs
@@ -7,5 +7,5 @@ public class AuthSettings
     public string Issuer { get; set; } =
         "https://sandbox.api.example.gov.uk/sui-find-a-record/auth";
 
-    public string BaseUrl { get; set; } = "https://localhost:7250/api";
+    public string BaseUrl { get; set; } = "https://localhost:7250";
 }

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/HealthController.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/HealthController.cs
@@ -5,7 +5,8 @@ namespace SUI.AuthEmulator.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class HealthController(IHostEnvironment env, ILogger<AuthController> logger) : ControllerBase
+public class HealthController(IHostEnvironment env, ILogger<HealthController> logger)
+    : ControllerBase
 {
     private const string ServiceName = nameof(AuthEmulator);
 

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/OIDCDiscoveryController.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/OIDCDiscoveryController.cs
@@ -23,8 +23,8 @@ public class OIDCDiscoveryController : ControllerBase
         var discoveryDocument = new
         {
             issuer = _authSettings.Issuer,
-            token_endpoint = $"{baseUrl}/v1/token",
-            jwks_uri = $"{baseUrl}/v1/jwks",
+            token_endpoint = $"{baseUrl}/api/v1/auth/token",
+            jwks_uri = $"{baseUrl}/api/v1/jwks",
             id_token_signing_alg_values_supported = new[] { "RS256" },
             grant_types_supported = new[] { "client_credentials" },
             response_types_supported = new[] { "token" },

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/HostApplicationBuilderOpenTelemetryExtensions.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/HostApplicationBuilderOpenTelemetryExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -6,6 +7,9 @@ using OpenTelemetry.Trace;
 
 namespace SUI.AuthEmulator;
 
+[ExcludeFromCodeCoverage(
+    Justification = "Behaviour heavily depends in integration with infrastructure."
+)]
 public static class HostApplicationBuilderOpenTelemetryExtensions
 {
     public static IHostApplicationBuilder UseOpenTelemetry(this IHostApplicationBuilder builder)

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Program.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Program.cs
@@ -1,3 +1,4 @@
+using System.IO.Abstractions;
 using SUI.AuthEmulator;
 using SUI.AuthEmulator.Configurations;
 using SUI.AuthEmulator.Services;
@@ -12,6 +13,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddProblemDetails();
 builder.Services.AddHttpContextAccessor();
 
+builder.Services.AddSingleton<IFileSystem, FileSystem>();
 builder.Services.AddSingleton<IAuthStoreService, MockAuthStoreService>();
 builder.Services.AddSingleton<IJwtTokenService, JwtTokenService>();
 builder.Services.AddSingleton<IJwksKeyProvider, JwksKeyProvider>();

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/SUI.AuthEmulator.csproj
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/SUI.AuthEmulator.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.1.0" />
     <PackageReference Include="Testably.Abstractions.FileSystem.Interface" Version="10.0.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
@@ -52,7 +52,7 @@ public class MockAuthStoreService : IAuthStoreService
     private AuthStore LoadStore()
     {
         var baseDir = AppContext.BaseDirectory;
-        var filePath = Path.Combine(baseDir, "Data", "auth-clients-inbound.json");
+        var filePath = Path.Join(baseDir, "Data", "auth-clients-inbound.json");
 
         if (!_fileSystem.File.Exists(filePath))
         {

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
@@ -1,3 +1,4 @@
+using System.IO.Abstractions;
 using System.Text.Json;
 using SUI.AuthEmulator.Models;
 
@@ -5,17 +6,24 @@ namespace SUI.AuthEmulator.Services;
 
 public class MockAuthStoreService : IAuthStoreService
 {
-    public async Task<AuthStore> GetAuthStoreAsync()
+    private readonly IFileSystem _fileSystem;
+    private readonly Lazy<AuthStore> _authStore;
+
+    public MockAuthStoreService(IFileSystem fileSystem)
     {
-        return await GetStore();
+        _fileSystem = fileSystem;
+        _authStore = new Lazy<AuthStore>(LoadStore);
     }
 
-    public async Task<Result<AuthClient>> GetClientByCredentials(
-        string clientId,
-        string clientSecret
-    )
+    public Task<AuthStore> GetAuthStoreAsync()
     {
-        var store = await GetStore();
+        // Instantly returns the cached in-memory store as a completed Task
+        return Task.FromResult(_authStore.Value);
+    }
+
+    public Task<Result<AuthClient>> GetClientByCredentials(string clientId, string clientSecret)
+    {
+        var store = _authStore.Value;
 
         if (
             string.IsNullOrWhiteSpace(store.Issuer)
@@ -34,28 +42,31 @@ public class MockAuthStoreService : IAuthStoreService
             c.ClientId == clientId && c.ClientSecret == clientSecret && c.Enabled
         );
 
-        return client is null
+        var result = client is null
             ? Result<AuthClient>.Fail("Unauthorized")
             : Result<AuthClient>.Ok(client);
+
+        return Task.FromResult(result);
     }
 
-    private async Task<AuthStore> GetStore()
+    private AuthStore LoadStore()
     {
         var baseDir = AppContext.BaseDirectory;
-        var filePath = Path.Join(baseDir, "Data", "auth-clients-inbound.json");
+        var filePath = Path.Combine(baseDir, "Data", "auth-clients-inbound.json");
 
-        if (!File.Exists(filePath))
+        if (!_fileSystem.File.Exists(filePath))
         {
             throw new InvalidOperationException($"Auth store file not found at: {filePath}");
         }
 
-        var json = await File.ReadAllTextAsync(filePath);
+        var json = _fileSystem.File.ReadAllText(filePath);
         var store = JsonSerializer.Deserialize<AuthStore>(json, JsonSerializerOptions.Web);
 
         if (store is null)
         {
             throw new InvalidOperationException("Auth store file could not be deserialized.");
         }
+
         return store;
     }
 }

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/appsettings.json
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/appsettings.json
@@ -8,6 +8,6 @@
   "AllowedHosts": "*",
   "AuthSettings": {
     "Issuer": "https://sandbox.api.example.gov.uk/sui-find-a-record/auth",
-    "BaseUrl": "https://localhost:7250/api"
+    "BaseUrl": "https://localhost:7250"
   }
 }

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Controllers/HealthControllerTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Controllers/HealthControllerTests.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SUI.AuthEmulator.Controllers;
+
+namespace SUI.AuthEmulator.UnitTests.Controllers;
+
+public class HealthControllerTests
+{
+    [Fact]
+    public void Get_Test()
+    {
+        // Arrange
+        var sut = new HealthController(
+            Substitute.For<IHostEnvironment>(),
+            Substitute.For<ILogger<HealthController>>()
+        )
+        {
+            ControllerContext = { HttpContext = Substitute.For<HttpContext>() },
+        };
+
+        // Act
+        var response = sut.Get();
+
+        // Assert
+        var valueProperty = response.GetType().GetProperty("Value");
+        Assert.NotNull(valueProperty);
+
+        var value = valueProperty.GetValue(response);
+        Assert.Equal("Healthy", value);
+    }
+}

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/OIDCDiscoveryControllerTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/OIDCDiscoveryControllerTests.cs
@@ -17,7 +17,7 @@ public class OIDCDiscoveryControllerTests
         var settings = new AuthSettings
         {
             Issuer = "https://test.issuer.com",
-            BaseUrl = "https://test.api.com/api/", // Testing with a trailing slash to verify truncation logic
+            BaseUrl = "https://test.api.com/", // Testing with a trailing slash to verify truncation logic
         };
         _mockOptions.Value.Returns(settings);
 
@@ -34,7 +34,7 @@ public class OIDCDiscoveryControllerTests
         var val = okResult.Value;
         Assert.Equal("https://test.issuer.com", val.GetType().GetProperty("issuer")?.GetValue(val));
         Assert.Equal(
-            "https://test.api.com/api/v1/token",
+            "https://test.api.com/api/v1/auth/token",
             val.GetType().GetProperty("token_endpoint")?.GetValue(val)
         );
         Assert.Equal(
@@ -42,7 +42,7 @@ public class OIDCDiscoveryControllerTests
             val.GetType().GetProperty("jwks_uri")?.GetValue(val)
         );
         Assert.Equal(
-            "https://test.api.com/api/dummy",
+            "https://test.api.com/dummy",
             val.GetType().GetProperty("authorization_endpoint")?.GetValue(val)
         );
 

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/SUI.AuthEmulator.UnitTests.csproj
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/SUI.AuthEmulator.UnitTests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/JwtTokenServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/JwtTokenServiceTests.cs
@@ -1,0 +1,37 @@
+﻿using NSubstitute;
+using SUI.AuthEmulator.Models;
+using SUI.AuthEmulator.Services;
+
+namespace SUI.AuthEmulator.UnitTests.Services;
+
+public class JwtTokenServiceTests
+{
+    [Fact]
+    public async Task GenerateToken_ReturnsTokenString()
+    {
+        // Arrange
+        var mockAuthStore = Substitute.For<IAuthStoreService>();
+        mockAuthStore
+            .GetAuthStoreAsync()
+            .Returns(
+                new AuthStore
+                {
+                    Issuer = "test-issuer",
+                    Audience = "test-audience",
+                    SigningKey = "test-signing-key-really-long-and-secure",
+                    DefaultTokenLifetimeMinutes = 60,
+                }
+            );
+
+        var service = new JwtTokenService(mockAuthStore);
+
+        // Act
+        var token = await service.GenerateToken(
+            "test-client-id",
+            new List<string> { "scope1", "scope2" }
+        );
+
+        // Assert
+        Assert.False(string.IsNullOrEmpty(token));
+    }
+}

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -1,0 +1,138 @@
+﻿using System.IO.Abstractions;
+using System.Text.Json;
+using NSubstitute;
+using SUI.AuthEmulator.Models;
+using SUI.AuthEmulator.Services;
+
+namespace SUI.AuthEmulator.UnitTests.Services;
+
+public class MockAuthStoreServiceTests
+{
+    private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
+    private readonly MockAuthStoreService _sut;
+    private readonly string _realStoreFilePath;
+
+    public MockAuthStoreServiceTests()
+    {
+        _sut = new MockAuthStoreService(_mockFileSystem);
+        _realStoreFilePath = Path.Join(
+            AppContext.BaseDirectory,
+            "Data",
+            "auth-clients-inbound.json"
+        );
+    }
+
+    [Fact]
+    public async Task GetAuthStoreAsync_MapsJsonToStoreDefinitionCorrectly()
+    {
+        // Arrange
+        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
+
+        // Act
+        var store = await _sut.GetAuthStoreAsync();
+
+        // Assert
+        Assert.NotNull(store);
+        Assert.Equal("https://sandbox.api.example.gov.uk/find-a-record/auth", store.Issuer);
+        Assert.Equal("find-a-record-api", store.Audience);
+        Assert.Equal(
+            "Wc8Kq1ZyR4hNfD0uVx3mS9JpA6eLrT2bG7wQvY5sCjP8kF1nH0tUoMzBiXaEdRl",
+            store.SigningKey
+        );
+        Assert.NotNull(store.Clients);
+        Assert.NotEmpty(store.Clients);
+
+        // Verify structure of an active client
+        var sampleClient = store.Clients.FirstOrDefault(c => c.ClientId == "LOCAL-AUTHORITY-01");
+        Assert.NotNull(sampleClient);
+        Assert.True(sampleClient.Enabled);
+        Assert.Equal("SUIProject", sampleClient.ClientSecret);
+        Assert.Contains("match-record.read", sampleClient.AllowedScopes!);
+    }
+
+    [Fact]
+    public async Task GetClientByCredentials_ShouldReturnClient_WhenIdAndSecretMatch()
+    {
+        // Arrange
+        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
+
+        // Act
+        var result = await _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "SUIProject");
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.Value);
+        Assert.Equal("LOCAL-AUTHORITY-01", result.Value.ClientId);
+    }
+
+    [Fact]
+    public async Task GetClientByCredentials_ShouldReturnFailure_WhenCredentialsAreInvalid()
+    {
+        // Arrange
+        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
+
+        // Act
+        var result = await _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "WRONG-PASSWORD-XYZ");
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("Unauthorized", result.Error);
+        Assert.Null(result.Value);
+    }
+
+    [Fact]
+    public async Task GetClientByCredentials_ShouldThrowInvalidOperationException_WhenFileHeaderIsMissingMetadata()
+    {
+        // Arrange
+        var badStore = new AuthStore
+        {
+            Issuer = "", // Missing
+            Audience = "some-audience",
+            SigningKey = "some-key",
+            DefaultTokenLifetimeMinutes = 60,
+        };
+        var badJson = JsonSerializer.Serialize(badStore, JsonSerializerOptions.Web);
+
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(badJson);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "SUIProject")
+        );
+
+        Assert.Equal("Auth store file is missing issuer, audience, or signingKey.", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadStore_ShouldThrowInvalidOperationException_WhenFileDoesNotExist()
+    {
+        // Arrange
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(false);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.GetAuthStoreAsync()
+        );
+        Assert.Contains("Auth store file not found at", ex.Message);
+    }
+
+    [Fact]
+    public async Task LoadStore_ShouldThrowInvalidOperationException_WhenJsonIsCorrupt()
+    {
+        // Arrange
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem
+            .File.ReadAllText(Arg.Any<string>())
+            .Returns("{ invalid-json-payload : true ");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<JsonException>(() => _sut.GetAuthStoreAsync());
+    }
+}

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Utility/BuildTimestampUtilityTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Utility/BuildTimestampUtilityTests.cs
@@ -1,0 +1,17 @@
+﻿using Shouldly;
+using SUI.AuthEmulator.Utility;
+using Xunit.Abstractions;
+
+namespace SUI.AuthEmulator.UnitTests.Utility;
+
+public class BuildTimestampUtilityTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void BuildTimestamp_Should_BeAGeneratedDateTime()
+    {
+        testOutputHelper.WriteLine($"BuildTimestamp: {BuildTimestampUtility.BuildTimestamp:O}");
+
+        BuildTimestampUtility.BuildTimestamp.ShouldBeGreaterThan(DateTimeOffset.MinValue);
+        BuildTimestampUtility.BuildTimestamp.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
+    }
+}

--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
@@ -59,7 +59,7 @@ public class MockAuthStoreService : IAuthStoreService
     private AuthStore LoadStore()
     {
         var baseDir = AppContext.BaseDirectory;
-        var filePath = Path.Combine(baseDir, "Data", "auth-clients-inbound.json");
+        var filePath = Path.Join(baseDir, "Data", "auth-clients-inbound.json");
 
         if (!_fileSystem.File.Exists(filePath))
         {

--- a/Apps/StubCustodians/src/SUI.StubCustodians.API/Controllers/HealthController.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.API/Controllers/HealthController.cs
@@ -5,7 +5,8 @@ namespace SUI.StubCustodians.API.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class HealthController(IHostEnvironment env, ILogger<AuthController> logger) : ControllerBase
+public class HealthController(IHostEnvironment env, ILogger<HealthController> logger)
+    : ControllerBase
 {
     private const string ServiceName = nameof(StubCustodians);
 


### PR DESCRIPTION
## Summary

This PR corrects the URLs in the OIDC document returned from the Auth Emulator.

Also contained in this PR are some (!) SonarQube related warning resolutions.

## Changes

* Corrected the URLs in the OIDC document returned from the Auth Emulator.

Also includes:
* sync'd latest changes to `AuthStoreService`, to cache its file contents in memory
* fixed the HealthController's logger to the correct type
* work on test coverage

## Validation 

* PR validation checks
