### PR TITLE
chore: SUI-1856 - Improve FindApi BaseUrl config flexibility

### DIFF
--- a/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/Config.cs
@@ -2,9 +2,17 @@
 
 public record Config
 {
-    public string BaseUrl { get; init; } = "http://localhost:7182/api/";
+    public string BaseUrl
+    {
+        get;
+        init => field = EnsureTrailingSlash(value);
+    } = "http://localhost:7182/api/";
 
-    public string StubCustodiansBaseUrl { get; init; } = "https://localhost:7256/api/";
+    public string StubCustodiansBaseUrl
+    {
+        get;
+        init => field = EnsureTrailingSlash(value);
+    } = "https://localhost:7256/api/";
 
     public bool IsLocal => BaseUrl.Contains("localhost");
 
@@ -41,4 +49,15 @@ public record Config
         "https://localhost:7250/api/health";
 
     public DateTimeOffset? CheckAuthEmulatorApiBuildTimestampThreshold { get; init; }
+
+    /// <summary>
+    /// Ensures that the base URL has a trailing slash to work with RFC 3986.
+    /// </summary>
+    /// <remarks>
+    /// Because of the official web standard (RFC 3986) for resolving URIs, if the base address does not end with a
+    /// trailing slash (/), the last segment of the path is treated as a file, not a directory.
+    /// This behaviour exists in .NET and hence breaks the configuration if it is missing a trailing slash.
+    /// Hence, this method ensures that the base address always ends with a trailing slash.
+    /// </remarks>
+    private static string EnsureTrailingSlash(string baseUrl) => baseUrl.TrimEnd('/') + '/';
 }

--- a/Apps/StubCustodians/src/SUI.StubCustodians.API/Program.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.API/Program.cs
@@ -1,6 +1,7 @@
 using Asp.Versioning;
 using Asp.Versioning.ApiExplorer;
 using SUI.StubCustodians.API.OpenApi;
+using SUI.StubCustodians.Application.Extensions;
 using SUI.StubCustodians.Application.Interfaces;
 using SUI.StubCustodians.Application.Services;
 using SUI.StubCustodians.Application.Utilities;
@@ -100,18 +101,15 @@ namespace SUI.StubCustodians.API
             services.AddHttpContextAccessor();
             services.AddSingleton<IBaseUrlProvider, HttpContextBaseUrlProvider>();
 
-            var baseUrl =
-                configuration["FindApi:BaseUrl"]
-                ?? throw new InvalidOperationException("FindApi:BaseUrl configuration is missing");
+            services.AddHttpClient<ITokenProvider, TokenProvider>();
 
-            services.AddHttpClient<ITokenProvider, TokenProvider>(c =>
-            {
-                c.BaseAddress = new Uri(baseUrl);
-            });
+            var findApiBaseUrl =
+                configuration["FindApi:BaseUrl"]?.EnsureTrailingSlash()
+                ?? throw new InvalidOperationException("FindApi:BaseUrl configuration is missing");
 
             services.AddHttpClient<IFindApiClient, FindApiClient>(c =>
             {
-                c.BaseAddress = new Uri(baseUrl);
+                c.BaseAddress = new Uri(findApiBaseUrl);
             });
 
             var sp = services.BuildServiceProvider();

--- a/Apps/StubCustodians/src/SUI.StubCustodians.Application/Extensions/StringExtensions.cs
+++ b/Apps/StubCustodians/src/SUI.StubCustodians.Application/Extensions/StringExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace SUI.StubCustodians.Application.Extensions;
+
+public static class StringExtensions
+{
+    /// <summary>
+    /// Ensures that the base URL has a trailing slash to work with RFC 3986.
+    /// </summary>
+    public static string EnsureTrailingSlash(this string baseUrl) => baseUrl.TrimEnd('/') + '/';
+}

--- a/Apps/StubCustodians/tests/SUI.StubCustodians.Application.Unit.Tests/Extensions/StringExtensionsTests.cs
+++ b/Apps/StubCustodians/tests/SUI.StubCustodians.Application.Unit.Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,13 @@
+﻿using SUI.StubCustodians.Application.Extensions;
+
+namespace SUI.StubCustodians.Application.Unit.Tests.Extensions;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData("example", "example/")]
+    [InlineData("example/", "example/")]
+    [InlineData("example//", "example/")]
+    public void EnsureTrailingSlash_Tests(string input, string expected) =>
+        Assert.Equal(expected, input.EnsureTrailingSlash());
+}

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Extensions/StringExtensions.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Extensions/StringExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace SUI.UIHarness.Web.Extensions;
+
+public static class StringExtensions
+{
+    /// <summary>
+    /// Ensures that the base URL has a trailing slash to work with RFC 3986.
+    /// </summary>
+    public static string EnsureTrailingSlash(this string baseUrl) => baseUrl.TrimEnd('/') + '/';
+}

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc;
 using SUI.UIHarness.Web;
 using SUI.UIHarness.Web.Components;
+using SUI.UIHarness.Web.Extensions;
 using SUI.UIHarness.Web.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -23,7 +24,7 @@ builder
 builder.Services.AddAuthorization();
 
 var baseUrl =
-    builder.Configuration["BaseUrl"]
+    builder.Configuration["BaseUrl"]?.EnsureTrailingSlash()
     ?? throw new InvalidOperationException("BaseUrl configuration is missing");
 
 builder.Services.AddHttpClient(

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.Development.json
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.Development.json
@@ -5,7 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "BaseUrl": "http://localhost:7182/",
+  "BaseUrl": "http://localhost:7182/api",
   "ArchitectureOptionHidden": false,
   "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
   "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",


### PR DESCRIPTION
## Summary

To make it easier to configure the system in the future -and avoid time consuming, tricky to debug errors- the system has been updated to support the Find API Base URL config value with or without a trailing slash.

## Changes

- Updated the places where the Find API base URL is used (Stubs, UI Test Harness & E2E Tests) to support the URL with or without the trailing slash.
- Also fixed the API prefix change for when the UI Test Harness locally.

## Validation

- Manual E2E tests runs and manual run of Test Harness