### PR TITLE
refactor: SUI-1790 - drive AuthSettings via GitHub Environment Secrets

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -216,7 +216,9 @@ jobs:
     # Runner labels from RUNNER_LABELS (JSON array). Default: ubuntu-latest.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-latest"]') }}
     if: needs.eval-workflow-setup.outputs.run_dev == 'true'
-    environment: ${{ inputs.environment || 'd01' }}
+    environment:
+      name: ${{ inputs.environment || 'd01' }}
+      deployment: false
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment || 'd01' }}
     steps:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -241,7 +241,7 @@ jobs:
             --results-directory TestResults \
             -e E2E__BaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}func-${{ steps.env_config.outputs.region_short }}-find01.azurewebsites.net/api/ \
             -e E2E__StubCustodiansBaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-custodians01.azurewebsites.net/api/ \
-            -e E2E__AccessTokenUrl=${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }} \
+            -e E2E__AccessTokenUrl=${{ secrets.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
             -e E2E__AuthEmulatorHealthCheckEndpoint="https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-authemulator01.azurewebsites.net/api/health" \
             -e E2E__SkipResetAzureTables=True \
             -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Build, Test, Deploy: "Custodians" Solution') && github.event.workflow_run.run_started_at || '' }} \

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -225,6 +225,8 @@ jobs:
       - name: Load tfvars for ${{ env.TARGET_ENVIRONMENT }}
         id: env_config
         uses: ./.github/actions/load-tfvars
+        with:
+          environment: ${{ env.TARGET_ENVIRONMENT }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -216,6 +216,7 @@ jobs:
     # Runner labels from RUNNER_LABELS (JSON array). Default: ubuntu-latest.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-latest"]') }}
     if: needs.eval-workflow-setup.outputs.run_dev == 'true'
+    environment: ${{ inputs.environment || 'd01' }}
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment || 'd01' }}
     steps:
@@ -225,8 +226,6 @@ jobs:
       - name: Load tfvars for ${{ env.TARGET_ENVIRONMENT }}
         id: env_config
         uses: ./.github/actions/load-tfvars
-        with:
-          environment: ${{ env.TARGET_ENVIRONMENT }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -242,7 +241,7 @@ jobs:
             --results-directory TestResults \
             -e E2E__BaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}func-${{ steps.env_config.outputs.region_short }}-find01.azurewebsites.net/api/ \
             -e E2E__StubCustodiansBaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-custodians01.azurewebsites.net/api/ \
-            -e E2E__AccessTokenUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-authemulator01.azurewebsites.net/api/v1/auth/token \
+            -e E2E__AccessTokenUrl=${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }} \
             -e E2E__AuthEmulatorHealthCheckEndpoint="https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-authemulator01.azurewebsites.net/api/health" \
             -e E2E__SkipResetAzureTables=True \
             -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Build, Test, Deploy: "Custodians" Solution') && github.event.workflow_run.run_started_at || '' }} \

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -216,6 +216,7 @@ jobs:
     # Runner labels from RUNNER_LABELS (JSON array). Default: ubuntu-latest.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-latest"]') }}
     if: needs.eval-workflow-setup.outputs.run_dev == 'true'
+    environment: ${{ inputs.environment || 'd01' }}
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment || 'd01' }}
     steps:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -216,7 +216,6 @@ jobs:
     # Runner labels from RUNNER_LABELS (JSON array). Default: ubuntu-latest.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-latest"]') }}
     if: needs.eval-workflow-setup.outputs.run_dev == 'true'
-    environment: ${{ inputs.environment || 'd01' }}
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment || 'd01' }}
     steps:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -243,7 +243,7 @@ jobs:
             --results-directory TestResults \
             -e E2E__BaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}func-${{ steps.env_config.outputs.region_short }}-find01.azurewebsites.net/api/ \
             -e E2E__StubCustodiansBaseUrl=https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-custodians01.azurewebsites.net/api/ \
