### PR TITLE
feat: SUI-1785 - configure Non-public Client IDs and Secrets

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -124,6 +124,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-latest"]') }}
     if: needs.eval-workflow-setup.outputs.run_ephemeral == 'true'
     env:
+      AuthClientCredentials__CLIENT-ID_LOCAL-AUTHORITY-01__NewClientId: TestExampleClientId-01
+      AuthClientCredentials__CLIENT-ID_LOCAL-AUTHORITY-01__NewClientSecret: TestExampleSecret
       # Point OpenSSL to the .NET dev certs trust directory
       SSL_CERT_DIR: /home/runner/.aspnet/dev-certs/trust:/usr/lib/ssl/certs:/etc/ssl/certs
     steps:
@@ -162,14 +164,14 @@ jobs:
       - name: Install Azure Functions Core Tools
         run: npm i -g azure-functions-core-tools@4
 
-      - name: Build Find Solution
-        run: dotnet build Apps/Find/SUI.Find.slnx
+      - name: Build Find API
+        run: dotnet build Apps/Find/src/SUI.Find.FindApi
 
-      - name: Build StubCustodians Solution
-        run: dotnet build Apps/StubCustodians/SUI.StubCustodians.slnx
+      - name: Build StubCustodians API
+        run: dotnet build Apps/StubCustodians/src/SUI.StubCustodians.API
 
-      - name: Build AuthEmulator Solution
-        run: dotnet build Apps/AuthEmulator/SUI.AuthEmulator.slnx
+      - name: Build AuthEmulator API
+        run: dotnet build Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Create local.settings.json for Find API
         run: |
@@ -189,6 +191,9 @@ jobs:
         working-directory: Apps/Find/src/SUI.Find.FindApi
 
       - name: Run E2E Tests (against ephemeral environment)
+        env:
+          E2E__AuthClientIdsJsonMap: '{"CLIENT-ID_LOCAL-AUTHORITY-01": "TestExampleClientId-01"}'
+          E2E__AuthClientSecretsJsonMap: '{"CLIENT-ID_LOCAL-AUTHORITY-01": "TestExampleSecret"}'
         run: |
           dotnet test Apps/Find/tests/SUI.Find.E2ETests/SUI.Find.E2ETests.csproj \
             --filter "Category=E2E&Suite=Standard" \
@@ -237,6 +242,9 @@ jobs:
           global-json-file: global.json
 
       - name: Run E2E Tests (against dev environment)
+        env:
+          E2E__AuthClientIdsJsonMap: ${{ secrets.AUTH_CLIENT_IDS_JSON_MAP }}
+          E2E__AuthClientSecretsJsonMap: ${{ secrets.AUTH_CLIENT_SECRETS_JSON_MAP }}
         run: |
           dotnet test Apps/Find/tests/SUI.Find.E2ETests/SUI.Find.E2ETests.csproj \
             --filter "Category=E2E&Suite=Standard" \

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -124,8 +124,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-latest"]') }}
     if: needs.eval-workflow-setup.outputs.run_ephemeral == 'true'
     env:
-      AuthClientCredentials__CLIENT-ID_LOCAL-AUTHORITY-01__NewClientId: TestExampleClientId-01
-      AuthClientCredentials__CLIENT-ID_LOCAL-AUTHORITY-01__NewClientSecret: TestExampleSecret
+      AuthClientCredentials__CLIENT_ID_LOCAL_AUTHORITY_01__NewClientId: TestExampleClientId-01
+      AuthClientCredentials__CLIENT_ID_LOCAL_AUTHORITY_01__NewClientSecret: TestExampleSecret
       # Point OpenSSL to the .NET dev certs trust directory
       SSL_CERT_DIR: /home/runner/.aspnet/dev-certs/trust:/usr/lib/ssl/certs:/etc/ssl/certs
     steps:
@@ -192,8 +192,8 @@ jobs:
 
       - name: Run E2E Tests (against ephemeral environment)
         env:
-          E2E__AuthClientIdsJsonMap: '{"CLIENT-ID_LOCAL-AUTHORITY-01": "TestExampleClientId-01"}'
-          E2E__AuthClientSecretsJsonMap: '{"CLIENT-ID_LOCAL-AUTHORITY-01": "TestExampleSecret"}'
+          E2E__AuthClientIdsJsonMap: '{"CLIENT_ID_LOCAL_AUTHORITY_01": "TestExampleClientId-01"}'
+          E2E__AuthClientSecretsJsonMap: '{"CLIENT_ID_LOCAL_AUTHORITY_01": "TestExampleSecret"}'
         run: |
           dotnet test Apps/Find/tests/SUI.Find.E2ETests/SUI.Find.E2ETests.csproj \
             --filter "Category=E2E&Suite=Standard" \

