### PR TITLE
build: swap order of Auth Emulator and Stub Custodians in ephemeral E2E tests to avoid errors

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -184,14 +184,14 @@ jobs:
       - name: Start AuthEmulator API
         run: dotnet run --no-build --launch-profile https &
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
-        
-      - name: Start StubCustodians API
-        run: dotnet run --no-build --launch-profile https &
-        working-directory: Apps/StubCustodians/src/SUI.StubCustodians.API
 
       - name: Start Find API
         run: func start --port 7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
+
+      - name: Start StubCustodians API
+        run: dotnet run --no-build --launch-profile https &
+        working-directory: Apps/StubCustodians/src/SUI.StubCustodians.API
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -181,13 +181,13 @@ jobs:
           cp Apps/Find/src/SUI.Find.FindApi/example.local.settings.json \
              Apps/Find/src/SUI.Find.FindApi/local.settings.json
 
-      - name: Start StubCustodians API
-        run: dotnet run --no-build --launch-profile https &
-        working-directory: Apps/StubCustodians/src/SUI.StubCustodians.API
-
       - name: Start AuthEmulator API
         run: dotnet run --no-build --launch-profile https &
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
+        
+      - name: Start StubCustodians API
+        run: dotnet run --no-build --launch-profile https &
+        working-directory: Apps/StubCustodians/src/SUI.StubCustodians.API
 
       - name: Start Find API
         run: func start --port 7182 &


### PR DESCRIPTION

## Summary

The Stub Custodians are dependent on the Auth Emulator and Find, so I'm swapping the order in which they're run in the ephemeral E2E tests so that the custodians don't throw errors on a successful test run

## Changes

- Move run step for Custodians to end of E2E Test order to avoid unnecessary errors

## Validation

- E2E tests