-            -e E2E__AccessTokenUrl=${{ secrets.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
+            -e E2E__AccessTokenUrl=${{ secrets.AUTH_SETTINGS__ACCESS_TOKEN_URL }} \
             -e E2E__AuthEmulatorHealthCheckEndpoint="https://${{ steps.env_config.outputs.subscription_prefix }}${{ steps.env_config.outputs.environment_id }}app-${{ steps.env_config.outputs.region_short }}-authemulator01.azurewebsites.net/api/health" \
             -e E2E__SkipResetAzureTables=True \
             -e E2E__CheckStubCustodiansApiBuildTimestampThreshold=${{ contains(github.event.workflow_run.name, 'Build, Test, Deploy: "Custodians" Solution') && github.event.workflow_run.run_started_at || '' }} \

--- a/.github/workflows/rotate-keyvault-secret.yml
+++ b/.github/workflows/rotate-keyvault-secret.yml
@@ -101,11 +101,11 @@ jobs:
       TF_VAR_nhs_digital_private_key: ${{ secrets.NHS_DIGITAL_PRIVATE_KEY}}
       # The secret below is required for the UI Test Harness, and is transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_ui_test_harness_password: ${{ secrets.UI_TEST_HARNESS_PASSWORD }}
-      # AuthSettings driven by GitHub Environment Variables:
-      TF_VAR_AuthSettings_Issuer: ${{ vars.AUTH_SETTINGS__ISSUER }}
-      TF_VAR_AuthSettings_Audience: ${{ vars.AUTH_SETTINGS__AUDIENCE }}
-      TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
-      TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
+      # Ability to pass sensitive Auth Settings:
+      TF_VAR_AuthSettings_Issuer: ${{ secrets.AUTH_SETTINGS__ISSUER }}
+      TF_VAR_AuthSettings_Audience: ${{ secrets.AUTH_SETTINGS__AUDIENCE }}
+      TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ secrets.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
+      TF_VAR_AuthSettings_AccessTokenUrl: ${{ secrets.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rotate-keyvault-secret.yml
+++ b/.github/workflows/rotate-keyvault-secret.yml
@@ -101,6 +101,11 @@ jobs:
       TF_VAR_nhs_digital_private_key: ${{ secrets.NHS_DIGITAL_PRIVATE_KEY}}
       # The secret below is required for the UI Test Harness, and is transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_ui_test_harness_password: ${{ secrets.UI_TEST_HARNESS_PASSWORD }}
+      # AuthSettings driven by GitHub Environment Variables:
+      TF_VAR_AuthSettings_Issuer: ${{ vars.AUTH_SETTINGS__ISSUER }}
+      TF_VAR_AuthSettings_Audience: ${{ vars.AUTH_SETTINGS__AUDIENCE }}
+      TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
+      TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rotate-keyvault-secret.yml
+++ b/.github/workflows/rotate-keyvault-secret.yml
@@ -101,7 +101,7 @@ jobs:
       TF_VAR_nhs_digital_private_key: ${{ secrets.NHS_DIGITAL_PRIVATE_KEY}}
       # The secret below is required for the UI Test Harness, and is transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_ui_test_harness_password: ${{ secrets.UI_TEST_HARNESS_PASSWORD }}
-      # Ability to pass sensitive Auth Settings:
+      # Ability to pass sensitive Auth Settings (these values can be checked for debugging purposes by looking at the app settings in the Azure Portal):
       TF_VAR_AuthSettings_Issuer: ${{ secrets.AUTH_SETTINGS__ISSUER }}
       TF_VAR_AuthSettings_Audience: ${{ secrets.AUTH_SETTINGS__AUDIENCE }}
       TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ secrets.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -35,6 +35,15 @@ on:
       # Secret that grants end-users access to the deployed UI Test Harness
       UI_TEST_HARNESS_PASSWORD:
         required: false
+      # Ability to pass sensitive Auth Settings:
+      AUTH_SETTINGS__ISSUER:
+        required: false
+      AUTH_SETTINGS__AUDIENCE:
+        required: false
+      AUTH_SETTINGS__OIDC_DISCOVERY_URL:
+        required: false
+      AUTH_SETTINGS__ACCESS_TOKEN_URL:
+        required: false
 
 permissions:
   id-token: write
@@ -56,20 +65,13 @@ jobs:
       TF_VAR_nhs_digital_private_key: ${{ secrets.NHS_DIGITAL_PRIVATE_KEY}}
       # The secret below is required for the UI Test Harness, and is transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_ui_test_harness_password: ${{ secrets.UI_TEST_HARNESS_PASSWORD }}
-      # AuthSettings driven by GitHub Environment Variables:
-      TF_VAR_AuthSettings_Issuer: ${{ vars.AUTH_SETTINGS__ISSUER }}
-      TF_VAR_AuthSettings_Audience: ${{ vars.AUTH_SETTINGS__AUDIENCE }}
-      TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
-      TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
+      # Ability to pass sensitive Auth Settings:
+      TF_VAR_AuthSettings_Issuer: ${{ secrets.AUTH_SETTINGS__ISSUER }}
+      TF_VAR_AuthSettings_Audience: ${{ secrets.AUTH_SETTINGS__AUDIENCE }}
+      TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ secrets.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
+      TF_VAR_AuthSettings_AccessTokenUrl: ${{ secrets.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
-      - name: Mask environment variables which should be hidden
-        run: |
-          echo "::add-mask::${{ vars.AUTH_SETTINGS__ISSUER }}"
-          echo "::add-mask::${{ vars.AUTH_SETTINGS__AUDIENCE }}"
-          echo "::add-mask::${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}"
-          echo "::add-mask::${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}"
-
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -56,6 +56,11 @@ jobs:
       TF_VAR_nhs_digital_private_key: ${{ secrets.NHS_DIGITAL_PRIVATE_KEY}}
       # The secret below is required for the UI Test Harness, and is transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_ui_test_harness_password: ${{ secrets.UI_TEST_HARNESS_PASSWORD }}
+      # AuthSettings driven by GitHub Environment Variables:
+      TF_VAR_AuthSettings_Issuer: ${{ vars.AUTH_SETTINGS__ISSUER }}
+      TF_VAR_AuthSettings_Audience: ${{ vars.AUTH_SETTINGS__AUDIENCE }}
+      TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
+      TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -63,12 +63,12 @@ jobs:
       TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
-      - name: Mask environment variables which should be hidden
+      - name: Mask environment variables which should be hidden from public view
         run: |
-          echo "::add-mask::${{ vars.AUTH_SETTINGS__ISSUER }}"
-          echo "::add-mask::${{ vars.AUTH_SETTINGS__AUDIENCE }}"
-          echo "::add-mask::${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}"
-          echo "::add-mask::${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}"
+          echo "::add-mask::$TF_VAR_AuthSettings_Issuer"
+          echo "::add-mask::$TF_VAR_AuthSettings_Audience"
+          echo "::add-mask::$TF_VAR_AuthSettings_OidcDiscoveryUrl"
+          echo "::add-mask::$TF_VAR_AuthSettings_AccessTokenUrl"
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -57,18 +57,23 @@ jobs:
       # The secret below is required for the UI Test Harness, and is transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_ui_test_harness_password: ${{ secrets.UI_TEST_HARNESS_PASSWORD }}
       # AuthSettings driven by GitHub Environment Variables:
-      TF_VAR_AuthSettings_Issuer: ${{ vars.AUTH_SETTINGS__ISSUER }}
       TF_VAR_AuthSettings_Audience: ${{ vars.AUTH_SETTINGS__AUDIENCE }}
       TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
       TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
-      - name: Mask environment variables which should be hidden from public view
+      - name: Fetch and mask config which should be hidden from public view
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          TF_VAR_AuthSettings_Issuer=$(gh api /repos/${{ github.repository }}/environments/${{ env.TARGET_ENVIRONMENT }}/variables/AUTH_SETTINGS__ISSUER --jq '.value')
+
           echo "::add-mask::$TF_VAR_AuthSettings_Issuer"
           echo "::add-mask::$TF_VAR_AuthSettings_Audience"
           echo "::add-mask::$TF_VAR_AuthSettings_OidcDiscoveryUrl"
           echo "::add-mask::$TF_VAR_AuthSettings_AccessTokenUrl"
+
+          echo "TF_VAR_AuthSettings_Issuer=$TF_VAR_AuthSettings_Issuer" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -87,7 +92,7 @@ jobs:
             curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           fi
 
-      - name: Azure login with OIDC for ${{ inputs.environment }}
+      - name: Azure login with OIDC for ${{ env.TARGET_ENVIRONMENT }}
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -63,6 +63,13 @@ jobs:
       TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
+      - name: Mask environment variables which should be hidden
+        run: |
+          echo "::add-mask::${{ vars.AUTH_SETTINGS__ISSUER }}"
+          echo "::add-mask::${{ vars.AUTH_SETTINGS__AUDIENCE }}"
+          echo "::add-mask::${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}"
+          echo "::add-mask::${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}"
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -63,12 +63,12 @@ jobs:
       TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
-      - name: Mask environment variables which should be hidden from public view
+      - name: Mask environment variables which should be hidden
         run: |
-          echo "::add-mask::$TF_VAR_AuthSettings_Issuer"
-          echo "::add-mask::$TF_VAR_AuthSettings_Audience"
-          echo "::add-mask::$TF_VAR_AuthSettings_OidcDiscoveryUrl"
-          echo "::add-mask::$TF_VAR_AuthSettings_AccessTokenUrl"
+          echo "::add-mask::${{ vars.AUTH_SETTINGS__ISSUER }}"
+          echo "::add-mask::${{ vars.AUTH_SETTINGS__AUDIENCE }}"
+          echo "::add-mask::${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}"
+          echo "::add-mask::${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}"
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -65,7 +65,7 @@ jobs:
       TF_VAR_nhs_digital_private_key: ${{ secrets.NHS_DIGITAL_PRIVATE_KEY}}
       # The secret below is required for the UI Test Harness, and is transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_ui_test_harness_password: ${{ secrets.UI_TEST_HARNESS_PASSWORD }}
-      # Ability to pass sensitive Auth Settings:
+      # Ability to pass sensitive Auth Settings (these values can be checked for debugging purposes by looking at the app settings in the Azure Portal):
       TF_VAR_AuthSettings_Issuer: ${{ secrets.AUTH_SETTINGS__ISSUER }}
       TF_VAR_AuthSettings_Audience: ${{ secrets.AUTH_SETTINGS__AUDIENCE }}
       TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ secrets.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -57,23 +57,18 @@ jobs:
       # The secret below is required for the UI Test Harness, and is transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_ui_test_harness_password: ${{ secrets.UI_TEST_HARNESS_PASSWORD }}
       # AuthSettings driven by GitHub Environment Variables:
+      TF_VAR_AuthSettings_Issuer: ${{ vars.AUTH_SETTINGS__ISSUER }}
       TF_VAR_AuthSettings_Audience: ${{ vars.AUTH_SETTINGS__AUDIENCE }}
       TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ vars.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
       TF_VAR_AuthSettings_AccessTokenUrl: ${{ vars.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
 
     steps:
-      - name: Fetch and mask config which should be hidden from public view
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Mask environment variables which should be hidden from public view
         run: |
-          TF_VAR_AuthSettings_Issuer=$(gh api /repos/${{ github.repository }}/environments/${{ env.TARGET_ENVIRONMENT }}/variables/AUTH_SETTINGS__ISSUER --jq '.value')
-
           echo "::add-mask::$TF_VAR_AuthSettings_Issuer"
           echo "::add-mask::$TF_VAR_AuthSettings_Audience"
           echo "::add-mask::$TF_VAR_AuthSettings_OidcDiscoveryUrl"
           echo "::add-mask::$TF_VAR_AuthSettings_AccessTokenUrl"
-
-          echo "TF_VAR_AuthSettings_Issuer=$TF_VAR_AuthSettings_Issuer" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -92,7 +87,7 @@ jobs:
             curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           fi
 
-      - name: Azure login with OIDC for ${{ env.TARGET_ENVIRONMENT }}
+      - name: Azure login with OIDC for ${{ inputs.environment }}
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/appsettings.json
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/appsettings.json
@@ -8,6 +8,7 @@
   "AllowedHosts": "*",
   "AuthSettings": {
     "Issuer": "https://sandbox.api.example.gov.uk/sui-find-a-record/auth",
+    "Audience": "sui-find-a-record-api",
     "BaseUrl": "https://localhost:7250"
   }
 }

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -179,7 +179,9 @@ public class FunctionTestFixture : IAsyncLifetime
     {
         var waitInterval = TimeSpan.FromSeconds(10);
 
-        testOutputHelper.WriteLine($"Checking {serviceName} is up: {client.BaseAddress}{url}");
+        testOutputHelper.WriteLine(
+            $"Checking {serviceName} is up: {(url.StartsWith("http") ? url : client.BaseAddress + url)}"
+        );
 
         var useExtendedTimeout = checkBuildTimestampThreshold != null;
         var timeout = useExtendedTimeout ? TimeSpan.FromMinutes(10) : TimeSpan.FromSeconds(60);

--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ Productionisation should include:
 * Review all occurrences of `#trivy:ignore`. They must be removed and resolved correctly, prior to handling any real data.
 
 
+## Development Environments
+
+| Environment ID | Purpose                                                                                                                                                                | Trigger                                                                                            |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `d01`          | **Primary development environment**. Used by the engineering team to test and verify changes. Possibly may contain broken functionality, although that is undesirable. | **Automatically trigerred deployments** (from changes to `main`).                                  |
+| `d02`          | **Demo environment**. Stable environment that should not contain broken functionality. Used in presentations and in research sessions.                                 | **Manually trigerred deployments**. Deployments must be scheduled and coordinated with whole team. |
+| `d03`          | **Sandbox environment**. Used for trialling potential changes and configurations, for example trialling integrating with FaUAPI.                                       | **Manually trigerred deployments**                                                                 |
+
+
 ## Getting Started
 
 ### Prerequisites

--- a/terraform/auth-emulator/main.tf
+++ b/terraform/auth-emulator/main.tf
@@ -48,8 +48,11 @@ module "web_app" {
       APPLICATIONINSIGHTS_CONNECTION_STRING = data.terraform_remote_state.core.outputs.app_insights_connection_string
       OTEL_RESOURCE_ATTRIBUTES = local.otel_resource_attributes
 
+      AuthSettings__Issuer   = var.AuthSettings_Issuer
+      AuthSettings__Audience = var.AuthSettings_Audience
+
       # Map the environment's dynamic base URL down to the Auth Emulator config
-      AuthSettings__BaseUrl                  = format("https://%s%sapp-%s-authemulator01.azurewebsites.net/", var.subscription_prefix, var.environment_id, var.region_short)
+      AuthSettings__BaseUrl = format("https://%s%sapp-%s-authemulator01.azurewebsites.net/", var.subscription_prefix, var.environment_id, var.region_short)
     },
     var.authemulator_app_settings,
   )

--- a/terraform/auth-emulator/variables.tf
+++ b/terraform/auth-emulator/variables.tf
@@ -79,3 +79,13 @@ variable "use_auth_emulator" {
   type        = bool
   default     = false
 }
+
+variable "AuthSettings_Issuer" {
+  description = "The OAuth Issuer to use when signing access tokens"
+  type        = string
+}
+
+variable "AuthSettings_Audience" {
+  description = "The OAuth Audience to use when signing access tokens"
+  type        = string
+}

--- a/terraform/auth-emulator/variables.tf
+++ b/terraform/auth-emulator/variables.tf
@@ -83,9 +83,11 @@ variable "use_auth_emulator" {
 variable "AuthSettings_Issuer" {
   description = "The OAuth Issuer to use when signing access tokens"
   type        = string
+  sensitive   = true
 }
 
 variable "AuthSettings_Audience" {
   description = "The OAuth Audience to use when signing access tokens"
   type        = string
+  sensitive   = true
 }

--- a/terraform/custodians/main.tf
+++ b/terraform/custodians/main.tf
@@ -47,7 +47,7 @@ module "web_app" {
     {
       APPLICATIONINSIGHTS_CONNECTION_STRING = data.terraform_remote_state.core.outputs.app_insights_connection_string
       OTEL_RESOURCE_ATTRIBUTES = local.otel_resource_attributes
-      AuthSettings__AccessTokenUrl = format("https://%s%sapp-%s-authemulator01.azurewebsites.net/api/v1/auth/token", var.subscription_prefix, var.environment_id, var.region_short)
+      AuthSettings__AccessTokenUrl = var.AuthSettings_AccessTokenUrl
       FindApi__BaseUrl = format("https://%s%sfunc-%s-find01.azurewebsites.net", var.subscription_prefix, var.environment_id, var.region_short)
       StubCustodians__BaseUrl = format("https://%s%sapp-%s-custodians01.azurewebsites.net", var.subscription_prefix, var.environment_id, var.region_short)
     },

--- a/terraform/custodians/variables.tf
+++ b/terraform/custodians/variables.tf
@@ -79,3 +79,8 @@ variable "use_stub_custodians" {
   type        = bool
   default     = false
 }
+
+variable "AuthSettings_AccessTokenUrl" {
+  description = "Inbound Access Token URL (to be able to request tokens to use the Find API)"
+  type        = string
+}

--- a/terraform/custodians/variables.tf
+++ b/terraform/custodians/variables.tf
@@ -83,4 +83,5 @@ variable "use_stub_custodians" {
 variable "AuthSettings_AccessTokenUrl" {
   description = "Inbound Access Token URL (to be able to request tokens to use the Find API)"
   type        = string
+  sensitive   = true
 }

--- a/terraform/environments/d01.tfvars
+++ b/terraform/environments/d01.tfvars
@@ -23,9 +23,6 @@ find_app_settings = {
   NhsAuthConfig__NHS_DIGITAL_TOKEN_URL                       = "https://int.api.service.nhs.uk/oauth2/token"
   NhsAuthConfig__NHS_DIGITAL_FHIR_ENDPOINT                   = "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/"
   NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
-  AuthSettings__Issuer           = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth"
-  AuthSettings__Audience         = "sui-find-a-record-api"
-  AuthSettings__OidcDiscoveryUrl = "https://s270d01app-ukw-authemulator01.azurewebsites.net/api/v1/.well-known/openid-configuration"
 }
 
 custodian_app_settings = {

--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -23,9 +23,6 @@ find_app_settings = {
   NhsAuthConfig__NHS_DIGITAL_TOKEN_URL                       = "https://int.api.service.nhs.uk/oauth2/token"
   NhsAuthConfig__NHS_DIGITAL_FHIR_ENDPOINT                   = "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/"
   NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
-  AuthSettings__Issuer           = "https://sandbox.api.example.gov.uk/sui-find-a-record/auth"
-  AuthSettings__Audience         = "sui-find-a-record-api"
-  AuthSettings__OidcDiscoveryUrl = "https://s270d02app-ukw-authemulator01.azurewebsites.net/api/v1/.well-known/openid-configuration"
 }
 
 custodian_app_settings = {

--- a/terraform/find/main.tf
+++ b/terraform/find/main.tf
@@ -210,8 +210,12 @@ module "function_app" {
           ? format("https://%s%sapp-%s-custodians01.azurewebsites.net", var.subscription_prefix, var.environment_id, var.region_short)
           : null
       )
-      
-      AuthSettings__AccessTokenUrl           = format("https://%s%sapp-%s-authemulator01.azurewebsites.net/api/v1/auth/token", var.subscription_prefix, var.environment_id, var.region_short)
+
+      AuthSettings__Issuer           = var.AuthSettings_Issuer
+      AuthSettings__Audience         = var.AuthSettings_Audience
+      AuthSettings__OidcDiscoveryUrl = var.AuthSettings_OidcDiscoveryUrl
+      AuthSettings__AccessTokenUrl   = var.AuthSettings_AccessTokenUrl
+
       MatchFunction__XApiKey                 = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.find_match_api_key.name}/)"
       NhsAuthConfig__NHS_DIGITAL_PRIVATE_KEY = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_private_key.name}/)"
       NhsAuthConfig__NHS_DIGITAL_KID         = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_kid.name}/)"

--- a/terraform/find/variables.tf
+++ b/terraform/find/variables.tf
@@ -120,3 +120,23 @@ variable "nhs_digital_client_id" {
   type = string
   sensitive = true
 }
+
+variable "AuthSettings_Issuer" {
+  description = "The expected OAuth Issuer of authentic access tokens"
+  type        = string
+}
+
+variable "AuthSettings_Audience" {
+  description = "The expected OAuth Audience of authentic access tokens"
+  type        = string
+}
+
+variable "AuthSettings_OidcDiscoveryUrl" {
+  description = "The URL to discover the OpenID Connect configuration of the Issuer of authentic access tokens"
+  type        = string
+}
+
+variable "AuthSettings_AccessTokenUrl" {
+  description = "Inbound Access Token URL (to be able to request tokens to use the Find API)"
+  type        = string
+}

--- a/terraform/find/variables.tf
+++ b/terraform/find/variables.tf
@@ -124,19 +124,23 @@ variable "nhs_digital_client_id" {
 variable "AuthSettings_Issuer" {
   description = "The expected OAuth Issuer of authentic access tokens"
   type        = string
+  sensitive   = true
 }
 
 variable "AuthSettings_Audience" {
   description = "The expected OAuth Audience of authentic access tokens"
   type        = string
+  sensitive   = true
 }
 
 variable "AuthSettings_OidcDiscoveryUrl" {
   description = "The URL to discover the OpenID Connect configuration of the Issuer of authentic access tokens"
   type        = string
+  sensitive   = true
 }
 
 variable "AuthSettings_AccessTokenUrl" {
   description = "Inbound Access Token URL (to be able to request tokens to use the Find API)"
   type        = string
+  sensitive   = true
 }

--- a/terraform/ui_test_harness/main.tf
+++ b/terraform/ui_test_harness/main.tf
@@ -124,7 +124,8 @@ module "web_app" {
       OTEL_RESOURCE_ATTRIBUTES              = local.otel_resource_attributes
 
       BaseUrl = format("https://%s%sfunc-%s-find01.azurewebsites.net/", var.subscription_prefix, var.environment_id, var.region_short)
-      AuthSettings__AccessTokenUrl = format("https://%s%sapp-%s-authemulator01.azurewebsites.net/api/v1/auth/token", var.subscription_prefix, var.environment_id, var.region_short)
+
+      AuthSettings__AccessTokenUrl = var.AuthSettings_AccessTokenUrl
 
       # Key Vault References mapped to App Settings
       UI_TEST_HARNESS_PASSWORD = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.ui_harness_password.name}/)"

--- a/terraform/ui_test_harness/variables.tf
+++ b/terraform/ui_test_harness/variables.tf
@@ -85,3 +85,8 @@ variable "ui_test_harness_password" {
   type        = string
   sensitive   = true
 }
+
+variable "AuthSettings_AccessTokenUrl" {
+  description = "Inbound Access Token URL (to be able to request tokens to use the Find API)"
+  type        = string
+}

--- a/terraform/ui_test_harness/variables.tf
+++ b/terraform/ui_test_harness/variables.tf
@@ -89,4 +89,5 @@ variable "ui_test_harness_password" {
 variable "AuthSettings_AccessTokenUrl" {
   description = "Inbound Access Token URL (to be able to request tokens to use the Find API)"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
## Summary

This PR updates the AuthSettings to be driven via GitHub Environment Secrets, so that the values used in the infrastructure are hidden from the public repository, and so that the values can be different to enable integrating with real identity providers, for example FaUAPI.

## Changes

* Updated the GitHub Workflows to pass the AuthSettings from GitHub Environment Secrets to the Terraform.
* Also updated `Apps/AuthEmulator/src/SUI.AuthEmulator/appsettings.json` to include the default `Audience`.  This has no functional change, it just standardises the approach to match the other config values.
* Also includes minor fix in the e2e FunctionTestFixture: if the URL is rooted, only log the URL because the base address won't be used in that case.
* Also includes small update to main readme: added overview of each Development Environment.

## Validation

- IDE linting
- E2E test run verifications
- Terraform plans, to show the expected changes:
    - `Find` and `AuthEmulator` apps show that the only changes are the `AuthSettings__Issuer` and `AuthSettings__Audience` (because these values are now infrastructure specific, are hidden from the public code by coming from GitHub Env Vars)
    - `StubCustodians` and `UITestHarness` show no changes