--- a/.github/workflows/rotate-keyvault-secret.yml
+++ b/.github/workflows/rotate-keyvault-secret.yml
@@ -106,6 +106,8 @@ jobs:
       TF_VAR_AuthSettings_Audience: ${{ secrets.AUTH_SETTINGS__AUDIENCE }}
       TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ secrets.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
       TF_VAR_AuthSettings_AccessTokenUrl: ${{ secrets.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
+      TF_VAR_AuthClientIdsJsonMap: ${{ secrets.AUTH_CLIENT_IDS_JSON_MAP }}
+      TF_VAR_AuthClientSecretsJsonMap: ${{ secrets.AUTH_CLIENT_SECRETS_JSON_MAP }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -44,6 +44,10 @@ on:
         required: false
       AUTH_SETTINGS__ACCESS_TOKEN_URL:
         required: false
+      AUTH_CLIENT_IDS_JSON_MAP:
+        required: false
+      AUTH_CLIENT_SECRETS_JSON_MAP:
+        required: false
 
 permissions:
   id-token: write
@@ -70,6 +74,8 @@ jobs:
       TF_VAR_AuthSettings_Audience: ${{ secrets.AUTH_SETTINGS__AUDIENCE }}
       TF_VAR_AuthSettings_OidcDiscoveryUrl: ${{ secrets.AUTH_SETTINGS__OIDC_DISCOVERY_URL }}
       TF_VAR_AuthSettings_AccessTokenUrl: ${{ secrets.AUTH_SETTINGS__ACCESS_TOKEN_URL }}
+      TF_VAR_AuthClientIdsJsonMap: ${{ secrets.AUTH_CLIENT_IDS_JSON_MAP }}
+      TF_VAR_AuthClientSecretsJsonMap: ${{ secrets.AUTH_CLIENT_SECRETS_JSON_MAP }}
 
     steps:
       - name: Checkout repository

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
@@ -7,11 +7,13 @@ namespace SUI.AuthEmulator.Services;
 public class MockAuthStoreService : IAuthStoreService
 {
     private readonly IFileSystem _fileSystem;
+    private readonly IConfiguration _configuration;
     private readonly Lazy<AuthStore> _authStore;
 
-    public MockAuthStoreService(IFileSystem fileSystem)
+    public MockAuthStoreService(IFileSystem fileSystem, IConfiguration configuration)
     {
         _fileSystem = fileSystem;
+        _configuration = configuration;
         _authStore = new Lazy<AuthStore>(LoadStore);
     }
 
@@ -48,6 +50,16 @@ public class MockAuthStoreService : IAuthStoreService
         if (store is null)
         {
             throw new InvalidOperationException("Auth store file could not be deserialized.");
+        }
+
+        foreach (var client in store.Clients ?? []) // rs-todo: tests
+        {
+            client.ClientId =
+                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientId"]
+                ?? client.ClientId;
+            client.ClientSecret =
+                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientSecret"]
+                ?? client.ClientSecret;
         }
 
         return store;

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/MockAuthStoreService.cs
@@ -52,13 +52,14 @@ public class MockAuthStoreService : IAuthStoreService
             throw new InvalidOperationException("Auth store file could not be deserialized.");
         }
 
-        foreach (var client in store.Clients ?? []) // rs-todo: tests
+        foreach (var client in store.Clients ?? [])
         {
+            var originalClientId = client.ClientId;
             client.ClientId =
-                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientId"]
+                _configuration[$"AuthClientCredentials:{originalClientId}:NewClientId"]
                 ?? client.ClientId;
             client.ClientSecret =
-                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientSecret"]
+                _configuration[$"AuthClientCredentials:{originalClientId}:NewClientSecret"]
                 ?? client.ClientSecret;
         }
 

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO.Abstractions;
-using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using NSubstitute;
-using SUI.AuthEmulator.Models;
+using NSubstitute.Extensions;
 using SUI.AuthEmulator.Services;
 
 namespace SUI.AuthEmulator.UnitTests.Services;
@@ -10,12 +10,15 @@ public class MockAuthStoreServiceTests
 {
     private const string ClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
+    private readonly IConfiguration _mockConfiguration = Substitute.For<IConfiguration>();
     private readonly MockAuthStoreService _sut;
     private readonly string _realStoreFilePath;
 
     public MockAuthStoreServiceTests()
     {
-        _sut = new MockAuthStoreService(_mockFileSystem);
+        _mockConfiguration.ReturnsForAll((string?)null);
+
+        _sut = new MockAuthStoreService(_mockFileSystem, _mockConfiguration);
         _realStoreFilePath = Path.Join(
             AppContext.BaseDirectory,
             "Data",

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -8,7 +8,7 @@ namespace SUI.AuthEmulator.UnitTests.Services;
 
 public class MockAuthStoreServiceTests
 {
-    private const string ClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
+    private const string ClientId = "CLIENT_ID_LOCAL_AUTHORITY_01";
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
     private readonly IConfiguration _mockConfiguration = Substitute.For<IConfiguration>();
     private readonly MockAuthStoreService _sut;

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -59,4 +59,34 @@ public class MockAuthStoreServiceTests
         Assert.Equal("Unauthorized", result.Error);
         Assert.Null(result.Value);
     }
+
+    [Theory]
+    [InlineData(null, null, ClientId, "SUIProject")]
+    [InlineData("SensitiveClientId", null, "SensitiveClientId", "SUIProject")]
+    [InlineData(null, "SensitiveClientSecret", ClientId, "SensitiveClientSecret")]
+    [InlineData("PrivateClientId", "PrivateClientSecret", "PrivateClientId", "PrivateClientSecret")]
+    public async Task GetClientByCredentials_ShouldSupportSensitiveOverridesViaConfiguration(
+        string? sensitiveClientId,
+        string? sensitiveClientSecret,
+        string expectedClientId,
+        string expectedClientSecret
+    )
+    {
+        // Arrange
+        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
+
+        _mockConfiguration[$"AuthClientCredentials:{ClientId}:NewClientId"] = sensitiveClientId;
+        _mockConfiguration[$"AuthClientCredentials:{ClientId}:NewClientSecret"] =
+            sensitiveClientSecret;
+
+        // Act
+        var result = await _sut.GetClientByCredentials(expectedClientId, expectedClientSecret);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.Value);
+        Assert.Equal(expectedClientId, result.Value.ClientId);
+    }
 }

--- a/Apps/Find/src/SUI.Find.Infrastructure/Models/AuthClient.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Models/AuthClient.cs
@@ -4,7 +4,6 @@ public sealed class AuthClient
 {
     public string ClientId { get; set; } = string.Empty;
     public string OrganisationId { get; set; } = string.Empty;
-    public string ClientSecret { get; set; } = string.Empty;
     public bool Enabled { get; set; } = true;
     public List<string>? AllowedScopes { get; set; }
 }

--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using SUI.Find.Infrastructure.Models;
 
 namespace SUI.Find.Infrastructure.Services;
@@ -13,11 +14,13 @@ public interface IAuthStoreService
 public class MockAuthStoreService : IAuthStoreService
 {
     private readonly IFileSystem _fileSystem;
+    private readonly IConfiguration _configuration;
     private readonly Lazy<AuthStore> _authStore;
 
-    public MockAuthStoreService(IFileSystem fileSystem)
+    public MockAuthStoreService(IFileSystem fileSystem, IConfiguration configuration)
     {
         _fileSystem = fileSystem;
+        _configuration = configuration;
         _authStore = new Lazy<AuthStore>(LoadStore);
     }
 
@@ -59,6 +62,13 @@ public class MockAuthStoreService : IAuthStoreService
         if (store is null)
         {
             throw new InvalidOperationException("Auth store file could not be deserialized.");
+        }
+
+        foreach (var client in store.Clients ?? []) // rs-todo: tests
+        {
+            client.ClientId =
+                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientId"]
+                ?? client.ClientId;
         }
 
         return store;

--- a/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
+++ b/Apps/Find/src/SUI.Find.Infrastructure/Services/MockAuthStoreService.cs
@@ -64,10 +64,11 @@ public class MockAuthStoreService : IAuthStoreService
             throw new InvalidOperationException("Auth store file could not be deserialized.");
         }
 
-        foreach (var client in store.Clients ?? []) // rs-todo: tests
+        foreach (var client in store.Clients ?? [])
         {
+            var originalClientId = client.ClientId;
             client.ClientId =
-                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientId"]
+                _configuration[$"AuthClientCredentials:{originalClientId}:NewClientId"]
                 ?? client.ClientId;
         }
 

--- a/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/CrossOrganisationIsolationSearchTestsBase.cs
@@ -20,9 +20,9 @@ public abstract class CrossOrganisationIsolationSearchTestsBase(
         );
 
         var attackerClientId =
-            testData.TestClientId == "CLIENT-ID_LOCAL-AUTHORITY-01"
-                ? "CLIENT-ID_EDUCATION-01"
-                : "CLIENT-ID_LOCAL-AUTHORITY-01";
+            testData.TestClientId == "CLIENT_ID_LOCAL_AUTHORITY_01"
+                ? "CLIENT_ID_EDUCATION_01"
+                : "CLIENT_ID_LOCAL_AUTHORITY_01";
 
         var attackerToken = await GetAuthTokenAsync(attackerClientId, TestClientSecret, TestScopes);
 

--- a/Apps/Find/tests/SUI.Find.E2ETests/E2ETestBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/E2ETestBase.cs
@@ -17,6 +17,11 @@ public class E2ETestBase
         TestOutputHelper = testOutputHelper;
 
         TestOutputHelper.WriteLine(Fixture.Config.ToString());
+
+        TestOutputHelper.WriteLine("Startup Diagnostic Messages:");
+        TestOutputHelper.WriteLine(
+            Fixture.StartupDiagnosticMessages == "" ? "None" : Fixture.StartupDiagnosticMessages
+        );
     }
 
     protected async Task<string?> GetAuthTokenAsync(
@@ -25,16 +30,24 @@ public class E2ETestBase
         string[] scopes
     )
     {
+        clientId =
+            Fixture.Configuration[$"E2E:AuthClientCredentials:{clientId}:NewClientId"] ?? clientId;
+
+        clientSecret =
+            Fixture.Configuration[$"E2E:AuthClientCredentials:{clientId}:NewClientSecret"]
+            ?? clientSecret;
+
         var authString = $"{clientId}:{clientSecret}";
         var base64Auth = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(authString));
         var clientCredentials = new AuthenticationHeaderValue("Basic", base64Auth);
 
-        return await GetAuthTokenWithRetryAsync(scopes, clientCredentials);
+        return await GetAuthTokenWithRetryAsync(scopes, clientCredentials, clientId);
     }
 
     private async Task<string> GetAuthTokenWithRetryAsync(
         string[] scopes,
-        AuthenticationHeaderValue clientCredentials
+        AuthenticationHeaderValue clientCredentials,
+        string clientId
     )
     {
         const int retryCount = 12;
@@ -78,7 +91,9 @@ public class E2ETestBase
             request.Content = content;
             request.Headers.Authorization = clientCredentials;
 
-            TestOutputHelper.WriteLine($"Requesting access token from: {request.RequestUri}");
+            TestOutputHelper.WriteLine(
+                $"Requesting access token from: {request.RequestUri} for client ID: {clientId}"
+            );
 
             var response = await Fixture.Client.SendAsync(request);
             if (!response.IsSuccessStatusCode)

--- a/Apps/Find/tests/SUI.Find.E2ETests/E2ETestBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/E2ETestBase.cs
@@ -30,24 +30,33 @@ public class E2ETestBase
         string[] scopes
     )
     {
+        var originalClientId = clientId;
+
         clientId =
-            Fixture.Configuration[$"E2E:AuthClientCredentials:{clientId}:NewClientId"] ?? clientId;
+            Fixture.Configuration[$"E2E:AuthClientCredentials:{originalClientId}:NewClientId"]
+            ?? clientId;
 
         clientSecret =
-            Fixture.Configuration[$"E2E:AuthClientCredentials:{clientId}:NewClientSecret"]
+            Fixture.Configuration[$"E2E:AuthClientCredentials:{originalClientId}:NewClientSecret"]
             ?? clientSecret;
 
         var authString = $"{clientId}:{clientSecret}";
         var base64Auth = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(authString));
         var clientCredentials = new AuthenticationHeaderValue("Basic", base64Auth);
 
-        return await GetAuthTokenWithRetryAsync(scopes, clientCredentials, clientId);
+        return await GetAuthTokenWithRetryAsync(
+            scopes,
+            clientCredentials,
+            clientId,
+            isClientIdSensitive: clientId != originalClientId
+        );
     }
 
     private async Task<string> GetAuthTokenWithRetryAsync(
         string[] scopes,
         AuthenticationHeaderValue clientCredentials,
-        string clientId
+        string clientId,
+        bool isClientIdSensitive
     )
     {
         const int retryCount = 12;
@@ -92,7 +101,7 @@ public class E2ETestBase
             request.Headers.Authorization = clientCredentials;
 
             TestOutputHelper.WriteLine(
-                $"Requesting access token from: {request.RequestUri} for client ID: {clientId}"
+                $"Requesting access token from: {request.RequestUri} for client ID: {FunctionTestFixture.MaskValue(clientId, isClientIdSensitive)}"
             );
 
             var response = await Fixture.Client.SendAsync(request);

--- a/Apps/Find/tests/SUI.Find.E2ETests/FindSmokeTests.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FindSmokeTests.cs
@@ -10,7 +10,7 @@ namespace SUI.Find.E2ETests;
 public class FindSmokeTests(FunctionTestFixture fixture, ITestOutputHelper testOutputHelper)
     : E2ETestBase(fixture, testOutputHelper)
 {
-    private const string TestClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
+    private const string TestClientId = "CLIENT_ID_LOCAL_AUTHORITY_01";
     private const string TestClientSecret = "SUIProject";
     private const int ApiKeyAcceptanceRetryCount = 6;
     private static readonly string[] MatchReadScopes = ["match-record.read"];

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -1,4 +1,6 @@
 using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
 using Azure;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Configuration;
@@ -13,21 +15,38 @@ public class FunctionTestFixture : IAsyncLifetime
     private bool _tableResetComplete;
     private readonly SemaphoreSlim _resetTablesMutex = new(1, 1);
     private const string HealthEndpointUrl = "health";
+    private readonly StringBuilder _startupDiagnosticMessages = new();
 
     public Config Config { get; }
+
+    public IConfiguration Configuration { get; }
 
     public HttpClient Client { get; }
 
     public HttpClient StubCustodiansClient { get; }
 
+    public string StartupDiagnosticMessages => _startupDiagnosticMessages.ToString();
+
     public FunctionTestFixture()
     {
-        var configurationRoot = new ConfigurationBuilder()
+        TransformAuthClientCredentialsEnvironmentVariables(
+            "E2E__AuthClientIdsJsonMap",
+            clientId => $"E2E__AuthClientCredentials__{clientId}__NewClientId",
+            sensitive: true
+        );
+
+        TransformAuthClientCredentialsEnvironmentVariables(
+            "E2E__AuthClientSecretsJsonMap",
+            clientId => $"E2E__AuthClientCredentials__{clientId}__NewClientSecret",
+            sensitive: true
+        );
+
+        Configuration = new ConfigurationBuilder()
             .AddEnvironmentVariables()
             .AddUserSecrets<FunctionTestFixture>()
             .Build();
 
-        Config = configurationRoot.GetSection("E2E").Get<Config>() ?? new Config();
+        Config = Configuration.GetSection("E2E").Get<Config>() ?? new Config();
 
         // For our HTTP clients, retry a small number of times if we ever receive a timeout, with a small wait in between
         var retryPolicy = Policy<HttpResponseMessage>
@@ -54,6 +73,35 @@ public class FunctionTestFixture : IAsyncLifetime
         StubCustodiansClient.Dispose();
         GC.SuppressFinalize(this);
         return ValueTask.CompletedTask;
+    }
+
+    private void TransformAuthClientCredentialsEnvironmentVariables(
+        string sourceEnvironmentVariableName,
+        Func<string, string> transformKey,
+        bool sensitive
+    )
+    {
+        var sourceJsonMap = Environment.GetEnvironmentVariable(sourceEnvironmentVariableName);
+
+        var map = JsonSerializer.Deserialize<Dictionary<string, string>>(sourceJsonMap ?? "{}");
+
+        if (map is { Count: > 0 })
+        {
+            foreach (var (key, value) in map)
+            {
+                var newKey = transformKey(key);
+                Environment.SetEnvironmentVariable(newKey, value);
+
+                var safeValue =
+                    !sensitive ? value
+                    : value.Length < 8 ? "***"
+                    : $"{value[..2]}***{value[^2..]}";
+
+                _startupDiagnosticMessages.AppendLine(
+                    $"Environment variable set: {newKey} = {safeValue}"
+                );
+            }
+        }
     }
 
     private record HealthCheckResponse(string? Value, DateTimeOffset? BuildTimestamp);

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -32,13 +32,13 @@ public class FunctionTestFixture : IAsyncLifetime
         TransformAuthClientCredentialsEnvironmentVariables(
             "E2E__AuthClientIdsJsonMap",
             clientId => $"E2E__AuthClientCredentials__{clientId}__NewClientId",
-            sensitive: true
+            isSensitive: true
         );
 
         TransformAuthClientCredentialsEnvironmentVariables(
             "E2E__AuthClientSecretsJsonMap",
             clientId => $"E2E__AuthClientCredentials__{clientId}__NewClientSecret",
-            sensitive: true
+            isSensitive: true
         );
 
         Configuration = new ConfigurationBuilder()
@@ -75,10 +75,15 @@ public class FunctionTestFixture : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
+    public static string MaskValue(string value, bool isSensitive) =>
+        !isSensitive ? value
+        : value.Length < 8 ? "***"
+        : $"{value[..2]}***{value[^2..]}";
+
     private void TransformAuthClientCredentialsEnvironmentVariables(
         string sourceEnvironmentVariableName,
         Func<string, string> transformKey,
-        bool sensitive
+        bool isSensitive
     )
     {
         var sourceJsonMap = Environment.GetEnvironmentVariable(sourceEnvironmentVariableName);
@@ -92,13 +97,8 @@ public class FunctionTestFixture : IAsyncLifetime
                 var newKey = transformKey(key);
                 Environment.SetEnvironmentVariable(newKey, value);
 
-                var safeValue =
-                    !sensitive ? value
-                    : value.Length < 8 ? "***"
-                    : $"{value[..2]}***{value[^2..]}";
-
                 _startupDiagnosticMessages.AppendLine(
-                    $"Environment variable set: {newKey} = {safeValue}"
+                    $"Environment variable set: {newKey} = {MaskValue(value, isSensitive)}"
                 );
             }
         }

--- a/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/SearchTestsBase.cs
@@ -53,7 +53,7 @@ public abstract class SearchTestsBase(
             new TestData
             {
                 Sui = "9691292211",
-                TestClientId = "CLIENT-ID_LOCAL-AUTHORITY-01",
+                TestClientId = "CLIENT_ID_LOCAL_AUTHORITY_01",
                 Records =
                 [
                     new TestRecord { RecordType = "health.details", TestValue = "Dr E Green" },
@@ -80,7 +80,7 @@ public abstract class SearchTestsBase(
             new TestData
             {
                 Sui = "9691292211",
-                TestClientId = "CLIENT-ID_EDUCATION-01",
+                TestClientId = "CLIENT_ID_EDUCATION_01",
                 Records =
                 [
                     new TestRecord { RecordType = "health.details", TestValue = "Dr E Green" },
@@ -97,13 +97,13 @@ public abstract class SearchTestsBase(
             new TestData
             {
                 Sui = "9449306613",
-                TestClientId = "CLIENT-ID_LOCAL-AUTHORITY-01",
+                TestClientId = "CLIENT_ID_LOCAL_AUTHORITY_01",
                 Records = [new TestRecord { RecordType = "personal.details", TestValue = "Briar" }],
             },
             new TestData
             {
                 Sui = "9449306494",
-                TestClientId = "CLIENT-ID_HEALTH-01",
+                TestClientId = "CLIENT_ID_HEALTH_01",
                 Records =
                 [
                     new TestRecord { RecordType = "personal.details", TestValue = "Red" },
@@ -117,13 +117,13 @@ public abstract class SearchTestsBase(
             new TestData
             {
                 Sui = "9693821998",
-                TestClientId = "CLIENT-ID_LOCAL-AUTHORITY-01",
+                TestClientId = "CLIENT_ID_LOCAL_AUTHORITY_01",
                 Records = [],
             },
             new TestData
             {
                 Sui = "9691292211",
-                TestClientId = "CLIENT-ID_NO-DSA-01",
+                TestClientId = "CLIENT_ID_NO_DSA_01",
                 Records = [],
             },
         ];

--- a/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/AuthContextFactoryTests.cs
+++ b/Apps/Find/tests/SUI.Find.FindApi.UnitTests/MiddlewareTests/AuthContextFactoryTests.cs
@@ -9,7 +9,7 @@ namespace SUI.Find.FindApi.UnitTests.MiddlewareTests;
 
 public class AuthContextFactoryTests
 {
-    private const string ClientId = "CLIENT-ID_EDUCATION-01";
+    private const string ClientId = "CLIENT_ID_EDUCATION_01";
     private const string OrganisationId = "EDUCATION-01";
     private readonly AuthContextFactory _sut;
     private readonly IAuthStoreService _store;

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -97,4 +97,25 @@ public class MockAuthStoreServiceTests
             _sut.GetOrganisationIdForClientId("invalid-client-id")
         );
     }
+
+    [Fact]
+    public async Task GetOrganisationIdForClientId_AndGetScopesByClientId_ShouldSupportSensitiveOverridesViaConfiguration()
+    {
+        // Arrange
+        var fileContent = await File.ReadAllTextAsync(_realStoreFilePath);
+        _mockFileSystem.File.Exists(Arg.Any<string>()).Returns(true);
+        _mockFileSystem.File.ReadAllText(Arg.Any<string>()).Returns(fileContent);
+
+        const string sensitiveClientId = "SensitiveClientId";
+
+        _mockConfiguration[$"AuthClientCredentials:{ClientId}:NewClientId"] = sensitiveClientId;
+
+        // Act
+        var resultOrganisationId = _sut.GetOrganisationIdForClientId(sensitiveClientId);
+        var resultScopes = _sut.GetScopesByClientId(sensitiveClientId);
+
+        // Assert
+        Assert.Equal("LOCAL-AUTHORITY-01", resultOrganisationId);
+        Assert.Equivalent(ExpectedScopes, resultScopes, strict: true);
+    }
 }

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -8,7 +8,7 @@ namespace SUI.Find.Infrastructure.UnitTests.Services;
 
 public class MockAuthStoreServiceTests
 {
-    private const string ClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
+    private const string ClientId = "CLIENT_ID_LOCAL_AUTHORITY_01";
     private const string ExpectedOrganisationId = "LOCAL-AUTHORITY-01";
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
     private readonly IConfiguration _mockConfiguration = Substitute.For<IConfiguration>();

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -1,5 +1,7 @@
 using System.IO.Abstractions;
+using Microsoft.Extensions.Configuration;
 using NSubstitute;
+using NSubstitute.Extensions;
 using SUI.Find.Infrastructure.Services;
 
 namespace SUI.Find.Infrastructure.UnitTests.Services;
@@ -8,6 +10,7 @@ public class MockAuthStoreServiceTests
 {
     private const string ClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
+    private readonly IConfiguration _mockConfiguration = Substitute.For<IConfiguration>();
     private readonly MockAuthStoreService _sut;
     private readonly string _realStoreFilePath;
     private static readonly string[] ExpectedScopes =
@@ -23,7 +26,9 @@ public class MockAuthStoreServiceTests
 
     public MockAuthStoreServiceTests()
     {
-        _sut = new MockAuthStoreService(_mockFileSystem);
+        _mockConfiguration.ReturnsForAll((string?)null);
+
+        _sut = new MockAuthStoreService(_mockFileSystem, _mockConfiguration);
         _realStoreFilePath = Path.Join(
             AppContext.BaseDirectory,
             "Data",

--- a/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
+++ b/Apps/Find/tests/SUI.Find.Infrastructure.UnitTests/Services/MockAuthStoreServiceTests.cs
@@ -9,6 +9,7 @@ namespace SUI.Find.Infrastructure.UnitTests.Services;
 public class MockAuthStoreServiceTests
 {
     private const string ClientId = "CLIENT-ID_LOCAL-AUTHORITY-01";
+    private const string ExpectedOrganisationId = "LOCAL-AUTHORITY-01";
     private readonly IFileSystem _mockFileSystem = Substitute.For<IFileSystem>();
     private readonly IConfiguration _mockConfiguration = Substitute.For<IConfiguration>();
     private readonly MockAuthStoreService _sut;
@@ -80,7 +81,7 @@ public class MockAuthStoreServiceTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal("LOCAL-AUTHORITY-01", result);
+        Assert.Equal(ExpectedOrganisationId, result);
     }
 
     [Fact]
@@ -115,7 +116,7 @@ public class MockAuthStoreServiceTests
         var resultScopes = _sut.GetScopesByClientId(sensitiveClientId);
 
         // Assert
-        Assert.Equal("LOCAL-AUTHORITY-01", resultOrganisationId);
+        Assert.Equal(ExpectedOrganisationId, resultOrganisationId);
         Assert.Equivalent(ExpectedScopes, resultScopes, strict: true);
     }
 }

--- a/Apps/StubCustodians/src/SUI.StubCustodians.Application/Services/FindApiAuthClientProvider.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.Application/Services/FindApiAuthClientProvider.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using SUI.StubCustodians.Application.Interfaces;
 using SUI.StubCustodians.Application.Models;
 
@@ -6,16 +7,18 @@ namespace SUI.StubCustodians.Application.Services;
 
 public class FindApiAuthClientProvider : IFindApiAuthClientProvider
 {
+    private readonly IConfiguration _configuration;
     private readonly Lazy<IReadOnlyList<AuthClient>> _authClients;
 
-    public FindApiAuthClientProvider()
+    public FindApiAuthClientProvider(IConfiguration configuration)
     {
+        _configuration = configuration;
         _authClients = new Lazy<IReadOnlyList<AuthClient>>(Load);
     }
 
     public IReadOnlyList<AuthClient> GetAuthClients() => _authClients.Value;
 
-    private static IReadOnlyList<AuthClient> Load()
+    private IReadOnlyList<AuthClient> Load()
     {
         var path = Path.Combine(AppContext.BaseDirectory, "Data", "auth-clients-inbound.json");
 
@@ -26,10 +29,20 @@ public class FindApiAuthClientProvider : IFindApiAuthClientProvider
 
         var json = File.ReadAllText(path);
 
-        var data =
+        var store =
             JsonSerializer.Deserialize<AuthStore>(json, JsonSerializerOptions.Web)
             ?? throw new InvalidOperationException("Invalid auth-clients-inbound.json");
 
-        return data.Clients ?? [];
+        foreach (var client in store.Clients ?? []) // rs-todo: tests
+        {
+            client.ClientId =
+                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientId"]
+                ?? client.ClientId;
+            client.ClientSecret =
+                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientSecret"]
+                ?? client.ClientSecret;
+        }
+
+        return store.Clients ?? [];
     }
 }

--- a/Apps/StubCustodians/src/SUI.StubCustodians.Application/Services/FindApiAuthClientProvider.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.Application/Services/FindApiAuthClientProvider.cs
@@ -33,13 +33,14 @@ public class FindApiAuthClientProvider : IFindApiAuthClientProvider
             JsonSerializer.Deserialize<AuthStore>(json, JsonSerializerOptions.Web)
             ?? throw new InvalidOperationException("Invalid auth-clients-inbound.json");
 
-        foreach (var client in store.Clients ?? []) // rs-todo: tests
+        foreach (var client in store.Clients ?? [])
         {
+            var originalClientId = client.ClientId;
             client.ClientId =
-                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientId"]
+                _configuration[$"AuthClientCredentials:{originalClientId}:NewClientId"]
                 ?? client.ClientId;
             client.ClientSecret =
-                _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientSecret"]
+                _configuration[$"AuthClientCredentials:{originalClientId}:NewClientSecret"]
                 ?? client.ClientSecret;
         }
 

--- a/Apps/StubCustodians/src/SUI.StubCustodians.Application/Utilities/CustodianWorker.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.Application/Utilities/CustodianWorker.cs
@@ -68,8 +68,9 @@ public class CustodianWorker : BackgroundService
     {
         if (_logger.IsEnabled(LogLevel.Information))
             _logger.LogInformation(
-                "Custodian {ClientId} started. Interval: {Interval}s",
-                _authClient.ClientId,
+                "Custodian {OrganisationId} ({ClientId}) started. Interval: {Interval} seconds",
+                _authClient.OrganisationId,
+                _clientId,
                 _intervalSeconds
             );
 
@@ -109,7 +110,12 @@ public class CustodianWorker : BackgroundService
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Polling failed for {ClientId}", _authClient.ClientId);
+                _logger.LogError(
+                    ex,
+                    "Polling failed for {OrganisationId} ({ClientId})",
+                    _authClient.OrganisationId,
+                    _clientId
+                );
                 sleep = true;
             }
 

--- a/Apps/StubCustodians/tests/SUI.StubCustodians.Application.Unit.Tests/Services/FindApiAuthClientProviderTests.cs
+++ b/Apps/StubCustodians/tests/SUI.StubCustodians.Application.Unit.Tests/Services/FindApiAuthClientProviderTests.cs
@@ -152,4 +152,55 @@ public class FindApiAuthClientProviderTests
             Cleanup();
         }
     }
+
+    [Theory]
+    [InlineData(null, null, "LOCAL-AUTHORITY-01", "SUIProject")]
+    [InlineData("SensitiveClientId", null, "SensitiveClientId", "SUIProject")]
+    [InlineData(null, "SensitiveClientSecret", "LOCAL-AUTHORITY-01", "SensitiveClientSecret")]
+    [InlineData("PrivateClientId", "PrivateClientSecret", "PrivateClientId", "PrivateClientSecret")]
+    public void GetAuthClients_ShouldSupportSensitiveOverridesViaConfiguration(
+        string? sensitiveClientId,
+        string? sensitiveClientSecret,
+        string expectedClientId,
+        string expectedClientSecret
+    )
+    {
+        try
+        {
+            var json = """
+                {
+                  "clients": [
+                    {
+                      "enabled": true,
+                      "clientId": "LOCAL-AUTHORITY-01",
+                      "clientSecret": "SUIProject",
+                      "allowedScopes": [
+                        "work-item.read",
+                        "work-item.write"
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+            WriteJson(json);
+
+            _mockConfiguration["AuthClientCredentials:LOCAL-AUTHORITY-01:NewClientId"] =
+                sensitiveClientId;
+            _mockConfiguration["AuthClientCredentials:LOCAL-AUTHORITY-01:NewClientSecret"] =
+                sensitiveClientSecret;
+
+            // ACT
+            var clients = _sut.GetAuthClients();
+
+            // ASSERT
+            Assert.Single(clients);
+            Assert.Equal(expectedClientId, clients[0].ClientId);
+            Assert.Equal(expectedClientSecret, clients[0].ClientSecret);
+        }
+        finally
+        {
+            Cleanup();
+        }
+    }
 }

--- a/Apps/StubCustodians/tests/SUI.StubCustodians.Application.Unit.Tests/Services/FindApiAuthClientProviderTests.cs
+++ b/Apps/StubCustodians/tests/SUI.StubCustodians.Application.Unit.Tests/Services/FindApiAuthClientProviderTests.cs
@@ -1,10 +1,24 @@
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using NSubstitute.Extensions;
 using SUI.StubCustodians.Application.Services;
 
 namespace SUI.StubCustodians.Application.Unit.Tests.Services;
 
 public class FindApiAuthClientProviderTests
 {
+    private readonly IConfiguration _mockConfiguration = Substitute.For<IConfiguration>();
+
+    private readonly FindApiAuthClientProvider _sut;
+
+    public FindApiAuthClientProviderTests()
+    {
+        _mockConfiguration.ReturnsForAll((string?)null);
+
+        _sut = new FindApiAuthClientProvider(_mockConfiguration);
+    }
+
     private static string DataDirectory => Path.Combine(AppContext.BaseDirectory, "Data");
 
     private static string FilePath => Path.Combine(DataDirectory, "auth-clients-inbound.json");
@@ -44,10 +58,10 @@ public class FindApiAuthClientProviderTests
 
             WriteJson(json);
 
-            var provider = new FindApiAuthClientProvider();
+            // ACT
+            var clients = _sut.GetAuthClients();
 
-            var clients = provider.GetAuthClients();
-
+            // ASSERT
             Assert.Single(clients);
             Assert.Equal("LOCAL-AUTHORITY-01", clients[0].ClientId);
         }
@@ -80,11 +94,11 @@ public class FindApiAuthClientProviderTests
 
             WriteJson(json);
 
-            var provider = new FindApiAuthClientProvider();
+            // ACT
+            var first = _sut.GetAuthClients();
+            var second = _sut.GetAuthClients();
 
-            var first = provider.GetAuthClients();
-            var second = provider.GetAuthClients();
-
+            // ASSERT
             Assert.Same(first, second);
         }
         finally
@@ -98,9 +112,8 @@ public class FindApiAuthClientProviderTests
     {
         Cleanup();
 
-        var provider = new FindApiAuthClientProvider();
-
-        var ex = Assert.Throws<InvalidOperationException>(() => provider.GetAuthClients());
+        // ACT & ASSERT
+        var ex = Assert.Throws<InvalidOperationException>(() => _sut.GetAuthClients());
 
         Assert.Contains("auth-clients-inbound.json not found", ex.Message);
     }
@@ -112,9 +125,8 @@ public class FindApiAuthClientProviderTests
         {
             WriteJson("invalid-json");
 
-            var provider = new FindApiAuthClientProvider();
-
-            Assert.ThrowsAny<JsonException>(() => provider.GetAuthClients());
+            // ACT & ASSERT
+            Assert.ThrowsAny<JsonException>(() => _sut.GetAuthClients());
         }
         finally
         {
@@ -129,10 +141,10 @@ public class FindApiAuthClientProviderTests
         {
             WriteJson("{}");
 
-            var provider = new FindApiAuthClientProvider();
+            // ACT
+            var result = _sut.GetAuthClients();
 
-            var result = provider.GetAuthClients();
-
+            // ASSERT
             Assert.Empty(result);
         }
         finally

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindApiAuthClientProvider.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindApiAuthClientProvider.cs
@@ -5,11 +5,18 @@ namespace SUI.UIHarness.Web.Services;
 
 public class FindApiAuthClientProvider : IFindApiAuthClientProvider
 {
-    private readonly Lazy<IReadOnlyList<AuthClient>> _authClients = new(Load);
+    private readonly Lazy<IReadOnlyList<AuthClient>> _authClients;
+    private readonly IConfiguration _configuration;
+
+    public FindApiAuthClientProvider(IConfiguration configuration)
+    {
+        _configuration = configuration;
+        _authClients = new Lazy<IReadOnlyList<AuthClient>>(Load);
+    }
 
     public IReadOnlyList<AuthClient> GetAuthClients() => _authClients.Value;
 
-    private static AuthClient[] Load()
+    private AuthClient[] Load()
     {
         var path = Path.Combine(AppContext.BaseDirectory, "Data", "auth-clients-inbound.json");
 
@@ -20,11 +27,23 @@ public class FindApiAuthClientProvider : IFindApiAuthClientProvider
 
         var json = File.ReadAllText(path);
 
-        var data =
+        var store =
             JsonSerializer.Deserialize<AuthStore>(json, JsonSerializerOptions.Web)
             ?? throw new InvalidOperationException("Invalid auth-clients-inbound.json");
 
-        return data.Clients ?? [];
+        return (store.Clients ?? [])
+            .Select(client =>
+                client with
+                {
+                    ClientId =
+                        _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientId"]
+                        ?? client.ClientId,
+                    ClientSecret =
+                        _configuration[$"AuthClientCredentials:{client.ClientId}:NewClientSecret"]
+                        ?? client.ClientSecret,
+                }
+            )
+            .ToArray();
     }
 
     private record AuthStore(AuthClient[]? Clients);

--- a/Data/auth-clients-inbound.json
+++ b/Data/auth-clients-inbound.json
@@ -2,7 +2,7 @@
   "clients": [
     {
       "enabled": true,
-      "clientId": "CLIENT-ID_LOCAL-AUTHORITY-01",
+      "clientId": "CLIENT_ID_LOCAL_AUTHORITY_01",
       "organisationId": "LOCAL-AUTHORITY-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -17,7 +17,7 @@
     },
     {
       "enabled": true,
-      "clientId": "CLIENT-ID_EDUCATION-01",
+      "clientId": "CLIENT_ID_EDUCATION_01",
       "organisationId": "EDUCATION-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -32,7 +32,7 @@
     },
     {
       "enabled": true,
-      "clientId": "CLIENT-ID_HEALTH-01",
+      "clientId": "CLIENT_ID_HEALTH_01",
       "organisationId": "HEALTH-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -47,7 +47,7 @@
     },
     {
       "enabled": true,
-      "clientId": "CLIENT-ID_POLICE-01",
+      "clientId": "CLIENT_ID_POLICE_01",
       "organisationId": "POLICE-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -62,7 +62,7 @@
     },
     {
       "enabled": true,
-      "clientId": "CLIENT-ID_HOUSING-01",
+      "clientId": "CLIENT_ID_HOUSING_01",
       "organisationId": "HOUSING-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [
@@ -77,7 +77,7 @@
     },
     {
       "enabled": true,
-      "clientId": "CLIENT-ID_NO-DSA-01",
+      "clientId": "CLIENT_ID_NO_DSA_01",
       "organisationId": "NO-DSA-01",
       "clientSecret": "SUIProject",
       "allowedScopes": [

--- a/README.md
+++ b/README.md
@@ -303,12 +303,12 @@ Both secrets must be JSON maps, where the key is the original Client ID and the 
 
 `AUTH_CLIENT_IDS_JSON_MAP` expects a map of `OriginalClientId` to `SensitiveClientId`, for example:
 ```json
-{"CLIENT-ID_LOCAL-AUTHORITY-01":"sensitive-client-id-1", "CLIENT-ID_EDUCATION-01":"sensitive-client-id-2"}
+{"CLIENT_ID_LOCAL_AUTHORITY_01":"sensitive-client-id-1", "CLIENT_ID_EDUCATION_01":"sensitive-client-id-2"}
 ```
 
 `AUTH_CLIENT_SECRETS_JSON_MAP` expects a map of `OriginalClientId` to `SensitiveClientSecret`, for example:
 ```json
-{"CLIENT-ID_LOCAL-AUTHORITY-01":"sensitive-client-secret-1", "CLIENT-ID_EDUCATION-01":"sensitive-client-secret-2"}
+{"CLIENT_ID_LOCAL_AUTHORITY_01":"sensitive-client-secret-1", "CLIENT_ID_EDUCATION_01":"sensitive-client-secret-2"}
 ```
 
 **It is important to note that these values must be a single line.  They must not be multi-line.  Newline characters break the GitHub workflows!**

--- a/README.md
+++ b/README.md
@@ -287,3 +287,40 @@ Example:
 ```
 GITHUB_USERNAME=YourGitHubUsername GITHUB_TOKEN_DFENUGET=YourTokenHere dotnet watch run --launch-profile https
 ```
+
+
+## Configuring Non-public Client IDs and Secrets for Authentication
+
+While having client secrets in a public repo is fine for local development and ephemeral environments, deployed environments should use actual secret values (rather than pretend secret values that have been publicly published) so that unauthorised people cannot authenticate with our deployed environments.
+
+This is achieved via the `AuthClientCredentials` configuration functionality that enables overriding the Client IDs and Secrets in the sample data.
+
+Ultimately this is driven by GitHub Environment Secrets called:
+- `AUTH_CLIENT_IDS_JSON_MAP`
+- `AUTH_CLIENT_SECRETS_JSON_MAP`
+
+Both secrets must be JSON maps, where the key is the original Client ID and the value is the corresponding private value.
+
+`AUTH_CLIENT_IDS_JSON_MAP` expects a map of `OriginalClientId` to `SensitiveClientId`, for example:
+```json
+{"CLIENT-ID_LOCAL-AUTHORITY-01":"sensitive-client-id-1", "CLIENT-ID_EDUCATION-01":"sensitive-client-id-2"}
+```
+
+`AUTH_CLIENT_SECRETS_JSON_MAP` expects a map of `OriginalClientId` to `SensitiveClientSecret`, for example:
+```json
+{"CLIENT-ID_LOCAL-AUTHORITY-01":"sensitive-client-secret-1", "CLIENT-ID_EDUCATION-01":"sensitive-client-secret-2"}
+```
+
+**It is important to note that these values must be a single line.  They must not be multi-line.  Newline characters break the GitHub workflows!**
+
+The PowerShell script `scripts/generate-auth-client-credentials-secrets.ps1` exists to help generate the values.
+
+To generate secret values:
+```bash
+dotnet pwsh ./scripts/generate-auth-client-credentials-secrets.ps1
+```
+
+To generate template values:
+```bash
+dotnet pwsh ./scripts/generate-auth-client-credentials-secrets.ps1 -TemplateMode
+```

--- a/scripts/generate-auth-client-credentials-secrets.ps1
+++ b/scripts/generate-auth-client-credentials-secrets.ps1
@@ -1,0 +1,51 @@
+<#
+    .DESCRIPTION
+    Script for generating the values/templates to use for the AUTH_CLIENT_IDS_JSON_MAP and AUTH_CLIENT_SECRETS_JSON_MAP secrets.
+    This is for the `AuthClientCredentials` configuration functionality that enables overriding the Client IDs and Secrets in the sample data.
+
+    .EXAMPLE
+    (Having already run `dotnet tool restore` as a one-off prerequisite. Using the dotnet tool alleviates PowerShell execution policy issues.)
+
+    To generate secret values:
+    dotnet pwsh ./scripts/generate-auth-client-credentials-secrets.ps1
+
+    To generate template values:
+    dotnet pwsh ./scripts/generate-auth-client-credentials-secrets.ps1 -TemplateMode
+#>
+
+param(
+    [switch]$TemplateMode
+)
+
+$ErrorActionPreference = "Stop"
+
+$authClientsFilePath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "..\Data\auth-clients-inbound.json"))
+$authClients = Get-Content -Path $authClientsFilePath -Raw | ConvertFrom-Json
+
+$clientIdsMap = [ordered]@{}
+$clientSecretMap = [ordered]@{}
+
+$rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+try {
+    foreach ($client in $authClients.clients) {
+        if ($TemplateMode) {
+            $clientIdsMap[$client.clientId] = ""
+            $clientSecretMap[$client.clientId] = ""
+        } else {
+            $clientIdsMap[$client.clientId] = "$(New-Guid)"
+
+            $randomBytes = New-Object byte[] 32
+            $rng.GetBytes($randomBytes)
+            $base64Secret = [System.Convert]::ToBase64String($randomBytes).TrimEnd('=')
+            $clientSecretMap[$client.clientId] = $base64Secret
+        }
+    }
+} finally {
+    $rng.Dispose()
+}
+
+Write-Host "AUTH_CLIENT_IDS_JSON_MAP:" -ForegroundColor Cyan
+Write-Host "$($clientIdsMap | ConvertTo-Json -Compress)" -ForegroundColor Green
+
+Write-Host "AUTH_CLIENT_SECRETS_JSON_MAP:" -ForegroundColor Cyan
+Write-Host "$($clientSecretMap | ConvertTo-Json -Compress)" -ForegroundColor Green

--- a/terraform/auth-emulator/main.tf
+++ b/terraform/auth-emulator/main.tf
@@ -55,6 +55,21 @@ module "web_app" {
       AuthSettings__BaseUrl = format("https://%s%sapp-%s-authemulator01.azurewebsites.net/", var.subscription_prefix, var.environment_id, var.region_short)
     },
     var.authemulator_app_settings,
+
+    # AuthClientCredentials:
+    {
+      # Provided for debugging and ease of updating, because these value can be retrieved from the app settings in the Azure Portal:
+      AuthClientIdsJsonMap = sensitive(var.AuthClientIdsJsonMap),
+      AuthClientSecretsJsonMap = sensitive(var.AuthClientSecretsJsonMap),
+    },
+    {
+      for clientId, newClientId in jsondecode(nonsensitive(coalesce(var.AuthClientIdsJsonMap, "{}"))) :
+        "AuthClientCredentials__${clientId}__NewClientId" => sensitive(newClientId)
+    },
+    {
+      for clientId, newClientSecret in jsondecode(nonsensitive(coalesce(var.AuthClientSecretsJsonMap, "{}"))) :
+        "AuthClientCredentials__${clientId}__NewClientSecret" => sensitive(newClientSecret)
+    },
   )
   tags           = var.tags
 }

--- a/terraform/auth-emulator/variables.tf
+++ b/terraform/auth-emulator/variables.tf
@@ -91,3 +91,17 @@ variable "AuthSettings_Audience" {
   type        = string
   sensitive   = true
 }
+
+variable "AuthClientIdsJsonMap" {
+  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Not considered sensitive."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "AuthClientSecretsJsonMap" {
+  description = "Optional string containing a JSON map to transform the Client Secrets in the sample data. Contains sensitive data, must be masked."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/terraform/auth-emulator/variables.tf
+++ b/terraform/auth-emulator/variables.tf
@@ -93,7 +93,7 @@ variable "AuthSettings_Audience" {
 }
 
 variable "AuthClientIdsJsonMap" {
-  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Not considered sensitive."
+  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Could contain sensitive data, should be masked."
   type        = string
   default     = null
   sensitive   = true

--- a/terraform/custodians/main.tf
+++ b/terraform/custodians/main.tf
@@ -52,6 +52,21 @@ module "web_app" {
       StubCustodians__BaseUrl = format("https://%s%sapp-%s-custodians01.azurewebsites.net", var.subscription_prefix, var.environment_id, var.region_short)
     },
     var.custodian_app_settings,
+
+    # AuthClientCredentials:
+    {
+      # Provided for debugging and ease of updating, because these value can be retrieved from the app settings in the Azure Portal:
+      AuthClientIdsJsonMap = sensitive(var.AuthClientIdsJsonMap),
+      AuthClientSecretsJsonMap = sensitive(var.AuthClientSecretsJsonMap),
+    },
+    {
+      for clientId, newClientId in jsondecode(nonsensitive(coalesce(var.AuthClientIdsJsonMap, "{}"))) :
+        "AuthClientCredentials__${clientId}__NewClientId" => sensitive(newClientId)
+    },
+    {
+      for clientId, newClientSecret in jsondecode(nonsensitive(coalesce(var.AuthClientSecretsJsonMap, "{}"))) :
+        "AuthClientCredentials__${clientId}__NewClientSecret" => sensitive(newClientSecret)
+    },
   )
   tags           = var.tags
 }

--- a/terraform/custodians/variables.tf
+++ b/terraform/custodians/variables.tf
@@ -85,3 +85,17 @@ variable "AuthSettings_AccessTokenUrl" {
   type        = string
   sensitive   = true
 }
+
+variable "AuthClientIdsJsonMap" {
+  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Not considered sensitive."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "AuthClientSecretsJsonMap" {
+  description = "Optional string containing a JSON map to transform the Client Secrets in the sample data. Contains sensitive data, must be masked."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/terraform/custodians/variables.tf
+++ b/terraform/custodians/variables.tf
@@ -87,7 +87,7 @@ variable "AuthSettings_AccessTokenUrl" {
 }
 
 variable "AuthClientIdsJsonMap" {
-  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Not considered sensitive."
+  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Could contain sensitive data, should be masked."
   type        = string
   default     = null
   sensitive   = true

--- a/terraform/find/main.tf
+++ b/terraform/find/main.tf
@@ -221,7 +221,17 @@ module "function_app" {
       NhsAuthConfig__NHS_DIGITAL_KID         = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_kid.name}/)"
       NhsAuthConfig__NHS_DIGITAL_CLIENT_ID   = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_client_id.name}/)"
     },
-    var.find_app_settings
+    var.find_app_settings,
+
+    # AuthClientCredentials:
+    {
+      # Provided for debugging and ease of updating, because these value can be retrieved from the app settings in the Azure Portal:
+      AuthClientIdsJsonMap = sensitive(var.AuthClientIdsJsonMap),
+    },
+    {
+      for clientId, newClientId in jsondecode(nonsensitive(coalesce(var.AuthClientIdsJsonMap, "{}"))) :
+        "AuthClientCredentials__${clientId}__NewClientId" => sensitive(newClientId)
+    },
   )
 
   application_insights_connection_string = data.terraform_remote_state.core.outputs.app_insights_connection_string

--- a/terraform/find/variables.tf
+++ b/terraform/find/variables.tf
@@ -146,7 +146,7 @@ variable "AuthSettings_AccessTokenUrl" {
 }
 
 variable "AuthClientIdsJsonMap" {
-  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Not considered sensitive."
+  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Could contain sensitive data, should be masked."
   type        = string
   default     = null
   sensitive   = true

--- a/terraform/find/variables.tf
+++ b/terraform/find/variables.tf
@@ -144,3 +144,10 @@ variable "AuthSettings_AccessTokenUrl" {
   type        = string
   sensitive   = true
 }
+
+variable "AuthClientIdsJsonMap" {
+  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Not considered sensitive."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/terraform/ui_test_harness/main.tf
+++ b/terraform/ui_test_harness/main.tf
@@ -132,6 +132,21 @@ module "web_app" {
       MATCH_API_KEY            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.find_match_api_key.versionless_id})"
     },
     var.ui_harness_app_settings,
+
+    # AuthClientCredentials:
+    {
+      # Provided for debugging and ease of updating, because these value can be retrieved from the app settings in the Azure Portal:
+      AuthClientIdsJsonMap = sensitive(var.AuthClientIdsJsonMap),
+      AuthClientSecretsJsonMap = sensitive(var.AuthClientSecretsJsonMap),
+    },
+    {
+      for clientId, newClientId in jsondecode(nonsensitive(coalesce(var.AuthClientIdsJsonMap, "{}"))) :
+        "AuthClientCredentials__${clientId}__NewClientId" => sensitive(newClientId)
+    },
+    {
+      for clientId, newClientSecret in jsondecode(nonsensitive(coalesce(var.AuthClientSecretsJsonMap, "{}"))) :
+        "AuthClientCredentials__${clientId}__NewClientSecret" => sensitive(newClientSecret)
+    },
   )
   tags = var.tags
 }

--- a/terraform/ui_test_harness/variables.tf
+++ b/terraform/ui_test_harness/variables.tf
@@ -91,3 +91,17 @@ variable "AuthSettings_AccessTokenUrl" {
   type        = string
   sensitive   = true
 }
+
+variable "AuthClientIdsJsonMap" {
+  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Not considered sensitive."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "AuthClientSecretsJsonMap" {
+  description = "Optional string containing a JSON map to transform the Client Secrets in the sample data. Contains sensitive data, must be masked."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/terraform/ui_test_harness/variables.tf
+++ b/terraform/ui_test_harness/variables.tf
@@ -93,7 +93,7 @@ variable "AuthSettings_AccessTokenUrl" {
 }
 
 variable "AuthClientIdsJsonMap" {
-  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Not considered sensitive."
+  description = "Optional string containing a JSON map to transform the Client IDs in the sample data. Could contain sensitive data, should be masked."
   type        = string
   default     = null
   sensitive   = true


### PR DESCRIPTION
## Summary

This PR enables non-public Client IDs and Secrets in our sample/mock data.

While having client secrets in a public repo is fine for local development and ephemeral environments, deployed environments should use actual secret values (rather than pretend secret values that have been publicly published) so that unauthorised people cannot authenticate with our deployed environments.

This will also enable us to be able to integrate with real identity providers, like Find and Use an API.

The design and implementation has been careful not to reveal any sensitive information in the public code or public workflow logs.

## Important Caveat

This design and implementation is a pragmatic step to completing the Auth Evolution, especially now that the scope of the programme is changing.

The final, tidier, and more straight forward to operate solution would be to remove our mock Organisation Directory and design and implement real a Organisation Directory, probably using Azure App Configuration.  However, it is not feasible to do that at this point in the project.

## Changes

- Added ability to override the Client IDs and Secrets in the Auth Store data, driving these values from JSON maps ultimately from GitHub Environment Secrets.
- Update sample data client IDs to not use dashes/hyphens.  Unfortunately hyphens are not supported as environment variable names in Azure App Settings, so the most straight forward solution is to sanitise our client IDs at source.
- Updated readme and added script to help explain and ease setup.

Also includes:
- `CustodianWorker` update: switch some more logging across to where its more useful to also see the Organisation ID.

## Validation

- Terraform plans
- Unit and E2E test runs
- Review of logs, to ensure no sensitive information is exposed:

<img width="698" height="407" alt="image" src="https://github.com/user-attachments/assets/8b68b6d6-93cc-4247-870f-e74f512298ee" />

<img width="803" height="292" alt="image" src="https://github.com/user-attachments/assets/d5ac5c37-e3f1-4893-8026-723695894b53" />

<img width="461" height="101" alt="image" src="https://github.com/user-attachments/assets/02f932e8-75de-4735-945d-a0c39dc26d96" />
