### PR TITLE
test: SUI-1845 - E2E test coverage of authentication & authorisation

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -272,7 +272,7 @@ jobs:
           E2E__AuthClientSecretsJsonMap: ${{ secrets.AUTH_CLIENT_SECRETS_JSON_MAP }}
         run: |
           dotnet test Apps/Find/tests/SUI.Find.E2ETests/SUI.Find.E2ETests.csproj \
-            --filter "Category=E2E&Suite=Standard" \
+            --filter "Category=E2E&Suite=Standard&RequiresAuthEmulator!=true" \
             --logger "console;verbosity=detailed" \
             --logger "trx;LogFileName=e2e-dev.trx" \
             --results-directory TestResults \

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/AuthController.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Controllers/AuthController.cs
@@ -74,7 +74,14 @@ public class AuthController(
             grantedScopes = requestedScopes;
         }
 
-        var token = jwtTokenService.GenerateToken(authClient.TokenRequest!.ClientId, grantedScopes);
+        var modeHeader = HttpContext.Request.Headers["mode"].FirstOrDefault();
+
+        // Pass the mode string to the token service
+        var token = jwtTokenService.GenerateToken(
+            authClient.TokenRequest!.ClientId,
+            grantedScopes,
+            modeHeader
+        );
 
         return TypedResults.Ok(
             new AuthTokenResponse

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/IJwtTokenService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/IJwtTokenService.cs
@@ -2,5 +2,5 @@ namespace SUI.AuthEmulator.Services;
 
 public interface IJwtTokenService
 {
-    string GenerateToken(string clientId, IReadOnlyList<string> scopes);
+    string GenerateToken(string clientId, IReadOnlyList<string> scopes, string? mode = null);
 }

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/JwtTokenService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/JwtTokenService.cs
@@ -45,36 +45,6 @@ public class JwtTokenService(
             }
         }
 
