### PR TITLE
feat: SUI-1854 - Use `dotnet run` to launch Azure Functions in the ephemeral E2E workflow, and locally

### DIFF
--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -190,7 +190,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: func start --port 7182 &
+        run: dotnet run --no-build &
         working-directory: Apps/Find/src/SUI.Find.FindApi
 
       - name: Run E2E Tests (against ephemeral environment)

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -190,7 +190,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: func start --port 7182 &
+        run: dotnet run --no-build -- --port 7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
 
       - name: Run E2E Tests (against ephemeral environment)

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -191,7 +191,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build --port 7182 &
+        run: dotnet run --no-build -- --port 7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Wait for Find API to be healthy
         run: |
           for i in {1..30}; do
-            body=$(curl -s http://localhost:7182/api/health)
+            body=$(curl -s http://localhost:7182/api/health || true)
             if echo "$body" | jq -e '.Value == "Healthy"' > /dev/null 2>&1; then
               echo "Find API is healthy: $body"
               exit 0

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -191,31 +191,11 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: |
-          dotnet run --no-build --no-launch-profile > find-api.log 2>&1 &
-          echo $! > find-api.pid
-        working-directory: Apps/Find/src/SUI.Find.FindApi
-        env:
-          FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
-          AzureWebJobsStorage: UseDevelopmentStorage=true
-          ASPNETCORE_URLS: http://localhost:7182
-
-      - name: Wait for Find API to be healthy
-        run: |
-          for i in {1..30}; do
-            if curl -s -o /dev/null -w "%{http_code}" http://localhost:7182/api/health | grep -q 200; then
-              echo "Find API is up"
-              exit 0
-            fi
-            if ! kill -0 $(cat Apps/Find/src/SUI.Find.FindApi/find-api.pid) 2>/dev/null; then
-              echo "Find API process died"
-              break
-            fi
-            sleep 1
-          done
-          echo "---- Find API log ----"
-          cat Apps/Find/src/SUI.Find.FindApi/find-api.log
-          exit 1
+          run: dotnet run --no-build --urls http://localhost:7182 &
+          working-directory: Apps/Find/src/SUI.Find.FindApi
+          env:
+            FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
+            AzureWebJobsStorage: UseDevelopmentStorage=true
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -190,7 +190,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build -- --port 7182 &
+        run: dotnet run -- --port 7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -191,11 +191,12 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build --urls http://localhost:7182 &
+        run: dotnet run --no-build --no-launch-profile &
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
           AzureWebJobsStorage: UseDevelopmentStorage=true
+          ASPNETCORE_URLS: http://localhost:7182
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -190,7 +190,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build &
+        run: dotnet run --no-build --dotnet-isolated &
         working-directory: Apps/Find/src/SUI.Find.FindApi
 
       - name: Run E2E Tests (against ephemeral environment)

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -190,8 +190,10 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build -- --port 7182 &
+        run: dotnet run -- -- --port 7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
+        env:
+          FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -191,11 +191,11 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-          run: dotnet run --no-build --urls http://localhost:7182 &
-          working-directory: Apps/Find/src/SUI.Find.FindApi
-          env:
-            FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
-            AzureWebJobsStorage: UseDevelopmentStorage=true
+        run: dotnet run --no-build --urls http://localhost:7182 &
+        working-directory: Apps/Find/src/SUI.Find.FindApi
+        env:
+          FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
+          AzureWebJobsStorage: UseDevelopmentStorage=true
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -191,11 +191,36 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build --urls http://localhost:7182 &
+        run: |
+          dotnet run --no-build --no-launch-profile > find-api.log 2>&1 &
+          echo $! > find-api.pid
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
           AzureWebJobsStorage: UseDevelopmentStorage=true
+          ASPNETCORE_URLS: http://localhost:7182
+          OTEL_LOGS_EXPORTER: none
+          OTEL_TRACES_EXPORTER: none
+          OTEL_METRICS_EXPORTER: none
+
+      - name: Wait for Find API to be healthy
+        run: |
+          for i in {1..30}; do
+            curl -s -o /dev/null http://localhost:7182/api/health && break
+            sleep 1
+          done
+          echo "---- process status ----"
+          ps aux | grep -i "SUI.Find.FindApi\|dotnet" | grep -v grep
+          echo "---- is pid alive? ----"
+          kill -0 $(cat Apps/Find/src/SUI.Find.FindApi/find-api.pid) 2>/dev/null && echo "ALIVE" || echo "DEAD"
+          echo "---- netstat ----"
+          ss -tlnp || netstat -tlnp
+          echo "---- log file size ----"
+          wc -l Apps/Find/src/SUI.Find.FindApi/find-api.log
+          echo "---- Find API log ----"
+          cat Apps/Find/src/SUI.Find.FindApi/find-api.log
+          echo "---- verbose curl ----"
+          curl -v http://localhost:7182/api/health || true
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -198,25 +198,20 @@ jobs:
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
           AzureWebJobsStorage: UseDevelopmentStorage=true
-      
+
       - name: Wait for Find API to be healthy
         run: |
           for i in {1..30}; do
-            curl -s -o /dev/null http://localhost:7182/api/health && break
+            body=$(curl -s http://localhost:7182/api/health)
+            if echo "$body" | jq -e '.Value == "Healthy"' > /dev/null 2>&1; then
+              echo "Find API is healthy: $body"
+              exit 0
+            fi
             sleep 1
           done
-          echo "---- process status ----"
-          ps aux | grep -i "SUI.Find.FindApi\|dotnet" | grep -v grep
-          echo "---- is pid alive? ----"
-          kill -0 $(cat Apps/Find/src/SUI.Find.FindApi/find-api.pid) 2>/dev/null && echo "ALIVE" || echo "DEAD"
-          echo "---- netstat ----"
-          ss -tlnp || netstat -tlnp
-          echo "---- log file size ----"
-          wc -l Apps/Find/src/SUI.Find.FindApi/find-api.log
-          echo "---- Find API log ----"
+          echo "Find API did not become healthy in time"
           cat Apps/Find/src/SUI.Find.FindApi/find-api.log
-          echo "---- verbose curl ----"
-          curl -v http://localhost:7182/api/health || true
+          exit 1
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -191,7 +191,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build --port 7182 &
+        run: dotnet run -- --port 7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -192,17 +192,13 @@ jobs:
 
       - name: Start Find API
         run: |
-          dotnet run --no-build --no-launch-profile > find-api.log 2>&1 &
+          dotnet run --no-build --no-launch-profile -- --port 7182 > find-api.log 2>&1 &
           echo $! > find-api.pid
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
           AzureWebJobsStorage: UseDevelopmentStorage=true
-          ASPNETCORE_URLS: http://localhost:7182
-          OTEL_LOGS_EXPORTER: none
-          OTEL_TRACES_EXPORTER: none
-          OTEL_METRICS_EXPORTER: none
-
+      
       - name: Wait for Find API to be healthy
         run: |
           for i in {1..30}; do

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -191,7 +191,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build -- --port 7182 &
+        run: dotnet run --no-build --urls http://localhost:7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -167,6 +167,11 @@ jobs:
 
       - name: Install Azure Functions Core Tools
         run: npm i -g azure-functions-core-tools@4
+        
+      - name: Create local.settings.json for Find API
+        run: |
+          cp Apps/Find/src/SUI.Find.FindApi/example.local.settings.json \
+             Apps/Find/src/SUI.Find.FindApi/local.settings.json
 
       - name: Build Find API
         run: dotnet build Apps/Find/src/SUI.Find.FindApi
@@ -177,11 +182,6 @@ jobs:
       - name: Build AuthEmulator API
         run: dotnet build Apps/AuthEmulator/src/SUI.AuthEmulator
 
-      - name: Create local.settings.json for Find API
-        run: |
-          cp Apps/Find/src/SUI.Find.FindApi/example.local.settings.json \
-             Apps/Find/src/SUI.Find.FindApi/local.settings.json
-
       - name: Start StubCustodians API
         run: dotnet run --no-build --launch-profile https &
         working-directory: Apps/StubCustodians/src/SUI.StubCustodians.API
@@ -191,7 +191,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run -- --port 7182 &
+        run: dotnet run --no-build --port 7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -191,12 +191,31 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run --no-build --no-launch-profile &
+        run: |
+          dotnet run --no-build --no-launch-profile > find-api.log 2>&1 &
+          echo $! > find-api.pid
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
           AzureWebJobsStorage: UseDevelopmentStorage=true
           ASPNETCORE_URLS: http://localhost:7182
+
+      - name: Wait for Find API to be healthy
+        run: |
+          for i in {1..30}; do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:7182/api/health | grep -q 200; then
+              echo "Find API is up"
+              exit 0
+            fi
+            if ! kill -0 $(cat Apps/Find/src/SUI.Find.FindApi/find-api.pid) 2>/dev/null; then
+              echo "Find API process died"
+              break
+            fi
+            sleep 1
+          done
+          echo "---- Find API log ----"
+          cat Apps/Find/src/SUI.Find.FindApi/find-api.log
+          exit 1
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -190,7 +190,7 @@ jobs:
         working-directory: Apps/AuthEmulator/src/SUI.AuthEmulator
 
       - name: Start Find API
-        run: dotnet run -- -- --port 7182 &
+        run: dotnet run --no-build -- --port 7182 &
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated

--- a/.github/workflows/find-e2e-tests.yml
+++ b/.github/workflows/find-e2e-tests.yml
@@ -194,6 +194,7 @@ jobs:
         working-directory: Apps/Find/src/SUI.Find.FindApi
         env:
           FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
+          AzureWebJobsStorage: UseDevelopmentStorage=true
 
       - name: Run E2E Tests (against ephemeral environment)
         env:

--- a/Apps/Find/Directory.Packages.props
+++ b/Apps/Find/Directory.Packages.props
@@ -20,6 +20,10 @@
       Version="1.14.1"
     />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageVersion
+      Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore"
+      Version="2.1.0"
+    />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="1.6.0" />
     <PackageVersion
       Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues"

--- a/Apps/Find/README.md
+++ b/Apps/Find/README.md
@@ -83,9 +83,9 @@ Using Rider:
 
 Or, using the command line (from the repo root):
 
-* `cd ./Apps/Find/src/SUI.Find.FindApi/; func start --port 7182`
+* `cd ./Apps/Find/src/SUI.Find.FindApi/; dotnet run -- --port 7182`
 * `cd ./Apps/StubCustodians/src/SUI.StubCustodians.API/; dotnet run`
-* `cd ./Apps/Find/src/SUI.Find.AuditProcessor/; func start --port 7151` <- Optional to have the audit processor running
+* `cd ./Apps/Find/src/SUI.Find.AuditProcessor/; dotnet run -- --port 7151` <- Optional to have the audit processor running
 
 
 ## Test Data

--- a/Apps/Find/src/SUI.Find.AuditProcessor/Properties/launchSettings.json
+++ b/Apps/Find/src/SUI.Find.AuditProcessor/Properties/launchSettings.json
@@ -3,7 +3,10 @@
     "SUI.Find.AuditProcessor": {
       "commandName": "Project",
       "commandLineArgs": "--port 7151",
-      "launchBrowser": false
+      "launchBrowser": false,
+      "environmentVariables": {
+        "AZURE_FUNCTIONS_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/Program.cs
+++ b/Apps/Find/src/SUI.Find.FindApi/Program.cs
@@ -33,6 +33,8 @@ Env.TraversePath().Load();
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
+builder.ConfigureFunctionsWebApplication();
+
 builder.UseOpenTelemetry();
 
 builder.Services.Configure<AuthTokenServiceConfig>(

--- a/Apps/Find/src/SUI.Find.FindApi/Properties/launchSettings.json
+++ b/Apps/Find/src/SUI.Find.FindApi/Properties/launchSettings.json
@@ -3,7 +3,10 @@
     "SUI.Find.FindApi": {
       "commandName": "Project",
       "commandLineArgs": "--port 7182",
-      "launchBrowser": false
+      "launchBrowser": false,
+      "environmentVariables": {
+        "AZURE_FUNCTIONS_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/Apps/Find/src/SUI.Find.FindApi/SUI.Find.FindApi.csproj
+++ b/Apps/Find/src/SUI.Find.FindApi/SUI.Find.FindApi.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="DotNetEnv" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" />

--- a/Apps/Find/src/SUI.Find.FindApi/example.local.settings.json
+++ b/Apps/Find/src/SUI.Find.FindApi/example.local.settings.json
@@ -1,8 +1,5 @@
 {
   "IsEncrypted": false,
-  "Host": {
-    "LocalHttpPort": 7182
-  },
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",

--- a/Apps/Find/src/SUI.Find.FindApi/example.local.settings.json
+++ b/Apps/Find/src/SUI.Find.FindApi/example.local.settings.json
@@ -1,5 +1,8 @@
 {
   "IsEncrypted": false,
+  "Host": {
+    "LocalHttpPort": 7182
+  },
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -283,7 +283,19 @@ public class FunctionTestFixture : IAsyncLifetime
                 request.Headers.Authorization = accessToken;
 
                 using var response = await client.SendAsync(request);
-                var content = response.Content.ReadFromJsonAsync<HealthCheckResponse>().Result;
+
+                HealthCheckResponse? content;
+                try
+                {
+                    content = await response.Content.ReadFromJsonAsync<HealthCheckResponse>();
+                }
+                catch (JsonException jsonEx)
+                {
+                    testOutputHelper.WriteLine(
+                        $"Warning: health check response was not valid JSON ({serviceName}): {jsonEx.Message}"
+                    );
+                    return (false, true); // Treat malformed/empty body as transient — retry
+                }
 
                 var healthy =
                     content?.Value == "Healthy"

--- a/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
+++ b/Apps/Find/tests/SUI.Find.E2ETests/FunctionTestFixture.cs
@@ -60,8 +60,15 @@ public class FunctionTestFixture : IAsyncLifetime
             .Handle<Exception>(IsTimeoutError)
             .WaitAndRetryAsync(retryCount: 3, sleepDurationProvider: _ => TimeSpan.FromSeconds(2));
 
-        var policyHandler = new PolicyHttpMessageHandler(retryPolicy);
-        policyHandler.InnerHandler = new HttpClientHandler();
+        var socketsHandler = new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromSeconds(1),
+        };
+
+        var policyHandler = new PolicyHttpMessageHandler(retryPolicy)
+        {
+            InnerHandler = socketsHandler,
+        };
 
         Client = new HttpClient(policyHandler) { BaseAddress = new Uri(Config.BaseUrl) };
 


### PR DESCRIPTION
## Summary

During the ephemeral E2E workflow the following warning is displayed:

> Running 'func start' directly against a .NET Isolated project may not correctly load function extensions. Use 'dotnet run' instead, which builds the project and starts the Functions host from the correct output directory.

This implies that we could be using `dotnet run` to launch Azure Funcs in the ephemeral E2E workflow, and locally.

The purpose of this ticket is to investigate whether this is possible, and if so update the ephemeral E2E workflow, Rider Run Profiles and the readme to change from `func start` to `dotnet run`.

## Changes

- The ephemeral E2E workflow is updated to use `dotnet run` rather than `func start`.
- The run profiles are updated to use `dotnet run` rather than `func start`, if possible.
- Our readmes are updated to explain how to run using `dotnet run` rather than `func start`, anywhere that `func start` is currently referenced.

## Validation

- Successful E2E runs without aforementioned warning
