### PR TITLE
fix: SUI-1851 - corrected the runtime hosting environment tag for Azure Funcs

### DIFF
--- a/terraform/modules/linux_function_app/main.tf
+++ b/terraform/modules/linux_function_app/main.tf
@@ -4,7 +4,7 @@ locals {
       FUNCTIONS_WORKER_RUNTIME    = "dotnet-isolated"
       WEBSITE_RUN_FROM_PACKAGE    = "1"
     },
-    var.environment_tag == null ? {} : { ASPNETCORE_ENVIRONMENT = var.environment_tag },
+    var.environment_tag == null ? {} : { AZURE_FUNCTIONS_ENVIRONMENT = var.environment_tag },
   )
 
   base_tags = merge(


### PR DESCRIPTION
## Summary

Our Azure Functions running in the Dev environment report back their Environment Name as `Production`, whereas they should report back `Dev` like the Web Apps do.  This PR fixes that issue by correctly specify the runtime hosting environment tag of our function apps, based on: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#azure_functions_environment.

## Validation

- Plan and then Apply of Find Terraform against d01, now https://s270d01func-ukw-find01.azurewebsites.net/api/health correctly reports: `"EnvironmentName": "Dev"`