-        // Determine which signing credentials to use
-        SigningCredentials credentials;
-
-        if (mode?.Equals("spoof-private-key", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            // Generate a fake, on-the-fly RSA key pair
-            var rsa = RSA.Create(2048);
-            var fakeKey = new RsaSecurityKey(rsa) { KeyId = Guid.NewGuid().ToString("N") };
-            credentials = new SigningCredentials(fakeKey, SecurityAlgorithms.RsaSha256);
-        }
-        else
-        {
-            // Fetch active keys from the JWKS key provider
-            var signingKeys = jwksKeyProvider.GetKeys();
-
-            if (signingKeys.Count == 0)
-            {
-                throw new InvalidOperationException(
-                    "No RSA signing keys are available from the JWKS provider."
-                );
-            }
-
-            // Randomly choose an RSA security key securely using CSPRNG
-            var randomIndex = RandomNumberGenerator.GetInt32(signingKeys.Count);
-            var selectedKey = signingKeys.ElementAt(randomIndex);
-
-            // Grab the Asymmetric Signing Credentials directly from the record
-            credentials = selectedKey.SigningCredentials;
-        }
-
         // Build the claims collection using updated configuration settings
         var claims = new List<Claim>
         {
@@ -87,6 +57,47 @@ public class JwtTokenService(
             new("client_id", clientId),
             new("scp", string.Join(' ', scopes)),
         };
+
+        // Determine which signing credentials to use
+        SigningCredentials credentials;
+
+        if (mode?.Equals("spoof-private-key", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            // Generate a fake, on-the-fly RSA key pair
+            using var rsa = RSA.Create(2048);
+            var fakeKey = new RsaSecurityKey(rsa) { KeyId = Guid.NewGuid().ToString("N") };
+            credentials = new SigningCredentials(fakeKey, SecurityAlgorithms.RsaSha256);
+
+            // Generate the asymmetric JWT structure
+            var spoofJwt = new JwtSecurityToken(
+                issuer: issuer,
+                audience: audience,
+                claims: claims,
+                notBefore: now.UtcDateTime,
+                expires: expires.UtcDateTime,
+                signingCredentials: credentials
+            );
+
+            // Write the token and return while RSA is still alive
+            return new JwtSecurityTokenHandler().WriteToken(spoofJwt);
+        }
+
+        // Fetch active keys from the JWKS key provider
+        var signingKeys = jwksKeyProvider.GetKeys();
+
+        if (signingKeys.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "No RSA signing keys are available from the JWKS provider."
+            );
+        }
+
+        // Randomly choose an RSA security key securely using CSPRNG
+        var randomIndex = RandomNumberGenerator.GetInt32(signingKeys.Count);
+        var selectedKey = signingKeys.ElementAt(randomIndex);
+
+        // Grab the Asymmetric Signing Credentials directly from the record
+        credentials = selectedKey.SigningCredentials;
 
         // Generate the asymmetric JWT structure
         var jwt = new JwtSecurityToken(

--- a/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/JwtTokenService.cs
+++ b/Apps/AuthEmulator/src/SUI.AuthEmulator/Services/JwtTokenService.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using SUI.AuthEmulator.Configurations;
 
 namespace SUI.AuthEmulator.Services;
@@ -14,28 +15,65 @@ public class JwtTokenService(
 {
     private readonly AuthSettings _authSettings = authSettings.Value;
 
-    public string GenerateToken(string clientId, IReadOnlyList<string> scopes)
+    public string GenerateToken(string clientId, IReadOnlyList<string> scopes, string? mode = null)
     {
-        // Fetch active keys from the JWKS key provider
-        var signingKeys = jwksKeyProvider.GetKeys();
-
-        if (signingKeys.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "No RSA signing keys are available from the JWKS provider."
-            );
-        }
-
-        // Randomly choose an RSA security key securely using CSPRNG
-        var randomIndex = RandomNumberGenerator.GetInt32(signingKeys.Count);
-        var selectedKey = signingKeys.ElementAt(randomIndex);
-
-        // Grab the Asymmetric Signing Credentials directly from the record
-        var credentials = selectedKey.SigningCredentials;
-
-        // Calculate token lifetime using the testable TimeProvider
+        // Set standard defaults
         var now = timeProvider.GetUtcNow();
         var expires = now.AddMinutes(_authSettings.TokenLifetimeMinutes);
+        var issuer = _authSettings.Issuer;
+        var audience = _authSettings.Audience;
+
+        // Apply tampering logic based on the mode
+        if (!string.IsNullOrWhiteSpace(mode))
+        {
+            switch (mode.ToLowerInvariant())
+            {
+                case "not-yet-active":
+                    now = timeProvider.GetUtcNow().AddHours(2);
+                    expires = timeProvider.GetUtcNow().AddHours(3);
+                    break;
+                case "expired":
+                    now = timeProvider.GetUtcNow().AddHours(-3);
+                    expires = timeProvider.GetUtcNow().AddHours(-2);
+                    break;
+                case "spoof-issuer":
+                    issuer = "spoof";
+                    break;
+                case "spoof-audience":
+                    audience = "spoof";
+                    break;
+            }
+        }
+
+        // Determine which signing credentials to use
+        SigningCredentials credentials;
+
+        if (mode?.Equals("spoof-private-key", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            // Generate a fake, on-the-fly RSA key pair
+            var rsa = RSA.Create(2048);
+            var fakeKey = new RsaSecurityKey(rsa) { KeyId = Guid.NewGuid().ToString("N") };
+            credentials = new SigningCredentials(fakeKey, SecurityAlgorithms.RsaSha256);
+        }
+        else
+        {
+            // Fetch active keys from the JWKS key provider
+            var signingKeys = jwksKeyProvider.GetKeys();
+
+            if (signingKeys.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "No RSA signing keys are available from the JWKS provider."
+                );
+            }
+
+            // Randomly choose an RSA security key securely using CSPRNG
+            var randomIndex = RandomNumberGenerator.GetInt32(signingKeys.Count);
+            var selectedKey = signingKeys.ElementAt(randomIndex);
+
+            // Grab the Asymmetric Signing Credentials directly from the record
+            credentials = selectedKey.SigningCredentials;
+        }
 
         // Build the claims collection using updated configuration settings
         var claims = new List<Claim>
@@ -52,8 +90,8 @@ public class JwtTokenService(
 
         // Generate the asymmetric JWT structure
         var jwt = new JwtSecurityToken(
-            issuer: _authSettings.Issuer,
-            audience: _authSettings.Audience,
+            issuer: issuer,
+            audience: audience,
             claims: claims,
             notBefore: now.UtcDateTime,
             expires: expires.UtcDateTime,

--- a/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/JwtTokenServiceTests.cs
+++ b/Apps/AuthEmulator/tests/SUI.AuthEmulator.UnitTests/Services/JwtTokenServiceTests.cs
@@ -10,10 +10,8 @@ namespace SUI.AuthEmulator.UnitTests.Services;
 
 public class JwtTokenServiceTests
 {
-    [Fact]
-    public void GenerateToken_ReturnsTokenString()
+    private static (JwtTokenService Service, TimeProvider TimeProvider) CreateTestService()
     {
-        // Arrange
         var authSettings = new AuthSettings
         {
             Issuer = "test-issuer",
@@ -38,6 +36,15 @@ public class JwtTokenServiceTests
 
         var service = new JwtTokenService(mockOptions, mockJwksKeyProvider, testTimeProvider);
 
+        return (service, testTimeProvider);
+    }
+
+    [Fact]
+    public void GenerateToken_ReturnsTokenString()
+    {
+        // Arrange
+        var (service, _) = CreateTestService();
+
         // Act
         var token = service.GenerateToken(
             "test-client-id",
@@ -53,6 +60,7 @@ public class JwtTokenServiceTests
 
         Assert.Equal("test-issuer", jwtToken.Issuer);
         Assert.Contains("test-audience", jwtToken.Audiences);
+        Assert.Equal("test-kid", jwtToken.Header.Kid);
     }
 
     [Fact]
@@ -77,5 +85,66 @@ public class JwtTokenServiceTests
             "No RSA signing keys are available from the JWKS provider.",
             exception.Message
         );
+    }
+
+    [Fact]
+    public void GenerateToken_WithModeNotYetActive_SetsNotBeforeToFuture()
+    {
+        var (service, timeProvider) = CreateTestService();
+
+        var token = service.GenerateToken("client", [], "not-yet-active");
+
+        var jwtToken = new JwtSecurityTokenHandler().ReadJwtToken(token);
+
+        // Assert that the token doesn't become valid until at least 1 hour from now
+        Assert.True(jwtToken.ValidFrom > timeProvider.GetUtcNow().UtcDateTime.AddHours(1));
+    }
+
+    [Fact]
+    public void GenerateToken_WithModeExpired_SetsValidToPast()
+    {
+        var (service, timeProvider) = CreateTestService();
+
+        var token = service.GenerateToken("client", [], "expired");
+
+        var jwtToken = new JwtSecurityTokenHandler().ReadJwtToken(token);
+
+        // Assert that the token expired at least 1 hour ago
+        Assert.True(jwtToken.ValidTo < timeProvider.GetUtcNow().UtcDateTime.AddHours(-1));
+    }
+
+    [Fact]
+    public void GenerateToken_WithModeSpoofIssuer_SetsSpoofIssuer()
+    {
+        var (service, _) = CreateTestService();
+
+        var token = service.GenerateToken("client", [], "spoof-issuer");
+
+        var jwtToken = new JwtSecurityTokenHandler().ReadJwtToken(token);
+        Assert.Equal("spoof", jwtToken.Issuer);
+    }
+
+    [Fact]
+    public void GenerateToken_WithModeSpoofAudience_SetsSpoofAudience()
+    {
+        var (service, _) = CreateTestService();
+
+        var token = service.GenerateToken("client", [], "spoof-audience");
+
+        var jwtToken = new JwtSecurityTokenHandler().ReadJwtToken(token);
+        Assert.Contains("spoof", jwtToken.Audiences);
+    }
+
+    [Fact]
+    public void GenerateToken_WithModeSpoofPrivateKey_UsesDifferentKeyId()
+    {
+        var (service, _) = CreateTestService();
+
+        var token = service.GenerateToken("client", [], "spoof-private-key");
+
+        var jwtToken = new JwtSecurityTokenHandler().ReadJwtToken(token);
+
+        // The mock sets the standard Kid to "test-kid". The spoofed one should generate a random Guid.
+        Assert.NotEqual("test-kid", jwtToken.Header.Kid);
     }
 }

--- a/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
@@ -15,7 +15,8 @@ public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache c
         string clientId,
         string clientSecret,
         string?[]? scopes,
-        ITestOutputHelper testOutputHelper
+        ITestOutputHelper testOutputHelper,
+        string? mode = null
     )
     {
         var originalClientId = clientId;
@@ -31,7 +32,7 @@ public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache c
             ?? clientSecret;
 
         var cacheKeyPlainText =
-            $"{clientId}_{clientSecret}_{string.Join("_", (scopes ?? []).Order())}";
+            $"{clientId}_{clientSecret}_{string.Join("_", (scopes ?? []).Order())}_{mode}";
         var cacheKey = Convert.ToBase64String(
             SHA256.HashData(Encoding.UTF8.GetBytes(cacheKeyPlainText))
         );
@@ -44,7 +45,8 @@ public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache c
                     clientId,
                     clientSecret,
                     testOutputHelper,
-                    isClientIdSensitive: clientId != originalClientId
+                    isClientIdSensitive: clientId != originalClientId,
+                    mode // <-- Pass it down
                 ),
             new MemoryCacheEntryOptions
             {
@@ -58,7 +60,8 @@ public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache c
         string clientId,
         string clientSecret,
         ITestOutputHelper testOutputHelper,
-        bool isClientIdSensitive
+        bool isClientIdSensitive,
+        string? mode = null
     )
     {
         var authString = $"{clientId}:{clientSecret}";
@@ -125,6 +128,11 @@ public class AccessTokenProvider(FunctionTestFixture testFixture, IMemoryCache c
 
             request.Content = content;
             request.Headers.Authorization = clientCredentials;
+
+            if (!string.IsNullOrWhiteSpace(mode))
+            {
+                request.Headers.Add("mode", mode);
+            }
 
             testOutputHelper.WriteLine(
                 $"Requesting access token from: {request.RequestUri} for client ID: {FunctionTestFixture.MaskValue(clientId, isClientIdSensitive)}"

--- a/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/AccessTokenProvider.cs
@@ -11,7 +11,8 @@ public class AccessTokenProvider(FunctionTestFixture testFixture)
         string clientId,
         string clientSecret,
         string?[]? scopes,
-        ITestOutputHelper testOutputHelper
+        ITestOutputHelper testOutputHelper,
+        string? mode = null
     )
     {
         var originalClientId = clientId;
@@ -31,7 +32,8 @@ public class AccessTokenProvider(FunctionTestFixture testFixture)
             clientId,
             clientSecret,
             testOutputHelper,
-            isClientIdSensitive: clientId != originalClientId
+            isClientIdSensitive: clientId != originalClientId,
+            mode
         );
     }
 
@@ -40,7 +42,8 @@ public class AccessTokenProvider(FunctionTestFixture testFixture)
         string clientId,
         string clientSecret,
         ITestOutputHelper testOutputHelper,
-        bool isClientIdSensitive
+        bool isClientIdSensitive,
+        string? mode = null
     )
     {
         var authString = $"{clientId}:{clientSecret}";
@@ -87,6 +90,11 @@ public class AccessTokenProvider(FunctionTestFixture testFixture)
 
             request.Content = content;
             request.Headers.Authorization = clientCredentials;
+
+            if (!string.IsNullOrWhiteSpace(mode))
+            {
+                request.Headers.Add("mode", mode);
+            }
 
             testOutputHelper.WriteLine(
                 $"Requesting access token from: {request.RequestUri} for client ID: {FunctionTestFixture.MaskValue(clientId, isClientIdSensitive)}"

--- a/Apps/Find/tests/SUI.Find.E2ETests/E2ETestBase.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/E2ETestBase.cs
@@ -1,8 +1,3 @@
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Text.Json;
-using Polly;
-
 namespace SUI.Find.E2ETests;
 
 public class E2ETestBase

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -137,7 +137,7 @@ public class FunctionTestFixture : IAsyncLifetime
         );
     }
 
-    private async Task EnsureAuthEmulatorApiIsUpAsync(ITestOutputHelper testOutputHelper)
+    public async Task EnsureAuthEmulatorApiIsUpAsync(ITestOutputHelper testOutputHelper)
     {
         if (!string.IsNullOrEmpty(Config.AuthEmulatorHealthCheckEndpoint))
         {

--- a/Apps/Find/tests/SUI.Find.E2ETests/MatchAuthE2ETests.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/MatchAuthE2ETests.cs
@@ -16,6 +16,7 @@ public class MatchAuthE2ETests(FunctionTestFixture fixture, ITestOutputHelper te
 
     public async ValueTask InitializeAsync()
     {
+        // Only boot the APIs necessary for this specific test suite
         await Fixture.EnsureFindApiIsUpAsync(TestOutputHelper);
         await Fixture.EnsureAuthEmulatorApiIsUpAsync(TestOutputHelper);
     }
@@ -32,15 +33,19 @@ public class MatchAuthE2ETests(FunctionTestFixture fixture, ITestOutputHelper te
 
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        var apiKey =
-            Fixture.Configuration["MatchFunctionConfiguration:XApiKey"] ?? "local-dev-api-key";
+        var apiKey = Fixture.Config.FindApiKey;
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            apiKey = Fixture.Configuration["MatchFunction:XApiKey"] ?? "local-dev-key-change-me";
+        }
+
         request.Headers.Add("x-api-key", apiKey);
 
         request.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
         return await Fixture.Client.SendAsync(request);
     }
 
-    private async Task AssertProblemDetailsAsync(
+    private static async Task AssertProblemDetailsAsync(
         HttpResponseMessage response,
         HttpStatusCode expectedStatus,
         string expectedErrorIndicator
@@ -79,13 +84,12 @@ public class MatchAuthE2ETests(FunctionTestFixture fixture, ITestOutputHelper te
             null,
             TestOutputHelper
         );
+
+        // Send the default empty "{}" body.
         var response = await CallMatchApiAsync(token!);
 
-        await AssertProblemDetailsAsync(
-            response,
-            HttpStatusCode.BadRequest,
-            "personspecification is required"
-        );
+        // It successfully passes Auth, hits the function, and is rejected for being an empty/invalid payload.
+        await AssertProblemDetailsAsync(response, HttpStatusCode.BadRequest, "invalid request");
     }
 
     [Fact]
@@ -98,7 +102,13 @@ public class MatchAuthE2ETests(FunctionTestFixture fixture, ITestOutputHelper te
             TestOutputHelper
         );
         var response = await CallMatchApiAsync(token!);
-        await AssertProblemDetailsAsync(response, HttpStatusCode.Forbidden, "insufficient scope");
+
+        // Middleware explicitly returns 401 for this
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "insufficient scope"
+        );
     }
 
     [Fact]
@@ -120,7 +130,7 @@ public class MatchAuthE2ETests(FunctionTestFixture fixture, ITestOutputHelper te
         await AssertProblemDetailsAsync(
             response,
             HttpStatusCode.Unauthorized,
-            "token validation failed"
+            "invalid bearer token"
         );
     }
 
@@ -143,7 +153,7 @@ public class MatchAuthE2ETests(FunctionTestFixture fixture, ITestOutputHelper te
         await AssertProblemDetailsAsync(
             response,
             HttpStatusCode.Unauthorized,
-            "token validation failed"
+            "invalid bearer token"
         );
     }
 
@@ -160,6 +170,7 @@ public class MatchAuthE2ETests(FunctionTestFixture fixture, ITestOutputHelper te
         var tamperedToken = $"{parts[0]}.{parts[1]}.";
 
         var response = await CallMatchApiAsync(tamperedToken);
+        // Stripping the signature keeps the base64 valid, so it hits the specific SecurityTokenException
         await AssertProblemDetailsAsync(
             response,
             HttpStatusCode.Unauthorized,

--- a/Apps/Find/tests/SUI.Find.E2ETests/MatchAuthE2ETests.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/MatchAuthE2ETests.cs
@@ -1,0 +1,264 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace SUI.Find.E2ETests;
+
+[Trait("Category", "E2E")]
+[Trait("Suite", "Standard")]
+public class MatchAuthE2ETests(FunctionTestFixture fixture, ITestOutputHelper testOutputHelper)
+    : E2ETestBase(fixture, testOutputHelper),
+        IAsyncLifetime
+{
+    private const string MatchEndpointUrl = "v1/matchperson";
+    private const string ValidClientId = "CLIENT_ID_LOCAL_AUTHORITY_01";
+    private const string InvalidScopeClientId = "CLIENT_ID_INVALID_SCOPE";
+    private const string TestClientSecret = "SUIProject";
+
+    public async ValueTask InitializeAsync()
+    {
+        await Fixture.EnsureFindApiIsUpAsync(TestOutputHelper);
+        await Fixture.EnsureAuthEmulatorApiIsUpAsync(TestOutputHelper);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task<HttpResponseMessage> CallMatchApiAsync(string token, string body = "{}")
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, MatchEndpointUrl);
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var apiKey =
+            Fixture.Configuration["MatchFunctionConfiguration:XApiKey"] ?? "local-dev-api-key";
+        request.Headers.Add("x-api-key", apiKey);
+
+        request.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+        return await Fixture.Client.SendAsync(request);
+    }
+
+    private async Task AssertProblemDetailsAsync(
+        HttpResponseMessage response,
+        HttpStatusCode expectedStatus,
+        string expectedErrorIndicator
+    )
+    {
+        Assert.Equal(expectedStatus, response.StatusCode);
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (
+            string.IsNullOrWhiteSpace(content)
+            && response.StatusCode == HttpStatusCode.Unauthorized
+        )
+        {
+            var authHeader = response.Headers.WwwAuthenticate.ToString();
+            Assert.Contains(
+                expectedErrorIndicator.ToLowerInvariant(),
+                authHeader.ToLowerInvariant()
+            );
+            return;
+        }
+
+        Assert.False(
+            string.IsNullOrWhiteSpace(content),
+            "Expected a response body or WWW-Authenticate header, but got empty."
+        );
+        Assert.Contains(expectedErrorIndicator.ToLowerInvariant(), content.ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task ValidToken_ShouldAllowAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper
+        );
+        var response = await CallMatchApiAsync(token!);
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "personspecification is required"
+        );
+    }
+
+    [Fact]
+    public async Task ValidToken_MissingRequiredScope_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            InvalidScopeClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper
+        );
+        var response = await CallMatchApiAsync(token!);
+        await AssertProblemDetailsAsync(response, HttpStatusCode.Forbidden, "insufficient scope");
+    }
+
+    [Fact]
+    public async Task InvalidSignature_ModifiedPayload_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper
+        );
+        var parts = token!.Split('.');
+
+        var payload = parts[1];
+        parts[1] = payload[..^1] + (payload.EndsWith('A') ? "B" : "A");
+        var tamperedToken = string.Join('.', parts);
+
+        var response = await CallMatchApiAsync(tamperedToken);
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "token validation failed"
+        );
+    }
+
+    [Fact]
+    public async Task InvalidSignature_ModifiedHeader_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper
+        );
+        var parts = token!.Split('.');
+
+        var header = parts[0];
+        parts[0] = header[..^1] + (header.EndsWith('A') ? "B" : "A");
+        var tamperedToken = string.Join('.', parts);
+
+        var response = await CallMatchApiAsync(tamperedToken);
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "token validation failed"
+        );
+    }
+
+    [Fact]
+    public async Task InvalidSignature_RemovedSignature_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper
+        );
+        var parts = token!.Split('.');
+        var tamperedToken = $"{parts[0]}.{parts[1]}.";
+
+        var response = await CallMatchApiAsync(tamperedToken);
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "token validation failed"
+        );
+    }
+
+    [Fact]
+    [Trait("RequiresAuthEmulator", "true")]
+    public async Task InvalidTime_NotYetActive_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper,
+            mode: "not-yet-active"
+        );
+        var response = await CallMatchApiAsync(token!);
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "token validation failed"
+        );
+    }
+
+    [Fact]
+    [Trait("RequiresAuthEmulator", "true")]
+    public async Task InvalidTime_Expired_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper,
+            mode: "expired"
+        );
+        var response = await CallMatchApiAsync(token!);
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "token validation failed"
+        );
+    }
+
+    [Fact]
+    [Trait("RequiresAuthEmulator", "true")]
+    public async Task InvalidSignature_SpoofPrivateKey_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper,
+            mode: "spoof-private-key"
+        );
+        var response = await CallMatchApiAsync(token!);
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "token validation failed"
+        );
+    }
+
+    [Fact]
+    [Trait("RequiresAuthEmulator", "true")]
+    public async Task InvalidSource_SpoofIssuer_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper,
+            mode: "spoof-issuer"
+        );
+        var response = await CallMatchApiAsync(token!);
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "token validation failed"
+        );
+    }
+
+    [Fact]
+    [Trait("RequiresAuthEmulator", "true")]
+    public async Task InvalidTarget_SpoofAudience_ShouldDenyAccess()
+    {
+        var token = await Fixture.AccessTokenProvider.GetAuthTokenAsync(
+            ValidClientId,
+            TestClientSecret,
+            null,
+            TestOutputHelper,
+            mode: "spoof-audience"
+        );
+        var response = await CallMatchApiAsync(token!);
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "token validation failed"
+        );
+    }
+}

