### PR TITLE
feat(find): SUI-1791 - Support for azp (Authorized party) claim to be used as the Client ID

### DIFF
--- a/Apps/Find/src/SUI.Find.FindApi/Middleware/AuthContextFactory.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Middleware/AuthContextFactory.cs
@@ -9,11 +9,15 @@ public class AuthContextFactory(IAuthStoreService storeService) : IAuthContextFa
     public AuthContext FromJwt(JwtSecurityToken jwt, bool useAuthStoreForAuthorisation)
     {
         var clientId = Get(jwt, "client_id");
+
+        if (string.IsNullOrWhiteSpace(clientId))
+            clientId = Get(jwt, "azp");
+
         if (string.IsNullOrWhiteSpace(clientId))
             clientId = Get(jwt, "sub");
 
         if (string.IsNullOrWhiteSpace(clientId))
-            throw new InvalidOperationException("Token did not contain client_id or sub.");
+            throw new InvalidOperationException("Token did not contain client_id, azp, or sub.");
 
         var organisationId = storeService.GetOrganisationIdForClientId(clientId);
 

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/AuthContextFactoryTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/AuthContextFactoryTests.cs
@@ -19,26 +19,26 @@ public class AuthContextFactoryTests
     }
 
     [Fact]
-    public void TestFromJwt_WhenClientIdAndSubEmpty_ShouldThrowException()
+    public void TestFromJwt_WhenClientIdAzpAndSubEmpty_ShouldThrowException()
     {
         // Arrange
-        var claims = new List<Claim> { new("client_id", ""), new("sub", "") };
+        var claims = new List<Claim> { new("client_id", ""), new("azp", ""), new("sub", "") };
         var jwt = new JwtSecurityToken(claims: claims);
 
-        // Act
-        // Assert
-        Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, false));
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, false));
+        Assert.Contains("Token did not contain client_id, azp, or sub", ex.Message);
     }
 
     [Fact]
-    public void TestFromJwt_WhenNoClientIdOrSub_ShouldThrowException()
+    public void TestFromJwt_WhenNoClientIdAzpOrSub_ShouldThrowException()
     {
         // Arrange
         var jwt = new JwtSecurityToken();
 
-        // Act
-        // Assert
-        Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, false));
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, false));
+        Assert.Contains("Token did not contain client_id, azp, or sub", ex.Message);
     }
 
     [Fact]
@@ -49,9 +49,58 @@ public class AuthContextFactoryTests
         var jwt = new JwtSecurityToken(claims: claims);
         _store.GetOrganisationIdForClientId("EDUCATION-01").Returns("");
 
-        // Act
-        // Assert
+        // Act & Assert
         Assert.Throws<InvalidOperationException>(() => _sut.FromJwt(jwt, false));
+    }
+
+    [Fact]
+    public void TestFromJwt_WhenAzpAndSubPresent_UsesAzpAsClientId()
+    {
+        // Arrange
+        var claims = new List<Claim> { new("azp", "AZP-CLIENT-01"), new("sub", "SUB-CLIENT-01") };
+        var jwt = new JwtSecurityToken(claims: claims);
+        _store.GetOrganisationIdForClientId("AZP-CLIENT-01").Returns("ORG-01");
+
+        // Act
+        var result = _sut.FromJwt(jwt, false);
+
+        // Assert
+        Assert.Equal("AZP-CLIENT-01", result.ClientId);
+    }
+
+    [Fact]
+    public void TestFromJwt_WhenClientIdAndAzpPresent_UsesClientId()
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new("client_id", "MAIN-CLIENT-01"),
+            new("azp", "AZP-CLIENT-01"),
+            new("sub", "SUB-CLIENT-01"),
+        };
+        var jwt = new JwtSecurityToken(claims: claims);
+        _store.GetOrganisationIdForClientId("MAIN-CLIENT-01").Returns("ORG-01");
+
+        // Act
+        var result = _sut.FromJwt(jwt, false);
+
+        // Assert
+        Assert.Equal("MAIN-CLIENT-01", result.ClientId);
+    }
+
+    [Fact]
+    public void TestFromJwt_WhenOnlySubPresent_UsesSubAsClientId()
+    {
+        // Arrange
+        var claims = new List<Claim> { new("sub", "SUB-CLIENT-01") };
+        var jwt = new JwtSecurityToken(claims: claims);
+        _store.GetOrganisationIdForClientId("SUB-CLIENT-01").Returns("ORG-01");
+
+        // Act
+        var result = _sut.FromJwt(jwt, false);
+
+        // Assert
+        Assert.Equal("SUB-CLIENT-01", result.ClientId);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Support the azp (Authorized party) claim to be used as the Client ID, so that we can integrate with various real identity providers.
The azp claim is used by the DfE Find and Use an API (FaUAPI) service to represent each “Client” (known as Subscriptions in FaUAPI’s terminology).

## Changes

- The AuthContextFactory is updated to try and get the “Client ID” value from the azp claim.
- The order of precedence of the claims is (from highest to lowest precedence):
> client_id 
> azp 
> sub
- Unit test is included the verifies that if both the azp and sub claims are present, that the azp claim is the value that is used as the Client ID.

## Validation

Successful unit tests
