### PR TITLE
feat(E2E): SUI-1850 - Restrict retrying on E2E health check and access token steps to avoid unnecessary retries

### DIFF
--- a/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Headers;
+﻿using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Polly;
@@ -53,11 +54,30 @@ public class AccessTokenProvider(FunctionTestFixture testFixture)
         var retryPolicy = Policy
             .Handle<Exception>(ex =>
             {
+                bool retry;
+                if (ex is HttpRequestException httpEx)
+                {
+                    testOutputHelper.WriteLine(
+                        $"Warning: exception while attempting to get auth token: {nameof(HttpRequestException)}:{httpEx.StatusCode} - {httpEx.Message}"
+                    );
+
+                    retry = httpEx.StatusCode switch
+                    {
+                        HttpStatusCode.BadRequest
+                        or HttpStatusCode.Unauthorized
+                        or HttpStatusCode.Forbidden
+                        or HttpStatusCode.InternalServerError => false,
+                        _ => true, // default to retrying for all other http exceptions
+                    };
+
+                    return retry;
+                }
+
                 testOutputHelper.WriteLine(
                     $"Warning: exception while attempting to get auth token: {ex.Message}"
                 );
 
-                const bool retry = true;
+                retry = false;
                 return retry;
             })
             .WaitAndRetryAsync(
@@ -96,7 +116,11 @@ public class AccessTokenProvider(FunctionTestFixture testFixture)
             if (!response.IsSuccessStatusCode)
             {
                 var error = await response.Content.ReadAsStringAsync();
-                throw new HttpRequestException($"Auth Failed: {response.StatusCode} - {error}");
+                throw new HttpRequestException(
+                    $"Auth Failed: {response.StatusCode} - {error}",
+                    statusCode: response.StatusCode,
+                    inner: null
+                );
             }
 
             var result = await response.Content.ReadFromJsonAsync<JsonElement>();

--- a/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
@@ -63,11 +63,12 @@ public class AccessTokenProvider(FunctionTestFixture testFixture)
 
                     retry = httpEx.StatusCode switch
                     {
-                        HttpStatusCode.BadRequest
-                        or HttpStatusCode.Unauthorized
-                        or HttpStatusCode.Forbidden
-                        or HttpStatusCode.InternalServerError => false,
-                        _ => true, // default to retrying for all other http exceptions
+                        HttpStatusCode.RequestTimeout
+                        or HttpStatusCode.TooManyRequests
+                        or HttpStatusCode.BadGateway
+                        or HttpStatusCode.ServiceUnavailable
+                        or HttpStatusCode.GatewayTimeout => true, // only retry for possible transient issues
+                        _ => false,
                     };
 
                     return retry;

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -307,11 +307,12 @@ public class FunctionTestFixture : IAsyncLifetime
 
                 return httpEx.StatusCode switch
                 {
-                    HttpStatusCode.BadRequest
-                    or HttpStatusCode.Unauthorized
-                    or HttpStatusCode.Forbidden
-                    or HttpStatusCode.InternalServerError => (false, false),
-                    _ => (false, true), // default to retrying for all other http exceptions
+                    HttpStatusCode.RequestTimeout
+                    or HttpStatusCode.TooManyRequests
+                    or HttpStatusCode.BadGateway
+                    or HttpStatusCode.ServiceUnavailable
+                    or HttpStatusCode.GatewayTimeout => (false, true), // only retry for possible transient issues
+                    _ => (false, false),
                 };
             }
             catch (Exception ex)

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
@@ -256,7 +257,7 @@ public class FunctionTestFixture : IAsyncLifetime
         // If health check does not indicate healthy, wait and then retry
         var retryCount = (int)Math.Round(timeout / waitInterval);
         var retryPolicy = Policy
-            .HandleResult<bool>(healthy => !healthy)
+            .HandleResult(((bool healthy, bool retry) result) => result.retry)
             .WaitAndRetryAsync(
                 retryCount,
                 retryAttempt =>
@@ -268,7 +269,7 @@ public class FunctionTestFixture : IAsyncLifetime
                 }
             );
 
-        var healthy = await retryPolicy.ExecuteAsync(async () =>
+        var (healthy, retry) = await retryPolicy.ExecuteAsync(async () =>
         {
             try
             {
@@ -278,8 +279,11 @@ public class FunctionTestFixture : IAsyncLifetime
                 using var response = await client.SendAsync(request);
                 var content = response.Content.ReadFromJsonAsync<HealthCheckResponse>().Result;
 
-                return content?.Value == "Healthy"
+                var healthy =
+                    content?.Value == "Healthy"
                     && (checkBuildTimestampThreshold == null || CheckBuildTimestampThreshold());
+
+                return (healthy, !healthy); // Retry if endpoint does not return "Healthy" or timestamp threshold is not met
 
                 // When used, this check causes the tests to wait until the API responds with a build timestamp which is on or after a known point in time that confirms the latest version is in use.
                 // This resolves false failures which can occur when the e2e tests are triggered immediately after deployment.
@@ -295,13 +299,28 @@ public class FunctionTestFixture : IAsyncLifetime
                     return isBuiltSinceThreshold;
                 }
             }
+            catch (HttpRequestException httpEx)
+            {
+                testOutputHelper.WriteLine(
+                    $"Warning: health check exception ({serviceName}): {nameof(HttpRequestException)}:{httpEx.StatusCode} - {httpEx.Message}"
+                );
+
+                return httpEx.StatusCode switch
+                {
+                    HttpStatusCode.BadRequest
+                    or HttpStatusCode.Unauthorized
+                    or HttpStatusCode.Forbidden
+                    or HttpStatusCode.InternalServerError => (false, false),
+                    _ => (false, true), // default to retrying for all other http exceptions
+                };
+            }
             catch (Exception ex)
             {
                 testOutputHelper.WriteLine(
                     $"Warning: health check exception ({serviceName}): {ex.GetType().Name}: {ex.Message}"
                 );
 
-                return false;
+                return (false, false); // Do not retry for any non-http exceptions
             }
         });
 


### PR DESCRIPTION
## Summary

The retry policies on some areas of the E2E tests are too broad, so we are waiting through multiple retries even when non-recoverable errors occur.

This PR restricts the health check and access token endpoints to limit their retries to a subset of http request exceptions.

## Changes

- Don't retry health check endpoint if a non-http exception is thrown, or if specific http requests are thrown
- Don't retry access token endpoint if a non-http exception is thrown, or if specific http requests are thrown

## Validation

- Running E2E tests