--- a/Data/auth-clients-inbound.json
+++ b/Data/auth-clients-inbound.json
@@ -89,6 +89,15 @@
         "work-item.read",
         "work-item.write"
       ]
+    },
+    {
+      "enabled": true,
+      "clientId": "CLIENT_ID_INVALID_SCOPE",
+      "organisationId": "INVALID-SCOPE-01",
+      "clientSecret": "SUIProject",
+      "allowedScopes": [
+        "other-scope.read"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Expand the E2E tests to cover the authentication & authorisation behaviour, so that we are certain that the security checks are behaving as necessary.

## Changes

- E2E tests are written to cover the scenarios described below.
- The new E2E tests **only call** the ‘Get An Identifier’ endpoint (`MatchFunction`).
- The new E2E tests do **not** follow the V1 / V2 subclass pattern.
- The new E2E tests must **only use** the `CLIENT_ID_LOCAL_AUTHORITY_01` and `CLIENT_ID_INVALID_SCOPE` organisations.

**Scenarios**

> Valid token, should Allow access
> Valid token, but missing required scope, should Deny access
> Invalid signature due to modified token payload, should Deny access
> Invalid signature due to modified token header, should Deny access
> Invalid signature due to signature removal, should Deny access
> Invalid due to use of token before valid time range (i.e. not-before), should Deny access (* implementation-note)
> Invalid due to use of token after valid time range (i.e. expiration), should Deny access (* implementation-note)
> Invalid signature due to non-genuine private key, should Deny access (* implementation-note)
> Invalid source (i.e. issuer), should Deny access (* implementation-note)
> Invalid target (i.e. audience), should Deny access (* implementation-note)

**Implementation Note**

- The scenarios tagged with (* implementation-note) will require an update to the Auth Emulator’s token endpoint so that it can issue non-valid tokens.  The suggestion here is have a mode header sent in the request to the token endpoint, that can apply special logic during the token creation:

> ```
> mode=not-yet-active
> mode=expired
> mode=spoof-private-key
> mode=spoof-issuer
> mode=spoof-audience
> ```

- The tests for the scenarios that use the mode header should be tagged with `[Trait("RequiresAuthEmulator", "true")]`so that we can exclude them when we run the E2E tests against environments where the Identity Provider is not the Auth Emulator.

- The new Run E2E Tests (against dev environment via gateway) step in the E2E tests workflow should use the filter: `--filter "Category=E2E&Suite=Standard&RequiresAuthEmulator!=true" \`

## Validation

Successful E2E test runs
