### PR TITLE
refactor: sui-1780 - Remove Inbound Symmetric Key & verification logic

### DIFF
--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Models/AuthStore.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Models/AuthStore.cs
@@ -2,9 +2,5 @@ namespace SUI.AuthEmulator.Models;
 
 public class AuthStore
 {
-    public string Issuer { get; init; } = string.Empty;
-    public string Audience { get; init; } = string.Empty;
-    public string SigningKey { get; init; } = string.Empty;
-    public required int DefaultTokenLifetimeMinutes { get; init; } = 60;
     public List<AuthClient>? Clients { get; set; }
 }

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/IAuthStoreService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/IAuthStoreService.cs
@@ -4,6 +4,5 @@ namespace SUI.AuthEmulator.Services;
 
 public interface IAuthStoreService
 {
-    Task<AuthStore> GetAuthStoreAsync();
     Task<Result<AuthClient>> GetClientByCredentials(string clientId, string clientSecret);
 }

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
@@ -25,17 +25,6 @@ public class MockAuthStoreService : IAuthStoreService
     {
         var store = _authStore.Value;
 
-        if (
-            string.IsNullOrWhiteSpace(store.Issuer)
-            || string.IsNullOrWhiteSpace(store.Audience)
-            || string.IsNullOrWhiteSpace(store.SigningKey)
-        )
-        {
-            throw new InvalidOperationException(
-                "Auth store file is missing issuer, audience, or signingKey."
-            );
-        }
-
         store.Clients ??= [];
 
         var client = store.Clients.FirstOrDefault(c =>

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
@@ -15,12 +15,6 @@ public class MockAuthStoreService : IAuthStoreService
         _authStore = new Lazy<AuthStore>(LoadStore);
     }
 
-    public Task<AuthStore> GetAuthStoreAsync()
-    {
-        // Instantly returns the cached in-memory store as a completed Task
-        return Task.FromResult(_authStore.Value);
-    }
-
     public Task<Result<AuthClient>> GetClientByCredentials(string clientId, string clientSecret)
     {
         var store = _authStore.Value;

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -35,12 +35,6 @@ public class MockAuthStoreServiceTests
 
         // Assert
         Assert.NotNull(store);
-        Assert.Equal("https://sandbox.api.example.gov.uk/find-a-record/auth", store.Issuer);
-        Assert.Equal("find-a-record-api", store.Audience);
-        Assert.Equal(
-            "Wc8Kq1ZyR4hNfD0uVx3mS9JpA6eLrT2bG7wQvY5sCjP8kF1nH0tUoMzBiXaEdRl",
-            store.SigningKey
-        );
         Assert.NotNull(store.Clients);
         Assert.NotEmpty(store.Clients);
 
@@ -84,30 +78,6 @@ public class MockAuthStoreServiceTests
         Assert.False(result.Success);
         Assert.Equal("Unauthorized", result.Error);
         Assert.Null(result.Value);
-    }
-
-    [Fact]
-    public async Task GetClientByCredentials_ShouldThrowInvalidOperationException_WhenFileHeaderIsMissingMetadata()
-    {
-        // Arrange
-        var badStore = new AuthStore
-        {
-            Issuer = "", // Missing
-            Audience = "some-audience",
-            SigningKey = "some-key",
-            DefaultTokenLifetimeMinutes = 60,
-        };
-        var badJson = JsonSerializer.Serialize(badStore, JsonSerializerOptions.Web);
-
-        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
-        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(badJson);
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "SUIProject")
-        );
-
-        Assert.Equal("Auth store file is missing issuer, audience, or signingKey.", ex.Message);
     }
 
     [Fact]

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -23,30 +23,6 @@ public class MockAuthStoreServiceTests
     }
 
     [Fact]
