### PR TITLE
chore: SUI-1862 - move scripts at root level to dedicated directory

### DIFF
--- a/Apps/Find/test_and_cover_find.ps1
+++ b/Apps/Find/test_and_cover_find.ps1
@@ -1,1 +1,1 @@
-& "../../test_and_cover.ps1" -SolutionPath "./Apps/Find/SUI.Find.slnx"
+& "../../scripts/test_and_cover.ps1" -SolutionPath "./Apps/Find/SUI.Find.slnx"

--- a/Apps/SingleView/test_and_cover_singleview.ps1
+++ b/Apps/SingleView/test_and_cover_singleview.ps1
@@ -1,1 +1,1 @@
-& "../../test_and_cover.ps1" -SolutionPath "./Apps/SingleView/SUI.SingleView.slnx"
+& "../../scripts/test_and_cover.ps1" -SolutionPath "./Apps/SingleView/SUI.SingleView.slnx"

--- a/Apps/StubCustodians/test_and_cover_stubcustodians.ps1
+++ b/Apps/StubCustodians/test_and_cover_stubcustodians.ps1
@@ -1,1 +1,1 @@
-& "../../test_and_cover.ps1" -SolutionPath "./Apps/StubCustodians/SUI.StubCustodians.slnx"
+& "../../scripts/test_and_cover.ps1" -SolutionPath "./Apps/StubCustodians/SUI.StubCustodians.slnx"

--- a/Apps/Transfer/test_and_cover_transfer.ps1
+++ b/Apps/Transfer/test_and_cover_transfer.ps1
@@ -1,1 +1,1 @@
-& "../../test_and_cover.ps1" -SolutionPath "./Apps/Transfer/SUI.Transfer.slnx"
+& "../../scripts/test_and_cover.ps1" -SolutionPath "./Apps/Transfer/SUI.Transfer.slnx"

--- a/scripts/run-find-e2e-tests.ps1
+++ b/scripts/run-find-e2e-tests.ps1
@@ -3,11 +3,14 @@
     Rudimentary script for reliably running e2e tests locally
 
     .EXAMPLE
-    dotnet pwsh ./run-find-e2e-tests.ps1
+    dotnet pwsh ./scripts/run-find-e2e-tests.ps1
         (Having already run `dotnet tool restore` as a one-off prerequisite. Using the dotnet tool alleviates PowerShell execution policy issues.)
 #>
 
 $ErrorActionPreference = "Stop"
+
+# ALWAYS execute from the repository root, regardless of where the script is invoked from
+Set-Location -Path "$PSScriptRoot/.."
 
 function SetupAndRunTests {
     docker compose --profile aspire down

--- a/scripts/test_and_cover.ps1
+++ b/scripts/test_and_cover.ps1
@@ -5,11 +5,14 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# Ensure script runs from the folder the script is in
+# Ensure script resolves the actual repository root (one level up from /scripts)
 $ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
-Push-Location $ScriptRoot
+$RepoRoot = Resolve-Path "$ScriptRoot\.." | Select-Object -ExpandProperty Path
 
-Write-Host "Running script from: $ScriptRoot"
+# Emulate the old behavior by starting in the repo root
+Push-Location $RepoRoot
+
+Write-Host "Running script from: $RepoRoot"
 Write-Host "Using solution path: $SolutionPath"
 
 # Determine solution folder and file name
@@ -19,8 +22,8 @@ $solutionFileName = Split-Path $SolutionPath -Leaf
 # Switch to solution folder so dotnet commands work correctly
 Push-Location $solutionDir
 
-# Directories for coverage reports
-$resultsDir = "$ScriptRoot/coverage"
+# Directories for coverage reports (Now correctly pointing to the repo root!)
+$resultsDir = "$RepoRoot/coverage"
 $finalReportDir = "$resultsDir/coveragereport"
 
 # Remove old coverage folder

--- a/scripts/test_and_cover.ps1
+++ b/scripts/test_and_cover.ps1
@@ -22,7 +22,7 @@ $solutionFileName = Split-Path $SolutionPath -Leaf
 # Switch to solution folder so dotnet commands work correctly
 Push-Location $solutionDir
 
-# Directories for coverage reports (Now correctly pointing to the repo root!)
+# Directories for coverage reports (Pointing to the repo root)
 $resultsDir = "$RepoRoot/coverage"
 $finalReportDir = "$resultsDir/coveragereport"
 


### PR DESCRIPTION
## Summary

Relocate the two PowerShell scripts currently in the repository root into `./scripts`.

## Changes

- Moved the two PowerShell scripts from the repository root into ./scripts.
- Updated all paths and references.
- Included any usage of test_and_cover.ps1 in the updates.

## Validation

- Successful Build, Test and Deploy runs
- Successful E2E test powershell script run locally
