### PR TITLE
fix: SUI-1808 - Add trailing slash back into non-gateway custodians settings

### DIFF
--- a/terraform/custodians/main.tf
+++ b/terraform/custodians/main.tf
@@ -51,7 +51,7 @@ module "web_app" {
       OTEL_RESOURCE_ATTRIBUTES = local.otel_resource_attributes
       AuthSettings__AccessTokenUrl = var.AuthSettings_AccessTokenUrl
       AuthSettings__FindApiGatewayAuthScope = var.FindApiGatewayAuthScope
-      FindApi__BaseUrl = coalesce(var.FindApiGatewayBaseUrl, format("https://%s%sfunc-%s-find01.azurewebsites.net/api", var.subscription_prefix, var.environment_id, var.region_short))
+      FindApi__BaseUrl = coalesce(var.FindApiGatewayBaseUrl, format("https://%s%sfunc-%s-find01.azurewebsites.net/api/", var.subscription_prefix, var.environment_id, var.region_short))
       StubCustodians__BaseUrl = format("https://%s%sapp-%s-custodians01.azurewebsites.net", var.subscription_prefix, var.environment_id, var.region_short)
     },
     var.custodian_app_settings,


### PR DESCRIPTION


<!--
Ensure PR title follows the conventional commit format with a Jira ticket reference:
<type>: SUI-1234 - concise description
-->

## Summary

Add a missing trailing slash to ensure E2E tests pass on a non-gateway environment

<!--
Describe the intent of the PR at a high level:
- what problem or need this change addresses
- why this approach was taken
- any important scope or non-goals if they matter for review
-->

## Changes

<!--
List the concrete changes in reviewer-friendly bullets.
Keep this focused on the meaningful implementation/documentation changes.
-->

- Add trailing slash to default Find Base Url

## Validation

<!--
List how you validated the change.
Examples:
- Unit/integration/E2E tests run
- Manual validation steps
- Terraform plan/apply environments
- Docs-only change; no code/runtime validation required
-->

- E2E Tests on d01 and d03