-    public async Task GetAuthStoreAsync_MapsJsonToStoreDefinitionCorrectly()
-    {
-        // Arrange
-        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
-        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
-        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
-
-        // Act
-        var store = await _sut.GetAuthStoreAsync();
-
-        // Assert
-        Assert.NotNull(store);
-        Assert.NotNull(store.Clients);
-        Assert.NotEmpty(store.Clients);
-
-        // Verify structure of an active client
-        var sampleClient = store.Clients.FirstOrDefault(c => c.ClientId == "LOCAL-AUTHORITY-01");
-        Assert.NotNull(sampleClient);
-        Assert.True(sampleClient.Enabled);
-        Assert.Equal("SUIProject", sampleClient.ClientSecret);
-        Assert.Contains("match-record.read", sampleClient.AllowedScopes!);
-    }
-
-    [Fact]
     public async Task GetClientByCredentials_ShouldReturnClient_WhenIdAndSecretMatch()
     {
         // Arrange
@@ -78,31 +54,5 @@ public class MockAuthStoreServiceTests
         Assert.False(result.Success);
         Assert.Equal("Unauthorized", result.Error);
         Assert.Null(result.Value);
-    }
-
-    [Fact]
-    public async Task LoadStore_ShouldThrowInvalidOperationException_WhenFileDoesNotExist()
-    {
-        // Arrange
-        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(false);
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _sut.GetAuthStoreAsync()
-        );
-        Assert.Contains("Auth store file not found at", ex.Message);
-    }
-
-    [Fact]
-    public async Task LoadStore_ShouldThrowInvalidOperationException_WhenJsonIsCorrupt()
-    {
-        // Arrange
-        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
-        _mockFileSystem
-            .File.ReadAllText(Arg.Any<string>())
-            .Returns("{ invalid-json-payload : true ");
-
-        // Act & Assert
-        await Assert.ThrowsAsync<JsonException>(() => _sut.GetAuthStoreAsync());
     }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
@@ -1,7 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Reflection;
-using System.Text;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
 using Microsoft.Extensions.Logging;
@@ -14,19 +13,16 @@ using SUI.Find.FindApi.Attributes;
 using SUI.Find.FindApi.Configurations;
 using SUI.Find.FindApi.Models;
 using SUI.Find.FindApi.Utility;
