### PR TITLE
feat(find): SUI-1775 - Update Auth Store (auth-clients-inbound.json) to use Client ID values that do not match Organisation ID

### DIFF
--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -8,6 +8,7 @@ namespace SUI.AuthEmulator.UnitTests.Services;
 
 public class MockAuthStoreServiceTests
 {
+    private const string ClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
     private readonly MockAuthStoreService _sut;
     private readonly string _realStoreFilePath;
@@ -31,12 +32,12 @@ public class MockAuthStoreServiceTests
         _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
-        var result = await _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "SUIProject");
+        var result = await _sut.GetClientByCredentials(ClientId, "SUIProject");
 
         // Assert
         Assert.True(result.Success);
         Assert.NotNull(result.Value);
-        Assert.Equal("LOCAL-AUTHORITY-01", result.Value.ClientId);
+        Assert.Equal(ClientId, result.Value.ClientId);
     }
 
     [Fact]
@@ -48,7 +49,7 @@ public class MockAuthStoreServiceTests
         _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
-        var result = await _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "WRONG-PASSWORD-XYZ");
+        var result = await _sut.GetClientByCredentials(ClientId, "WRONG-PASSWORD-XYZ");
 
         // Assert
         Assert.False(result.Success);

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -8,6 +8,7 @@ namespace SUI.AuthEmulator.UnitTests.Services;
 
 public class MockAuthStoreServiceTests
 {
+    private const string ClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
     private readonly MockAuthStoreService _sut;
     private readonly string _realStoreFilePath;
@@ -45,7 +46,7 @@ public class MockAuthStoreServiceTests
         Assert.NotEmpty(store.Clients);
 
         // Verify structure of an active client
-        var sampleClient = store.Clients.FirstOrDefault(c => c.ClientId == "LOCAL-AUTHORITY-01");
+        var sampleClient = store.Clients.FirstOrDefault(c => c.ClientId == ClientId);
         Assert.NotNull(sampleClient);
         Assert.True(sampleClient.Enabled);
         Assert.Equal("SUIProject", sampleClient.ClientSecret);
@@ -61,12 +62,12 @@ public class MockAuthStoreServiceTests
         _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
-        var result = await _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "SUIProject");
+        var result = await _sut.GetClientByCredentials(ClientId, "SUIProject");
 
         // Assert
         Assert.True(result.Success);
         Assert.NotNull(result.Value);
-        Assert.Equal("LOCAL-AUTHORITY-01", result.Value.ClientId);
+        Assert.Equal(ClientId, result.Value.ClientId);
     }
 
     [Fact]
@@ -78,7 +79,7 @@ public class MockAuthStoreServiceTests
         _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
-        var result = await _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "WRONG-PASSWORD-XYZ");
+        var result = await _sut.GetClientByCredentials(ClientId, "WRONG-PASSWORD-XYZ");
 
         // Assert
         Assert.False(result.Success);
@@ -104,7 +105,7 @@ public class MockAuthStoreServiceTests
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _sut.GetClientByCredentials("LOCAL-AUTHORITY-01", "SUIProject")
+            _sut.GetClientByCredentials(ClientId, "SUIProject")
         );
 
         Assert.Equal("Auth store file is missing issuer, audience, or signingKey.", ex.Message);

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
@@ -20,7 +20,9 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
         );
 
         var attackerClientId =
-            testData.TestClientId == "LOCAL-AUTHORITY-01" ? "EDUCATION-01" : "LOCAL-AUTHORITY-01";
+            testData.TestClientId == "CLIENT-ID_LOCAL-AUTHORITY-01"
+                ? "CLIENT-ID_EDUCATION-01"
+                : "CLIENT-ID_LOCAL-AUTHORITY-01";
 
         var attackerToken = await GetAuthTokenAsync(attackerClientId, TestClientSecret, TestScopes);
 

