### PR TITLE
feat(E2E): Add caching to access token retrieval for the E2E tests

### DIFF
--- a/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
@@ -1,12 +1,15 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
 using Polly;
 
 namespace SUI.Find.E2ETests;
 
-public class AccessTokenProvider(FunctionTestFixture testFixture)
+public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache cache)
 {
     public async Task<string?> GetAuthTokenAsync(
         string clientId,
@@ -27,12 +30,26 @@ public class AccessTokenProvider(FunctionTestFixture testFixture)
             ]
             ?? clientSecret;
 
-        return await GetAuthTokenWithRetryAsync(
-            scopes,
-            clientId,
-            clientSecret,
-            testOutputHelper,
-            isClientIdSensitive: clientId != originalClientId
+        var cacheKeyPlainText =
+            $"{clientId}_{clientSecret}_{string.Join("_", (scopes ?? []).Order())}";
+        var cacheKey = Convert.ToBase64String(
+            SHA256.HashData(Encoding.UTF8.GetBytes(cacheKeyPlainText))
+        );
+
+        return await cache.GetOrCreateAsync<string?>(
+            cacheKey,
+            async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30);
+
+                return await GetAuthTokenWithRetryAsync(
+                    scopes,
+                    clientId,
+                    clientSecret,
+                    testOutputHelper,
+                    isClientIdSensitive: clientId != originalClientId
+                );
+            }
         );
     }
 

--- a/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
@@ -36,6 +36,11 @@ public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache c
             SHA256.HashData(Encoding.UTF8.GetBytes(cacheKeyPlainText))
         );
 
+        if (cache.TryGetValue(cacheKey, out _))
+        {
+            testOutputHelper.WriteLine("Access token cache used");
+        }
+
         return await cache.GetOrCreateAsync<string?>(
             cacheKey,
             async _ =>

--- a/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
@@ -36,11 +36,6 @@ public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache c
             SHA256.HashData(Encoding.UTF8.GetBytes(cacheKeyPlainText))
         );
 
-        if (cache.TryGetValue(cacheKey, out _))
-        {
-            testOutputHelper.WriteLine("Access token cache used");
-        }
-
         return await cache.GetOrCreateAsync<string?>(
             cacheKey,
             async _ =>

--- a/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
@@ -38,17 +38,17 @@ public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache c
 
         return await cache.GetOrCreateAsync<string?>(
             cacheKey,
-            async entry =>
-            {
-                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30);
-
-                return await GetAuthTokenWithRetryAsync(
+            async _ =>
+                await GetAuthTokenWithRetryAsync(
                     scopes,
                     clientId,
                     clientSecret,
                     testOutputHelper,
                     isClientIdSensitive: clientId != originalClientId
-                );
+                ),
+            new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30),
             }
         );
     }

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using Azure;
 using Azure.Data.Tables;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Http;
 using Polly;
@@ -28,6 +29,8 @@ public class FunctionTestFixture : IAsyncLifetime
     public HttpClient StubCustodiansClient { get; }
 
     public AccessTokenProvider AccessTokenProvider { get; }
+
+    private MemoryCache Cache { get; }
 
     public string StartupDiagnosticMessages => _startupDiagnosticMessages.ToString();
 
@@ -67,7 +70,9 @@ public class FunctionTestFixture : IAsyncLifetime
             BaseAddress = new Uri(Config.StubCustodiansBaseUrl),
         };
 
-        AccessTokenProvider = new AccessTokenProvider(this);
+        Cache = new MemoryCache(new MemoryCacheOptions());
+
+        AccessTokenProvider = new AccessTokenProvider(this, Cache);
     }
 
     public ValueTask InitializeAsync() => ValueTask.CompletedTask;
@@ -77,6 +82,7 @@ public class FunctionTestFixture : IAsyncLifetime
         // MAYBE: Delete everything in storage as a cleanup operation?
         Client.Dispose();
         StubCustodiansClient.Dispose();
+        Cache.Dispose();
         GC.SuppressFinalize(this);
         return ValueTask.CompletedTask;
     }


### PR DESCRIPTION
## Summary

Add in-memory caching for the access token for the end to end tests, to minimise the number of calls needed to the auth endpoint.

## Changes

- Add memory cache to Function Test Fixture, to be used by the Access Token Provider
- Apply caching to the access tokens

## Validation

- E2E Tests - local, ephemeral, and in d01