-using SUI.Find.Infrastructure.Services;
 
 namespace SUI.Find.FindApi.Middleware;
 
 public class JwtAuthMiddleware(
-    IAuthStoreService authStoreService,
     IAuthContextFactory authContextFactory,
     IConfigurationManager<OpenIdConnectConfiguration> oidcConfigManager,
     IOptions<AuthSettings> authSettings,
     ILogger<JwtAuthMiddleware> logger
 ) : IFunctionsWorkerMiddleware
 {
-    // One concrete handler with no interfaces, no injection mocks.
     private static readonly JwtSecurityTokenHandler TokenHandler = new();
 
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
@@ -76,51 +72,19 @@ public class JwtAuthMiddleware(
 
         var token = bearer["Bearer ".Length..].Trim();
 
-        var store = await authStoreService.GetAuthStoreAsync();
         JwtSecurityToken jwt;
 
         try
         {
+            // Read the unverified token for passing into ValidateAsymmetricTokenAsync for the OIDC refresh logic.
             var unverifiedToken = TokenHandler.ReadJwtToken(token);
-            var algorithm = unverifiedToken.Header.Alg;
-            SecurityToken validatedToken;
 
-            if (algorithm == SecurityAlgorithms.RsaSha256)
-            {
-                validatedToken = await ValidateAsymmetricTokenAsync(
-                    token,
-                    unverifiedToken,
-                    context.CancellationToken
-                );
-            }
-            else if (algorithm == SecurityAlgorithms.HmacSha256)
-            {
-                var validationParameters = new TokenValidationParameters
-                {
-                    ValidateIssuer = true,
-                    ValidIssuer = store.Issuer,
-                    ValidateAudience = true,
-                    ValidAudience = store.Audience,
-                    ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(
-                        Encoding.UTF8.GetBytes(store.SigningKey)
-                    ),
-                    ValidateLifetime = true,
-                };
-
-                // Uses the concrete .NET framework validation engine directly
-                TokenHandler.ValidateToken(token, validationParameters, out validatedToken);
-            }
-            else
-            {
-                context.GetInvocationResult().Value = await HttpResponseUtility.ProblemResponse(
-                    req,
-                    HttpStatusCode.Unauthorized,
-                    nameof(HttpStatusCode.Unauthorized),
-                    $"Unsupported signing algorithm '{algorithm}'."
-                );
-                return;
-            }
+            // The underlying TokenHandler will only accept RSA.
+            var validatedToken = await ValidateAsymmetricTokenAsync(
+                token,
+                unverifiedToken,
+                context.CancellationToken
+            );
 
             jwt = (JwtSecurityToken)validatedToken;
         }

--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/JwtAuthMiddleware.cs
@@ -204,10 +204,13 @@ public class JwtAuthMiddleware(
             return [];
         }
 
+        // It is safe to bypass accessibility here because we are only reading attributes for authorization, not invoking the method.
+#pragma warning disable S3011
         var method = type.GetMethod(
             methodName,
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
         );
+#pragma warning restore S3011
         if (method is null)
         {
             return [];

--- a/Apps/Find/src/SUI.Find.Infrastructure/Models/AuthStore.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Models/AuthStore.cs
@@ -2,9 +2,5 @@ namespace SUI.Find.Infrastructure.Models;
 
 public class AuthStore
 {
-    public string Issuer { get; init; } = string.Empty;
-    public string Audience { get; init; } = string.Empty;
-    public string SigningKey { get; init; } = string.Empty;
-    public required int DefaultTokenLifetimeMinutes { get; init; } = 60;
     public List<AuthClient>? Clients { get; set; }
 }

--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
@@ -44,17 +44,6 @@ public class MockAuthStoreService : IAuthStoreService
     {
         var store = _authStore.Value;
 
-        if (
-            string.IsNullOrWhiteSpace(store.Issuer)
-            || string.IsNullOrWhiteSpace(store.Audience)
-            || string.IsNullOrWhiteSpace(store.SigningKey)
-        )
-        {
-            throw new InvalidOperationException(
-                "Auth store file is missing issuer, audience, or signingKey."
-            );
-        }
-
         var client = store.Clients?.FirstOrDefault(x => x.ClientId == clientId);
 
         return client

--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
@@ -6,7 +6,6 @@ namespace SUI.Find.Infrastructure.Services;
 
 public interface IAuthStoreService
 {
-    Task<AuthStore> GetAuthStoreAsync();
     IReadOnlyList<string> GetScopesByClientId(string clientId);
     string GetOrganisationIdForClientId(string clientId);
 }
@@ -20,12 +19,6 @@ public class MockAuthStoreService : IAuthStoreService
     {
         _fileSystem = fileSystem;
         _authStore = new Lazy<AuthStore>(LoadStore);
-    }
-
-    public Task<AuthStore> GetAuthStoreAsync()
-    {
-        // Instantly returns the cached in-memory store as a completed Task
-        return Task.FromResult(_authStore.Value);
     }
 
     public IReadOnlyList<string> GetScopesByClientId(string clientId)

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -3,7 +3,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Security.Claims;
 using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -17,14 +16,11 @@ using SUI.Find.Application.Constants;
 using SUI.Find.FindApi.Configurations;
 using SUI.Find.FindApi.Middleware;
 using SUI.Find.FindApi.Models;
-using SUI.Find.Infrastructure.Models;
-using SUI.Find.Infrastructure.Services;
 
 namespace SUI.Find.FindApi.UnitTests.MiddlewareTests;
 
 public class JwtAuthMiddlewareTests
 {
-    private readonly IAuthStoreService _mockAuthStore = Substitute.For<IAuthStoreService>();
     private readonly IAuthContextFactory _mockAuthContextFactory =
         Substitute.For<IAuthContextFactory>();
     private readonly IConfigurationManager<OpenIdConnectConfiguration> _mockConfigManager =
@@ -47,6 +43,7 @@ public class JwtAuthMiddlewareTests
         {
             Issuer = "https://sandbox.api.example.gov.uk/find-a-record/auth",
             Audience = "sui-find-a-record-api",
+            UseAuthStoreForAuthorisation = false, // Explicitly set for mocked AuthContextFactory predictability
         };
         _mockOptions.Value.Returns(_authSettings);
     }
@@ -103,27 +100,7 @@ public class JwtAuthMiddlewareTests
         }
     }
 
-    private static string GenerateSymmetricToken(
-        string issuer,
-        string audience,
-        string signingKey,
-        string clientId,
-        string scope = "fetch-record.read"
-    )
-    {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
-        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-        var claims = new[] { new Claim("client_id", clientId), new Claim("scp", scope) };
-
-        var token = new JwtSecurityToken(
-            issuer,
-            audience,
-            claims,
-            expires: DateTime.UtcNow.AddMinutes(30),
-            signingCredentials: credentials
-        );
-        return new JwtSecurityTokenHandler().WriteToken(token);
-    }
+    // REMOVED: GenerateSymmetricToken Helper
 
     private string GenerateAsymmetricToken(
         RSA rsaKey,
@@ -261,7 +238,6 @@ public class JwtAuthMiddlewareTests
             var req = await context.GetHttpRequestDataAsync();
             req!.Url.Returns(new Uri("https://mock.gov.uk/api/" + endpoint));
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -273,7 +249,6 @@ public class JwtAuthMiddlewareTests
 
             // Assert
             Assert.True(_nextExecuted);
-            await _mockAuthStore.DidNotReceive().GetAuthStoreAsync();
         }
 
         [Fact]
@@ -282,7 +257,6 @@ public class JwtAuthMiddlewareTests
             // Arrange
             var context = CreateMockFunctionContext(null);
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -302,7 +276,6 @@ public class JwtAuthMiddlewareTests
             // Arrange
             var context = CreateMockFunctionContext("Invalid");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -319,122 +292,9 @@ public class JwtAuthMiddlewareTests
             );
             AssertAccessDenied(context, "Invalid Authorization header");
         }