--- a/Apps/Find/tests/SUI.Find.E2ETests/FindSmokeTests.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FindSmokeTests.cs
@@ -10,7 +10,7 @@ namespace SUI.Find.E2ETests;
 public class FindSmokeTests(FunctionTestFixture fixture, ITestOutputHelper testOutputHelper)
     : E2ETestBase(fixture, testOutputHelper)
 {
-    private const string TestClientId = "LOCAL-AUTHORITY-01";
+    private const string TestClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
     private const string TestClientSecret = "SUIProject";
     private const int ApiKeyAcceptanceRetryCount = 6;
     private static readonly string[] MatchReadScopes = ["match-record.read"];

--- a/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
@@ -53,7 +53,7 @@ public abstract class SearchTestsBase(
             new TestData
             {
                 Sui = "9691292211",
-                TestClientId = "LOCAL-AUTHORITY-01",
+                TestClientId = "CLIENT-ID_LOCAL-AUTHORITY-01",
                 Records =
                 [
                     new TestRecord { RecordType = "health.details", TestValue = "Dr E Green" },
@@ -80,7 +80,7 @@ public abstract class SearchTestsBase(
             new TestData
             {
                 Sui = "9691292211",
-                TestClientId = "EDUCATION-01",
+                TestClientId = "CLIENT-ID_EDUCATION-01",
                 Records =
                 [
                     new TestRecord { RecordType = "health.details", TestValue = "Dr E Green" },
@@ -97,13 +97,13 @@ public abstract class SearchTestsBase(
             new TestData
             {
                 Sui = "9449306613",
-                TestClientId = "LOCAL-AUTHORITY-01",
+                TestClientId = "CLIENT-ID_LOCAL-AUTHORITY-01",
                 Records = [new TestRecord { RecordType = "personal.details", TestValue = "Briar" }],
             },
             new TestData
             {
                 Sui = "9449306494",
-                TestClientId = "HEALTH-01",
+                TestClientId = "CLIENT-ID_HEALTH-01",
                 Records =
                 [
                     new TestRecord { RecordType = "personal.details", TestValue = "Red" },
@@ -117,13 +117,13 @@ public abstract class SearchTestsBase(
             new TestData
             {
                 Sui = "9693821998",
-                TestClientId = "LOCAL-AUTHORITY-01",
+                TestClientId = "CLIENT-ID_LOCAL-AUTHORITY-01",
                 Records = [],
             },
             new TestData
             {
                 Sui = "9691292211",
-                TestClientId = "NO-DSA-01",
+                TestClientId = "CLIENT-ID_NO-DSA-01",
                 Records = [],
             },
         ];

--- a/Apps/Find/tests/SUI.Find.E2ETests/TestOutboundAuthService.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/TestOutboundAuthService.cs
@@ -46,7 +46,7 @@ public sealed class TestOutboundAuthService(
                 Auth = new AuthDefinition
                 {
                     TokenUrl = $"{fixture.StubCustodiansClient.BaseAddress}v1/auth/token",
-                    ClientId = "CLIENT-ID_SUI-SERVICE",
+                    ClientId = "SUI-SERVICE",
                     ClientSecret = "SUIProject",
                     Scopes = new List<string> { "find-record.read", "fetch-record.read" },
                 },
@@ -115,7 +115,7 @@ public sealed class TestOutboundAuthService(
                 Auth = new AuthDefinition
                 {
                     TokenUrl = $"{fixture.StubCustodiansClient.BaseAddress}v1/auth/token",
-                    ClientId = "CLIENT-ID_SUI-SERVICE",
+                    ClientId = "SUI-SERVICE",
                     ClientSecret = "SUIProject",
                     Scopes = new List<string> { "find-record.read", "fetch-record.read" },
                 },

--- a/Apps/Find/tests/SUI.Find.E2ETests/TestOutboundAuthService.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/TestOutboundAuthService.cs
@@ -46,7 +46,7 @@ public sealed class TestOutboundAuthService(
                 Auth = new AuthDefinition
                 {
                     TokenUrl = $"{fixture.StubCustodiansClient.BaseAddress}v1/auth/token",
-                    ClientId = "SUI-SERVICE",
+                    ClientId = "CLIENT-ID_SUI-SERVICE",
                     ClientSecret = "SUIProject",
                     Scopes = new List<string> { "find-record.read", "fetch-record.read" },
                 },
@@ -115,7 +115,7 @@ public sealed class TestOutboundAuthService(
                 Auth = new AuthDefinition
                 {
                     TokenUrl = $"{fixture.StubCustodiansClient.BaseAddress}v1/auth/token",
-                    ClientId = "SUI-SERVICE",
+                    ClientId = "CLIENT-ID_SUI-SERVICE",
                     ClientSecret = "SUIProject",
                     Scopes = new List<string> { "find-record.read", "fetch-record.read" },
                 },

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/AuthContextFactoryTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/AuthContextFactoryTests.cs
@@ -9,6 +9,8 @@ namespace SUI.Find.FindApi.UnitTests.MiddlewareTests;
 
 public class AuthContextFactoryTests
 {
+    private const string ClientId = "CLIENT-ID_EDUCATION-01";
+    private const string OrganisationId = "EDUCATION-01";
     private readonly AuthContextFactory _sut;
     private readonly IAuthStoreService _store;
 
@@ -45,9 +47,9 @@ public class AuthContextFactoryTests
     public void TestFromJwt_WhenNoOrganisationIdForClientId_ShouldThrowException()
     {
         // Arrange
-        var claims = new List<Claim> { new("client_id", "EDUCATION-01") };
+        var claims = new List<Claim> { new("client_id", ClientId) };
         var jwt = new JwtSecurityToken(claims: claims);
-        _store.GetOrganisationIdForClientId("EDUCATION-01").Returns("");
+        _store.GetOrganisationIdForClientId(ClientId).Returns("");
 
         // Act
         // Assert
@@ -58,26 +60,24 @@ public class AuthContextFactoryTests
     public void TestFromJwt_WithValidInputs_UsingTokenScopes_ReturnsAuthContext()
     {
         // Arrange
-        const string clientId = "EDUCATION-01";
-        const string organisationId = "Edu-ORG-01";
         List<string> scopesList = ["file.read", "file.write"];
 
         var claims = new List<Claim>
         {
-            new("client_id", clientId),
+            new("client_id", ClientId),
             new("scope", "file.read file.write"),
         };
         var jwt = new JwtSecurityToken(claims: claims);
 
-        _store.GetOrganisationIdForClientId("EDUCATION-01").Returns(organisationId);
+        _store.GetOrganisationIdForClientId(ClientId).Returns(OrganisationId);
         _store.GetScopesByClientId(Arg.Any<string>()).Throws<InvalidOperationException>(); // Should not use Auth Store for authorisation
 
         // Act
         var result = _sut.FromJwt(jwt, false);
 
         // Assert
-        Assert.Equal(clientId, result.ClientId);
-        Assert.Equal(organisationId, result.OrganisationId);
+        Assert.Equal(ClientId, result.ClientId);
+        Assert.Equal(OrganisationId, result.OrganisationId);
         Assert.Equal(scopesList, result.Scopes);
     }
 
@@ -85,26 +85,24 @@ public class AuthContextFactoryTests
     public void TestFromJwt_WithValidInputs_UsingAuthStoreScopes_ReturnsAuthContext()
     {
         // Arrange
-        const string clientId = "EDUCATION-01";
-        const string organisationId = "Edu-ORG-01";
         List<string> scopesList = ["file.read", "file.write"];
 
         var claims = new List<Claim>
         {
-            new("client_id", clientId),
+            new("client_id", ClientId),
             new("scope", "incorrect.scope"),
         };
         var jwt = new JwtSecurityToken(claims: claims);
 
-        _store.GetOrganisationIdForClientId("EDUCATION-01").Returns(organisationId);
+        _store.GetOrganisationIdForClientId(ClientId).Returns(OrganisationId);
         _store.GetScopesByClientId(Arg.Any<string>()).Returns(scopesList);
 
         // Act
         var result = _sut.FromJwt(jwt, true);
 
         // Assert
-        Assert.Equal(clientId, result.ClientId);
-        Assert.Equal(organisationId, result.OrganisationId);
+        Assert.Equal(ClientId, result.ClientId);
+        Assert.Equal(OrganisationId, result.OrganisationId);
         Assert.Equal(scopesList, result.Scopes);
     }
 }

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -54,7 +54,9 @@ public class MockAuthStoreServiceTests
         Assert.NotEmpty(store.Clients);
 
         // Verify structure of an active client
-        var sampleClient = store.Clients.FirstOrDefault(c => c.ClientId == "LOCAL-AUTHORITY-01");
+        var sampleClient = store.Clients.FirstOrDefault(c =>
+            c.ClientId == "CLIENT-ID_LOCAL-AUTHORITY-01"
+        );
         Assert.NotNull(sampleClient);
         Assert.True(sampleClient.Enabled);
         Assert.Equal("SUIProject", sampleClient.ClientSecret);
@@ -96,7 +98,7 @@ public class MockAuthStoreServiceTests
         _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
-        var result = _sut.GetScopesByClientId("LOCAL-AUTHORITY-01");
+        var result = _sut.GetScopesByClientId("CLIENT-ID_LOCAL-AUTHORITY-01");
 
         // Assert
         Assert.NotNull(result);
@@ -127,7 +129,7 @@ public class MockAuthStoreServiceTests
         _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
-        var result = _sut.GetOrganisationIdForClientId("LOCAL-AUTHORITY-01");
+        var result = _sut.GetOrganisationIdForClientId("CLIENT-ID_LOCAL-AUTHORITY-01");
 
         // Assert
         Assert.NotNull(result);

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -1,5 +1,4 @@
 using System.IO.Abstractions;
-using System.Text.Json;
 using NSubstitute;
 using SUI.Find.Infrastructure.Services;
 
@@ -7,6 +6,7 @@ namespace SUI.Find.Infrastructure.UnitTests.Services;
 
 public class MockAuthStoreServiceTests
 {
+    private const string ClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
     private readonly MockAuthStoreService _sut;
     private readonly string _realStoreFilePath;
@@ -40,7 +40,7 @@ public class MockAuthStoreServiceTests
         _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
-        var result = _sut.GetScopesByClientId("LOCAL-AUTHORITY-01");
+        var result = _sut.GetScopesByClientId(ClientId);
 
         // Assert
         Assert.NotNull(result);
@@ -71,7 +71,7 @@ public class MockAuthStoreServiceTests
         _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
 
         // Act
-        var result = _sut.GetOrganisationIdForClientId("LOCAL-AUTHORITY-01");
+        var result = _sut.GetOrganisationIdForClientId(ClientId);
 
         // Assert
         Assert.NotNull(result);

--- a/Apps/StubCustodians/src/SUI.StubCustodians.Application/Models/AuthClient.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.Application/Models/AuthClient.cs
@@ -7,6 +7,7 @@ public sealed class AuthClient
 {
     public string ClientId { get; set; } = string.Empty;
     public string ClientSecret { get; set; } = string.Empty;
+    public string OrganisationId { get; set; } = string.Empty;
     public bool Enabled { get; set; } = true;
     public List<string>? AllowedScopes { get; set; }
 }

--- a/Apps/StubCustodians/src/SUI.StubCustodians.Application/Utilities/CustodianWorker.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.Application/Utilities/CustodianWorker.cs
@@ -135,7 +135,7 @@ public class CustodianWorker : BackgroundService
             {
                 ["JobId"] = job.JobId,
                 ["LeaseId"] = job.LeaseId,
-                ["OrgId"] = _authClient.ClientId,
+                ["OrgId"] = _authClient.OrganisationId,
             }
         );
 
@@ -146,7 +146,7 @@ public class CustodianWorker : BackgroundService
                 {
                     job.JobId,
                     job.LeaseId,
-                    _authClient.ClientId,
+                    _authClient.OrganisationId,
                 }
             );
 
@@ -159,7 +159,7 @@ public class CustodianWorker : BackgroundService
         var baseUrl = _config["StubCustodians:BaseUrl"]!;
 
         var manifest = await manifestService.GetManifestForOrganisation(
-            _authClient.ClientId,
+            _authClient.OrganisationId,
             job.Sui,
             baseUrl,
             job.RecordType,

--- a/Apps/StubCustodians/tests/SUI.StubCustodians.Application.Unit.Tests/Utilities/CustodianWorkerTests.cs
+++ b/Apps/StubCustodians/tests/SUI.StubCustodians.Application.Unit.Tests/Utilities/CustodianWorkerTests.cs
@@ -28,6 +28,7 @@ public class CustodianWorkerTests
         _testClient = new AuthClient()
         {
             ClientId = "client-id",
+            OrganisationId = "organisation-id",
             ClientSecret = "secret",
             Enabled = true,
             AllowedScopes = ["test-scope"],
@@ -93,7 +94,7 @@ public class CustodianWorkerTests
 
         _manifestService
             .GetManifestForOrganisation(
-                _testClient.ClientId,
+                _testClient.OrganisationId,
                 job.Sui,
                 "https://api.test",
                 job.RecordType,
@@ -301,7 +302,7 @@ public class CustodianWorkerTests
 
         _manifestService
             .GetManifestForOrganisation(
-                _testClient.ClientId,
+                _testClient.OrganisationId,
                 job.Sui,
                 "https://api.test",
                 job.RecordType,

--- a/Data/auth-clients-inbound.json
+++ b/Data/auth-clients-inbound.json
@@ -6,7 +6,7 @@
   "clients": [
     {
       "enabled": true,
-      "clientId": "LOCAL-AUTHORITY-01",
+      "clientId": "CLIENT-ID_LOCAL-AUTHORITY-01",
       "organisationId": "LOCAL-AUTHORITY-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -21,7 +21,7 @@
     },
     {
       "enabled": true,
-      "clientId": "EDUCATION-01",
+      "clientId": "CLIENT-ID_EDUCATION-01",
       "organisationId": "EDUCATION-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -36,7 +36,7 @@
     },
     {
       "enabled": true,
-      "clientId": "HEALTH-01",
+      "clientId": "CLIENT-ID_HEALTH-01",
       "organisationId": "HEALTH-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -51,7 +51,7 @@
     },
     {
       "enabled": true,
-      "clientId": "POLICE-01",
+      "clientId": "CLIENT-ID_POLICE-01",
       "organisationId": "POLICE-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -66,7 +66,7 @@
     },
     {
       "enabled": true,
-      "clientId": "HOUSING-01",
+      "clientId": "CLIENT-ID_HOUSING-01",
       "organisationId": "HOUSING-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -81,7 +81,7 @@
     },
     {
       "enabled": true,
-      "clientId": "NO-DSA-01",
+      "clientId": "CLIENT-ID_NO-DSA-01",
       "organisationId": "NO-DSA-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [


### PR DESCRIPTION
## Summary
As part of evolving the Auth to be more production-ready we need to update Auth Store (auth-clients-inbound.json) to use Client ID values that do not match their respective Organisation ID, so that we can verify that the Client ID can be any value to enable integrating with 3rd party identity providers.

## Changes

- Add "CLIENT-ID_" as a prefix to existing client IDs in the auth json file
- Update tests to search for these values in the auth store
- Update tests to follow the new client ID pattern for consistency

## Validation

- Unit/integration/E2E tests run