### PR TITLE
fix: SUI-1849 - resolve invalid "Turn on Application Insights" message in Azure Portal

### DIFF
--- a/terraform/modules/linux_web_app/main.tf
+++ b/terraform/modules/linux_web_app/main.tf
@@ -4,6 +4,7 @@ locals {
       WEBSITE_RUN_FROM_PACKAGE = "1"
       APPLICATIONINSIGHTS_CONNECTION_STRING = sensitive(var.application_insights_connection_string)
     },
+    var.application_insights_connection_string == null ? {} : { ApplicationInsightsAgent_EXTENSION_VERSION = "~3" },
     var.environment_tag == null ? {} : { ASPNETCORE_ENVIRONMENT = var.environment_tag },
   )
 


### PR DESCRIPTION
## Summary

The changes in this PR fix the invalid "Turn on Application Insights" message that was appearing for Web Apps, which was caused by a quirk with Azure Portal + Terraform.

Because we are setting up the link to App Insights via Terraform, we need to explicitly set this value too, otherwise the Azure Portal isn't in a valid state.

By setting this value, the App Insights blade of each Web App now shows the correct information, whereas before it was incorrectly showing just a "Turn on Application Insights" message.

## Changes

- Explicitly set the `ApplicationInsightsAgent_EXTENSION_VERSION = "~3"` app setting for our web apps, in the Terraform web app module.

## Validation

- Planned then applied to `d01` for the `StubCustodians`, and saw that the issue was resolved.