-
-        [Fact]
-        public async Task TestInvoke_Handles_UnsupportedSigningAlgorithms()
-        {
-            // Arrange
-            var store = new AuthStore
-            {
-                Audience = "Audience",
-                Issuer = "Issuer",
-                SigningKey = "SecretKeyShouldBeLongEnoughToPass12345!",
-                DefaultTokenLifetimeMinutes = 60,
-            };
-            _mockAuthStore.GetAuthStoreAsync().Returns(store);
-            var context = CreateMockFunctionContext(
-                "Bearer eyJobGciOiJIUzI1NiJ9.eyJpc3MiOiJJc3N1ZXIifQ.badsignature"
-            );
-            var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
-                _mockAuthContextFactory,
-                _mockConfigManager,
-                _mockOptions,
-                _mockLogger
-            );
-
-            // Act
-            await sut.Invoke(context, Next);
-
-            // Assert
-            Assert.Equal(
-                HttpStatusCode.Unauthorized,
-                ((HttpResponseData)context.GetInvocationResult().Value!).StatusCode
-            );
-            AssertAccessDenied(context, "Unsupported signing algorithm");
-        }
     }
 
-    public class SymmetricVerificationTests : JwtAuthMiddlewareTests
-    {
-        [Fact]
-        public async Task TestInvoke_WhenScopesIncorrect_ReturnsProblemResponse()
-        {
-            // Arrange
-            var store = new AuthStore
-            {
-                Audience = "Audience",
-                Issuer = "Issuer",
-                SigningKey = "SecretKeyShouldBeLongEnoughToPass12345!",
-                DefaultTokenLifetimeMinutes = 60,
-            };
-            _mockAuthStore.GetAuthStoreAsync().Returns(store);
-            var token = GenerateSymmetricToken(
-                store.Issuer,
-                store.Audience,
-                store.SigningKey,
-                "clientId",
-                "wrong.scope"
-            );
-            var context = CreateMockFunctionContext($"Bearer {token}");
-
-            _mockAuthContextFactory
-                .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<bool>())
-                .Returns(new AuthContext("clientId", "organisationId", ["wrong.scope"]));
-            var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
-                _mockAuthContextFactory,
-                _mockConfigManager,
-                _mockOptions,
-                _mockLogger
-            );
-
-            // Act
-            await sut.Invoke(context, Next);
-
-            // Assert
-            AssertAccessDenied(context, "Insufficient scope for this operation");
-        }
-
-        [Fact]
-        public async Task TestInvoke_WithValidInputs_ReturnsAuthContext()
-        {
-            // Arrange
-            var store = new AuthStore
-            {
-                Audience = "Audience",
-                Issuer = "Issuer",
-                SigningKey = "SecretKeyShouldBeLongEnoughToPass12345!",
-                DefaultTokenLifetimeMinutes = 60,
-            };
-            _mockAuthStore.GetAuthStoreAsync().Returns(store);
-            var token = GenerateSymmetricToken(
-                store.Issuer,
-                store.Audience,
-                store.SigningKey,
-                "clientId"
-            );
-            var context = CreateMockFunctionContext($"Bearer {token}");
-
-            var authContext = new AuthContext("clientId", "organisationId", ["fetch-record.read"]);
-            _mockAuthContextFactory
-                .FromJwt(Arg.Any<JwtSecurityToken>(), Arg.Any<bool>())
-                .Returns(authContext);
-            var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
-                _mockAuthContextFactory,
-                _mockConfigManager,
-                _mockOptions,
-                _mockLogger
-            );
-
-            // Act
-            await sut.Invoke(context, Next);
-
-            // Assert
-            AssertAccessAllowed(context, authContext);
-        }
-    }
+    // REMOVED: SymmetricVerificationTests class entirely
 
     public class AsymmetricVerificationTests : JwtAuthMiddlewareTests
     {
@@ -445,9 +305,6 @@ public class JwtAuthMiddlewareTests
             var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid, scope: "wrong.scope");
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var authContext = new AuthContext("clientId", "organisationId", ["wrong.scope"]);
             _mockAuthContextFactory
