### PR TITLE
Update dependabot configuration with cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       github-actions-updates:
         patterns:
           - "*"
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semvar-patch-days: 7
 
   - package-ecosystem: nuget
     directory: "/Apps/Find"
@@ -30,6 +34,10 @@ updates:
         update-types:
           - "version-update:semver-major" # Do not allow FluentAssertions to be upgraded past v7, v8+ requires a commercial licence, whereas v7 is free-to-use commercially.
       - dependency-name: "Azure.Storage.Queues" # Stay on 12.24.0 of Azure.Storage.Queues until Azurite is updated to support the new API version
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semvar-patch-days: 7
 
   - package-ecosystem: nuget
     directory: "/Apps/StubCustodians"
@@ -47,3 +55,7 @@ updates:
       - dependency-name: "FluentAssertions"
         update-types:
           - "version-update:semver-major" # Do not allow FluentAssertions to be upgraded past v7, v8+ requires a commercial licence, whereas v7 is free-to-use commercially.
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semvar-patch-days: 7


### PR DESCRIPTION
Reduces supply chain risks to the repository, by waiting some time before applying new versions, in case a supply chain attack occurs and remedial steps are taken.

Kept minimum value at 7, since dependencies are only checked weekly.

Lack of cooldowns raised by Hippo security reporting.