### PR TITLE
feat: SUI-1855 - enable UI Test Harness to work when Find API is behind a gateway

### DIFF
--- a/.github/rotate-keyvault-secret.manifest.json
+++ b/.github/rotate-keyvault-secret.manifest.json
@@ -42,7 +42,8 @@
         "enabled": true,
         "environments": [
           "d01",
-          "d02"
+          "d02",
+          "d03"
         ]
       }
     }

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Pages/Home.razor
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Components/Pages/Home.razor
@@ -42,7 +42,7 @@
         @if (_showDebug)
         {
            <div class="mt-3">
-                <div><strong>Base URL:</strong> @Configuration["BaseURL"]</div>
+                <div><strong>Base URL:</strong> @Configuration[ConfigKeys.FindApiBaseUrl]</div>
                 <div><strong>Architecture:</strong> @_architecture</div>
                 <div><strong>@(_architecture == ArchitectureConstants.Fanout ? "Job ID" : "Work Item ID"):</strong> @_currentWorkItemId</div>
                 @if (!string.IsNullOrWhiteSpace(_currentTraceId))
@@ -138,7 +138,7 @@
             return (null, null);
         }
         
-        var isLocal = Configuration["BaseURL"]?.Contains("localhost") == true;
+        var isLocal = Configuration[ConfigKeys.FindApiBaseUrl]?.Contains("localhost") == true;
         return isLocal
             ? ($"http://localhost:18888/structuredlogs?filters=log.traceid%3Aequals%3A{traceId}", null)
             : (null, $"""

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/ConfigKeys.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/ConfigKeys.cs
@@ -1,0 +1,28 @@
+﻿namespace SUI.UIHarness.Web;
+
+public static class ConfigKeys
+{
+    /// <summary>
+    /// Configuration key for the Base URL of the Find API.
+    /// Required.
+    /// </summary>
+    public const string FindApiBaseUrl = "FindApi:BaseUrl";
+
+    /// <summary>
+    /// Configuration key for the Auth Scope to use when calling the Find API via a Gateway.
+    /// Optional, only needed when the Find API is behind a Gateway.
+    /// </summary>
+    public const string FindApiGatewayAuthScope = "AuthSettings:FindApiGatewayAuthScope";
+
+    /// <summary>
+    /// Configuration key for the URL to use to get client credential access tokens for subsequently calling the Find API.
+    /// Required.
+    /// </summary>
+    public const string AccessTokenUrl = "AuthSettings:AccessTokenUrl";
+
+    /// <summary>
+    /// Configuration key for the API Key to use when calling the Match endpoint.
+    /// Required.
+    /// </summary>
+    public const string MatchApiKey = "MATCH_API_KEY";
+}

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/ConfigKeys.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/ConfigKeys.cs
@@ -6,7 +6,7 @@ public static class ConfigKeys
     /// Configuration key for the Base URL of the Find API.
     /// Required.
     /// </summary>
-    public const string FindApiBaseUrl = "FindApi:BaseUrl";
+    public const string FindApiBaseUrl = "BaseUrl";
 
     /// <summary>
     /// Configuration key for the Auth Scope to use when calling the Find API via a Gateway.

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Program.cs
@@ -23,13 +23,13 @@ builder
     });
 builder.Services.AddAuthorization();
 
-var baseUrl =
-    builder.Configuration["BaseUrl"]?.EnsureTrailingSlash()
-    ?? throw new InvalidOperationException("BaseUrl configuration is missing");
+var findApiBaseUrl =
+    builder.Configuration[ConfigKeys.FindApiBaseUrl]?.EnsureTrailingSlash()
+    ?? throw new InvalidOperationException($"{ConfigKeys.FindApiBaseUrl} configuration is missing");
 
 builder.Services.AddHttpClient(
     nameof(FindService),
-    client => client.BaseAddress = new Uri(baseUrl)
+    client => client.BaseAddress = new Uri(findApiBaseUrl)
 );
 builder.Services.AddScoped<IFindService, FindService>();
 builder.Services.AddScoped<IFindApiAuthClientProvider, FindApiAuthClientProvider>();

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindService.cs
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/Services/FindService.cs
@@ -14,15 +14,7 @@ public class FindService : IFindService
     private readonly ILogger<FindService> _logger;
     private readonly string _matchApiKey;
     private readonly string _inboundAccessTokenUrl;
-
-    private static readonly string[] Scopes =
-    [
-        "match-record.read",
-        "find-record.write",
-        "find-record.read",
-        "fetch-record.write",
-        "fetch-record.read",
-    ];
+    private readonly string? _gatewayAuthScope;
 
     private const string ErrorPersonId = "Error";
     private const string NotFoundPersonId = "Not Found";
@@ -36,17 +28,21 @@ public class FindService : IFindService
     {
         _httpClient = httpClientFactory.CreateClient(nameof(FindService));
         _authClientProvider = authClientProvider;
-        _matchApiKey = configuration.GetValue<string>("MATCH_API_KEY") ?? "local-dev-key-change-me";
+        _matchApiKey =
+            configuration.GetValue<string>(ConfigKeys.MatchApiKey) ?? "local-dev-key-change-me";
         _inboundAccessTokenUrl =
-            configuration.GetValue<string>("AuthSettings:AccessTokenUrl")
-            ?? "https://localhost:7250/api/v1/auth/token";
+            configuration.GetValue<string>(ConfigKeys.AccessTokenUrl)
+            ?? throw new InvalidOperationException(
+                $"{ConfigKeys.AccessTokenUrl} configuration is missing"
+            );
+        _gatewayAuthScope = configuration.GetValue<string>(ConfigKeys.FindApiGatewayAuthScope);
         _logger = logger;
     }
 
     public async Task<FindMatchResult> MatchRecord(LocalPerson person, string clientId)
     {
         string personId;
-        await GetAuthTokenAsync(clientId, Scopes);
+        await GetAuthTokenAsync(clientId);
         var matchRequest = new FindMatchRequest
         {
             Metadata = [],
@@ -105,7 +101,7 @@ public class FindService : IFindService
 
     public async Task<StartSearchResult> StartSearch(string clientId, string suid, bool usePolling)
     {
-        await GetAuthTokenAsync(clientId, Scopes);
+        await GetAuthTokenAsync(clientId);
 
         try
         {
@@ -155,7 +151,7 @@ public class FindService : IFindService
         bool usePolling
     )
     {
-        await GetAuthTokenAsync(clientId, Scopes);
+        await GetAuthTokenAsync(clientId);
 
         try
         {
@@ -205,7 +201,7 @@ public class FindService : IFindService
 
     public async Task<FindCustodianRecord?> FetchRecord(string clientId, string recordId)
     {
-        await GetAuthTokenAsync(clientId, Scopes);
+        await GetAuthTokenAsync(clientId);
 
         try
         {
@@ -227,12 +223,12 @@ public class FindService : IFindService
         return null;
     }
 
-    private async Task GetAuthTokenAsync(string clientId, string[] scopes)
+    private async Task GetAuthTokenAsync(string clientId)
     {
-        var formData = new Dictionary<string, string>
+        var formData = new Dictionary<string, string?>
         {
             { "grant_type", "client_credentials" },
-            { "scope", string.Join(" ", scopes) },
+            { "scope", _gatewayAuthScope },
         };
 
         var content = new FormUrlEncodedContent(formData);

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.Development.json
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.Development.json
@@ -5,7 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "BaseUrl": "http://localhost:7182/api",
+  "FindApi": {
+    "BaseUrl": "http://localhost:7182/api"
+  },
+  "AuthSettings": {
+    "AccessTokenUrl": "https://localhost:7250/api/v1/auth/token"
+  },
   "ArchitectureOptionHidden": false,
   "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
   "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.Development.json
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.Development.json
@@ -5,9 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "FindApi": {
-    "BaseUrl": "http://localhost:7182/api"
-  },
+  "BaseUrl": "http://localhost:7182/api",
   "AuthSettings": {
     "AccessTokenUrl": "https://localhost:7250/api/v1/auth/token"
   },

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.json
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.json
@@ -6,9 +6,11 @@
     }
   },
   "AllowedHosts": "*",
-  "BaseUrl": "",
+  "FindApi": {
+    "BaseUrl": ""
+  },
   "AuthSettings": {
-    "AccessTokenUrl": "https://localhost:7250/api/v1/auth/token"
+    "AccessTokenUrl": ""
   },
   "MATCH_API_KEY": "local-dev-key-change-me",
   "UI_TEST_HARNESS_PASSWORD": "local-dev-only",

--- a/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.json
+++ b/Apps/UIHarness/src/SUI.UIHarness.Web/appsettings.json
@@ -6,9 +6,7 @@
     }
   },
   "AllowedHosts": "*",
-  "FindApi": {
-    "BaseUrl": ""
-  },
+  "BaseUrl": "",
   "AuthSettings": {
     "AccessTokenUrl": ""
   },

--- a/terraform/ui_test_harness/app/main.tf
+++ b/terraform/ui_test_harness/app/main.tf
@@ -124,7 +124,7 @@ module "web_app" {
     {
       OTEL_RESOURCE_ATTRIBUTES              = local.otel_resource_attributes
 
-      FindApi__BaseUrl = coalesce(var.FindApiGatewayBaseUrl, format("https://%s%sfunc-%s-find01.azurewebsites.net/api/", var.subscription_prefix, var.environment_id, var.region_short))
+      BaseUrl = coalesce(var.FindApiGatewayBaseUrl, format("https://%s%sfunc-%s-find01.azurewebsites.net/api/", var.subscription_prefix, var.environment_id, var.region_short))
 
       AuthSettings__AccessTokenUrl = var.AuthSettings_AccessTokenUrl
       AuthSettings__FindApiGatewayAuthScope = var.FindApiGatewayAuthScope

--- a/terraform/ui_test_harness/app/main.tf
+++ b/terraform/ui_test_harness/app/main.tf
@@ -124,9 +124,10 @@ module "web_app" {
     {
       OTEL_RESOURCE_ATTRIBUTES              = local.otel_resource_attributes
 
-      BaseUrl = coalesce(var.FindApiGatewayBaseUrl, format("https://%s%sfunc-%s-find01.azurewebsites.net/api/", var.subscription_prefix, var.environment_id, var.region_short))
+      FindApi__BaseUrl = coalesce(var.FindApiGatewayBaseUrl, format("https://%s%sfunc-%s-find01.azurewebsites.net/api/", var.subscription_prefix, var.environment_id, var.region_short))
 
       AuthSettings__AccessTokenUrl = var.AuthSettings_AccessTokenUrl
+      AuthSettings__FindApiGatewayAuthScope = var.FindApiGatewayAuthScope
 
       # Key Vault References mapped to App Settings
       UI_TEST_HARNESS_PASSWORD = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.ui_harness_password.name}/)"

--- a/terraform/ui_test_harness/app/variables.tf
+++ b/terraform/ui_test_harness/app/variables.tf
@@ -111,3 +111,9 @@ variable "FindApiGatewayBaseUrl" {
   type = string
   default = null
 }
+
+variable "FindApiGatewayAuthScope" {
+  description = "Optional Auth Scopes needed to use Find through a gateway"
+  type = string
+  default = null
+}

--- a/terraform/ui_test_harness/main.tf
+++ b/terraform/ui_test_harness/main.tf
@@ -25,6 +25,7 @@ module "app" {
   AuthClientIdsJsonMap          = var.AuthClientIdsJsonMap
   AuthClientSecretsJsonMap      = var.AuthClientSecretsJsonMap
   FindApiGatewayBaseUrl         = var.FindApiGatewayBaseUrl
+  FindApiGatewayAuthScope       = var.FindApiGatewayAuthScope
 }
 
 # Moving top-level resources down into the conditional 'app' sub-module to prevent destroy/recreate during refactoring.

--- a/terraform/ui_test_harness/variables.tf
+++ b/terraform/ui_test_harness/variables.tf
@@ -117,3 +117,9 @@ variable "FindApiGatewayBaseUrl" {
   type = string
   default = null
 }
+
+variable "FindApiGatewayAuthScope" {
+  description = "Optional Auth Scopes needed to use Find through a gateway"
+  type = string
+  default = null
+}


### PR DESCRIPTION
## Summary

The changes in this PR enable the UI Test Harness to work when the Find API is behind a gateway, and includes related tidying.

## Changes

* UI Test Harness changes:
    * Added optional Gateway Auth Scope to the UI Test Harness, to use when calling Find API.
    * Removed `SUI.UIHarness.Web.Services.FindService.Scopes` because its not necessary.
    * Standardised config approach to use constants, to make the code more cohesive and future proofed.  Decided not to use options pattern in this case because the additional overhead isn't justified in a test harness.

Also includes:
- Noticed and updated the Find Match API key to be rotated in d03 too.

## Validation

- Manually triggered deployments of Terraform and App to d02 and d03, and manually tested to verify everything works as expected, whether there is a gateway or not.
- E2E test run locally and via GitHub ephemeral workflow.