@@ -456,7 +313,6 @@ public class JwtAuthMiddlewareTests
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -473,14 +329,10 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario1_ValidToken_ShouldAllowAccessAndPopulateAuthContext()
         {
-            // Scenario: Valid token, should Allow access, and the auth context should be set as expected
             // Arrange
             var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid);
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var authContext = new AuthContext("clientId", "organisationId", ["fetch-record.read"]);
             _mockAuthContextFactory
@@ -489,7 +341,6 @@ public class JwtAuthMiddlewareTests
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -506,7 +357,6 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario2_KidMissingInitially_ShouldForceRefreshAndSucceedOnRetry()
         {
-            // Scenario: Valid token, except for kid is missing in our OIDC Config, so force refresh should happen, and the final result should Allow access
             // Arrange
             var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid);
             var emptyConfig = new OpenIdConnectConfiguration();
@@ -514,9 +364,6 @@ public class JwtAuthMiddlewareTests
             _mockConfigManager
                 .GetConfigurationAsync(Arg.Any<CancellationToken>())
                 .Returns(emptyConfig, refreshedConfig);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var authContext = new AuthContext("clientId", "organisationId", ["fetch-record.read"]);
             _mockAuthContextFactory
@@ -525,7 +372,6 @@ public class JwtAuthMiddlewareTests
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -543,20 +389,15 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario3_KidMissingEvenAfterForceRefresh_ShouldDenyAccess()
         {
-            // Scenario: Valid token, except for kid is missing in our oidcConfig, so force refresh should happen, and after force refresh the kid is still missing, then should Deny access
             // Arrange
             var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid);
             var emptyConfig = new OpenIdConnectConfiguration();
             _mockConfigManager
                 .GetConfigurationAsync(Arg.Any<CancellationToken>())
                 .Returns(emptyConfig);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -574,18 +415,13 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario4_ModifiedPayload_ShouldDenyAccess()
         {
-            // Scenario: Invalid signature due to modified token payload, should Deny access
             // Arrange
             var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid, modifyPayload: true);
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -602,18 +438,13 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario5_ModifiedHeader_ShouldDenyAccess()
         {
-            // Scenario: Invalid signature due to modified token header, should Deny access
             // Arrange
             var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid, modifyHeader: true);
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -630,7 +461,6 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario6_TokenNotActiveYet_ShouldDenyAccess()
         {
-            // Scenario: Invalid due to use of token before valid time range (i.e. not-before), should Deny access
             // Arrange
             var token = GenerateAsymmetricToken(
                 _genuineRsa,
@@ -640,13 +470,9 @@ public class JwtAuthMiddlewareTests
             );
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -663,7 +489,6 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario7_TokenExpired_ShouldDenyAccess()
         {
-            // Scenario: Invalid due to use of token after valid time range (i.e. expiration), should Deny access
             // Arrange
             var token = GenerateAsymmetricToken(
                 _genuineRsa,
@@ -673,13 +498,9 @@ public class JwtAuthMiddlewareTests
             );
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -696,18 +517,13 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario8_StrippedSignature_ShouldDenyAccess()
         {
-            // Scenario: Invalid signature due to signature removal, should Deny access
             // Arrange
             var token = GenerateAsymmetricToken(_genuineRsa, _genuineKid, stripSignature: true);
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -728,19 +544,14 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario9_ForgedPrivateKeySignature_ShouldDenyAccess()
         {
-            // Scenario: Invalid signature due to non-genuine private key, should Deny access
             // Arrange
             using var forgedRsaKey = RSA.Create(2048);
             var token = GenerateAsymmetricToken(forgedRsaKey, _genuineKid);
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -757,7 +568,6 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario10_InvalidIssuer_ShouldDenyAccess()
         {
-            // Scenario: Invalid source (i.e. issuer), should Deny access
             // Arrange
             var token = GenerateAsymmetricToken(
                 _genuineRsa,
@@ -766,13 +576,9 @@ public class JwtAuthMiddlewareTests
             );
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,
@@ -789,7 +595,6 @@ public class JwtAuthMiddlewareTests
         [Fact]
         public async Task Scenario11_InvalidAudience_ShouldDenyAccess()
         {
-            // Scenario: Invalid target (i.e. audience), should Deny access
             // Arrange
             var token = GenerateAsymmetricToken(
                 _genuineRsa,
@@ -798,13 +603,9 @@ public class JwtAuthMiddlewareTests
             );
             var config = CreateOidcConfig(_genuineRsa, _genuineKid);
             _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
-            _mockAuthStore
-                .GetAuthStoreAsync()
-                .Returns(new AuthStore { DefaultTokenLifetimeMinutes = 60 });
 
             var context = CreateMockFunctionContext($"Bearer {token}");
             var sut = new JwtAuthMiddleware(
-                _mockAuthStore,
                 _mockAuthContextFactory,
                 _mockConfigManager,
                 _mockOptions,

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/JwtAuthMiddlewareTests.cs
@@ -3,6 +3,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -100,7 +101,27 @@ public class JwtAuthMiddlewareTests
         }
     }
 
-    // REMOVED: GenerateSymmetricToken Helper
+    private static string GenerateSymmetricToken(
+        string issuer,
+        string audience,
+        string signingKey,
+        string clientId,
+        string scope = "fetch-record.read"
+    )
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var claims = new[] { new Claim("client_id", clientId), new Claim("scp", scope) };
+
+        var token = new JwtSecurityToken(
+            issuer,
+            audience,
+            claims,
+            expires: DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: credentials
+        );
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
 
     private string GenerateAsymmetricToken(
         RSA rsaKey,
@@ -294,7 +315,38 @@ public class JwtAuthMiddlewareTests
         }
     }
 
-    // REMOVED: SymmetricVerificationTests class entirely
+    public class SymmetricVerificationTests : JwtAuthMiddlewareTests
+    {
+        [Fact]
+        public async Task TestInvoke_WithSymmetricToken_ReturnsProblemResponse()
+        {
+            // Arrange
+            var config = CreateOidcConfig(_genuineRsa, _genuineKid);
+            _mockConfigManager.GetConfigurationAsync(Arg.Any<CancellationToken>()).Returns(config);
+
+            var token = GenerateSymmetricToken(
+                _authSettings.Issuer,
+                _authSettings.Audience,
+                "SecretKeyShouldBeLongEnoughToPass12345!",
+                "clientId"
+            );
+
+            var context = CreateMockFunctionContext($"Bearer {token}");
+
+            var sut = new JwtAuthMiddleware(
+                _mockAuthContextFactory,
+                _mockConfigManager,
+                _mockOptions,
+                _mockLogger
+            );
+
+            // Act
+            await sut.Invoke(context, Next);
+
+            // Assert
+            AssertAccessDenied(context, "Token validation failed", "Signature validation failed");
+        }
+    }
 
     public class AsymmetricVerificationTests : JwtAuthMiddlewareTests
     {

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -32,56 +32,6 @@ public class MockAuthStoreServiceTests
     }
 
     [Fact]
-    public async Task GetAuthStoreAsync_MapsJsonToStoreDefinitionCorrectly()
-    {
-        // Arrange
-        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
-        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
-        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
-
-        // Act
-        var store = await _sut.GetAuthStoreAsync();
-
-        // Assert
-        Assert.NotNull(store);
-        Assert.NotNull(store.Clients);
-        Assert.NotEmpty(store.Clients);
-
-        // Verify structure of an active client
-        var sampleClient = store.Clients.FirstOrDefault(c => c.ClientId == "LOCAL-AUTHORITY-01");
-        Assert.NotNull(sampleClient);
-        Assert.True(sampleClient.Enabled);
-        Assert.Equal("SUIProject", sampleClient.ClientSecret);
-        Assert.Contains("match-record.read", sampleClient.AllowedScopes!);
-    }
-
-    [Fact]
-    public async Task LoadStore_ShouldThrowInvalidOperationException_WhenFileDoesNotExist()
-    {
-        // Arrange
-        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(false);
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _sut.GetAuthStoreAsync()
-        );
-        Assert.Contains("Auth store file not found at", ex.Message);
-    }
-
-    [Fact]
-    public async Task LoadStore_ShouldThrowInvalidOperationException_WhenJsonIsCorrupt()
-    {
-        // Arrange
-        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
-        _mockFileSystem
-            .File.ReadAllText(Arg.Any<string>())
-            .Returns("{ invalid-json-payload : true ");
-
-        // Act & Assert
-        await Assert.ThrowsAsync<JsonException>(() => _sut.GetAuthStoreAsync());
-    }
-
-    [Fact]
     public async Task GetScopesByClientId_WithValidClientId_ShouldReturnScopes()
     {
         // Arrange

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -44,12 +44,6 @@ public class MockAuthStoreServiceTests
 
         // Assert
         Assert.NotNull(store);
-        Assert.Equal("https://sandbox.api.example.gov.uk/find-a-record/auth", store.Issuer);
-        Assert.Equal("find-a-record-api", store.Audience);
-        Assert.Equal(
-            "Wc8Kq1ZyR4hNfD0uVx3mS9JpA6eLrT2bG7wQvY5sCjP8kF1nH0tUoMzBiXaEdRl",
-            store.SigningKey
-        );
         Assert.NotNull(store.Clients);
         Assert.NotEmpty(store.Clients);
 

--- a/Apps/StubCustodians/src/SUI.StubCustodians.API/Controllers/AuthController.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.API/Controllers/AuthController.cs
@@ -16,7 +16,7 @@ namespace SUI.StubCustodians.API.Controllers;
 [ApiVersion("1.0")]
 public class AuthController(ILogger<AuthController> logger) : ControllerBase
 {
-    private static readonly Lazy<AuthStore> Store = new(LoadAuthStore);
+    private static readonly Lazy<OutboundAuthStore> Store = new(LoadOutboundAuthStore);
 
     private readonly int _tokenLifetimeMinutes =
         Store.Value.DefaultTokenLifetimeMinutes > 0 ? Store.Value.DefaultTokenLifetimeMinutes : 60;
@@ -153,7 +153,7 @@ public class AuthController(ILogger<AuthController> logger) : ControllerBase
         );
     }
 
-    private string CreateJwt(AuthStore store, string clientId, IReadOnlyList<string> scopes)
+    private string CreateJwt(OutboundAuthStore store, string clientId, IReadOnlyList<string> scopes)
     {
         var now = DateTimeOffset.UtcNow;
         var expires = now.AddMinutes(_tokenLifetimeMinutes);
@@ -212,7 +212,7 @@ public class AuthController(ILogger<AuthController> logger) : ControllerBase
             .ToArray();
     }
 
-    private static AuthStore LoadAuthStore()
+    private static OutboundAuthStore LoadOutboundAuthStore()
     {
         var baseDir = AppContext.BaseDirectory;
         var filePath = Path.Combine(baseDir, "Data", "auth-clients-outbound.json");
@@ -223,7 +223,7 @@ public class AuthController(ILogger<AuthController> logger) : ControllerBase
         }
 
         var json = System.IO.File.ReadAllText(filePath);
-        var store = JsonSerializer.Deserialize<AuthStore>(json, JsonSerializerOptions.Web);
+        var store = JsonSerializer.Deserialize<OutboundAuthStore>(json, JsonSerializerOptions.Web);
 
         if (store is null)
         {

--- a/Apps/StubCustodians/src/SUI.StubCustodians.API/ScopeEnforcementMiddleware.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.API/ScopeEnforcementMiddleware.cs
@@ -15,7 +15,7 @@ namespace SUI.StubCustodians.API;
 public class ScopeEnforcementMiddleware
 {
     private static readonly JwtSecurityTokenHandler Handler = new();
-    private static readonly Lazy<AuthStore> Store = new(LoadAuthStore);
+    private static readonly Lazy<OutboundAuthStore> Store = new(LoadOutboundAuthStore);
     private readonly RequestDelegate _next;
 
     public ScopeEnforcementMiddleware(RequestDelegate next)
@@ -156,7 +156,7 @@ public class ScopeEnforcementMiddleware
         return requiredScopesAttribute?.Scopes.ToArray() ?? [];
     }
 
-    private static AuthStore LoadAuthStore()
+    private static OutboundAuthStore LoadOutboundAuthStore()
     {
         var baseDir = AppContext.BaseDirectory;
         var filePath = Path.Combine(baseDir, "Data", "auth-clients-outbound.json");
@@ -167,7 +167,7 @@ public class ScopeEnforcementMiddleware
         }
 
         var json = File.ReadAllText(filePath);
-        var store = JsonSerializer.Deserialize<AuthStore>(json, JsonSerializerOptions.Web);
+        var store = JsonSerializer.Deserialize<OutboundAuthStore>(json, JsonSerializerOptions.Web);
 
         if (store is null)
         {

--- a/Apps/StubCustodians/src/SUI.StubCustodians.Application/Models/AuthStore.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.Application/Models/AuthStore.cs
@@ -5,9 +5,5 @@ namespace SUI.StubCustodians.Application.Models;
 [ExcludeFromCodeCoverage(Justification = "Mock service")]
 public sealed class AuthStore
 {
-    public string Issuer { get; set; } = string.Empty;
-    public string Audience { get; set; } = string.Empty;
-    public string SigningKey { get; set; } = string.Empty;
-    public int DefaultTokenLifetimeMinutes { get; set; } = 60;
     public List<AuthClient>? Clients { get; set; }
 }

--- a/Apps/StubCustodians/src/SUI.StubCustodians.Application/Models/OutboundAuthStore.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.Application/Models/OutboundAuthStore.cs
@@ -1,0 +1,10 @@
+namespace SUI.StubCustodians.Application.Models;
+
+public class OutboundAuthStore
+{
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string SigningKey { get; set; } = string.Empty;
+    public int DefaultTokenLifetimeMinutes { get; set; } = 60;
+    public List<AuthClient>? Clients { get; set; }
+}

--- a/Data/auth-clients-inbound.json
+++ b/Data/auth-clients-inbound.json
@@ -1,8 +1,4 @@
 {
-  "issuer": "https://sandbox.api.example.gov.uk/find-a-record/auth",
-  "audience": "find-a-record-api",
-  "signingKey": "Wc8Kq1ZyR4hNfD0uVx3mS9JpA6eLrT2bG7wQvY5sCjP8kF1nH0tUoMzBiXaEdRl",
-  "defaultTokenLifetimeMinutes": 60,
   "clients": [
     {
       "enabled": true,


### PR DESCRIPTION
## Summary

- Remove the unused SymmetricSecurityKey and related code, that was obsoleted to avoid auth bypasses becoming part of the architecture.

## Changes

- The SUI.StubCustodians.API.ScopeEnforcementMiddleware and SUI.StubCustodians.API.Controllers.AuthController classes are changed to use a copy of SUI.StubCustodians.Application.Models.AuthStore class but called OutboundAuthStore, and that copied class should keep all of the defined properties.
- The signingKey, issuer, audience and defaultTokenLifetimeMinutes properties are removed from Data/auth-clients-inbound.json
- The SigningKey, Issuer, Audience and DefaultTokenLifetimeMinutes properties are removed from the models:
> SUI.AuthEmulator.Models.AuthStore
> SUI.StubCustodians.Application.Models.AuthStore
- The “Auth store file is missing issuer, audience, or signingKey” validation logic is removed from MockAuthStoreService
- The SymmetricSecurityKey branch of code in JwtAuthMiddleware (that was used for token verification, but now isn’t used anymore) is totally removed, and any related now unused code is also removed.

## Validation

- Successful Unit tests and E2E tests