### PR TITLE
ops(getAnIdentifier): SUI-1914 - Add new workflows for Get An Identifier

### DIFF
--- a/.github/workflows/get-an-identifier-build-and-deploy.yml
+++ b/.github/workflows/get-an-identifier-build-and-deploy.yml
@@ -1,0 +1,93 @@
+name: 'Build, Test, Deploy: "Get An Identifier" Solution'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment for deployment
+        required: false
+        default: d01
+        type: choice
+        options:
+          - d01
+          - d02
+          - d03
+      deploy:
+        description: Deploy to Azure Function App
+        required: false
+        default: false
+        type: boolean
+      upload_artifacts:
+        description: Upload build artifacts (auto-enabled when deploying)
+        required: false
+        default: false
+        type: boolean
+      artifact_store:
+        description: Artifact storage backend (github or azure)
+        required: false
+        default: azure
+        type: string
+      skip_tests:
+        description: Skip tests and related setup
+        required: false
+        default: false
+        type: boolean
+      skip_scans:
+        description: Skip SonarCloud scans
+        required: false
+        default: false
+        type: boolean
+  push:
+    branches:
+      - main
+    paths:
+      - "Apps/GetAnIdentifier/**"
+      - "Data/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "Apps/GetAnIdentifier/**"
+      - "Data/**"
+
+jobs:
+  build-and-test-GetAnIdentifier:
+    name: GetAnIdentifier - Build Test Dotnet
+    uses: ./.github/workflows/build-test-dotnet.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      checks: write
+      packages: read
+      actions: write
+    with:
+      directory_name: Apps/GetAnIdentifier
+      project_names: '["SUI.GetAnIdentifier.Function"]'
+      requires_azurite: true
+      upload_artifacts: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.deploy == 'true' || github.event.inputs.upload_artifacts == 'true')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+      artifact_store: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.artifact_store || vars.ARTIFACT_STORE || 'azure' }}
+      skip_tests: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_tests == 'true' }}
+      skip_scans: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_scans == 'true' }}
+      deploy_requested: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true' }}
+
+#  deploy-GetAnIdentifier:
+#    name: GetAnIdentifier - Deploy Function App
+#    if: |
+#      (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true') ||
+#      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+#    needs: build-and-test-GetAnIdentifier
+#    uses: ./.github/workflows/deploy-dotnet-functionapp.yml
+#    secrets: inherit
+#    with:
+#      environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'd01' }}
+#      directory_name: Apps/GetAnIdentifier
+#      artifact_name: ${{ fromJson(needs.build-and-test-GetAnIdentifier.outputs.artifact_names)['SUI.GetAnIdentifier.Function'] }}
+#      artifact_store: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.artifact_store || vars.ARTIFACT_STORE || 'azure' }}
+#      component_descriptor: getanidentifier01
+#      package_path: publish

--- a/.github/workflows/terraform-get-an-identifier.yml
+++ b/.github/workflows/terraform-get-an-identifier.yml
@@ -1,0 +1,35 @@
+name: Terraform Get An Identifier
+run-name: Terraform Get An Identifier - ${{ inputs.environment }} (${{ inputs.apply && 'apply' || 'plan' }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        required: true
+        default: d01
+        type: choice
+        options:
+          - d01
+          - d02
+          - d03
+      apply:
+        description: Apply changes (otherwise plan only)
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform:
+    name: Terraform Get An Identifier for ${{ inputs.environment }} (${{ inputs.apply && 'apply' || 'plan' }})
+    uses: ./.github/workflows/terraform-plan-and-apply.yml
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}
+      apply: ${{ inputs.apply }}
+      root: terraform/get-an-identifier
+      state_key: ${{ format('{0}/getanidentifier.tfstate', inputs.environment) }}

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.Function/Program.cs
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.Function/Program.cs
@@ -5,4 +5,4 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Build().Run();
+await builder.Build().RunAsync();

--- a/Apps/GetAnIdentifier/test_and_cover_getanidentifier.ps1
+++ b/Apps/GetAnIdentifier/test_and_cover_getanidentifier.ps1
@@ -1,0 +1,1 @@
+& "../../scripts/test_and_cover.ps1" -SolutionPath "./Apps/GetAnIdentifier/GetAnIdentifier.slnx"

--- a/Apps/GetAnIdentifier/tests.runsettings
+++ b/Apps/GetAnIdentifier/tests.runsettings
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+    <RunConfiguration>
+		<EnvironmentVariables>
+		</EnvironmentVariables>
+	</RunConfiguration>
+	<DataCollectionRunSettings>
+		<DataCollectors>
+			<DataCollector friendlyName="XPlat code coverage">
+				<Configuration>
+					<Format>cobertura,opencover</Format>
+					<Exclude>[*.Tests?]*</Exclude>
+					<!-- [Assembly-Filter]Type-Filter -->
+					<ExcludeByFile>**/**/Program.cs</ExcludeByFile>
+					<!-- Globbing filter -->
+					<SkipAutoProps>true</SkipAutoProps>
+				</Configuration>
+			</DataCollector>
+		</DataCollectors>
+	</DataCollectionRunSettings>
+</RunSettings>

--- a/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Function.Tests/HelloWorldFunctionTests.cs
+++ b/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Function.Tests/HelloWorldFunctionTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SUI.GetAnIdentifier.Function.Functions;
+
+namespace SUI.GetAnIdentifier.Function.Tests;
+
+public class HelloWorldFunctionTests
+{
+    [Fact]
+    public async Task HelloWorld_ReturnsOk_WithExpectedMessage()
+    {
+        // Arrange
+        var workerOptions = new WorkerOptions
+        {
+            Serializer = new Azure.Core.Serialization.JsonObjectSerializer(),
+        };
+
+        var optionsSubstitute = Substitute.For<IOptions<WorkerOptions>>();
+        optionsSubstitute.Value.Returns(workerOptions);
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton(optionsSubstitute);
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var contextSubstitute = Substitute.For<FunctionContext>();
+        contextSubstitute.InstanceServices.Returns(serviceProvider);
+
+        var responseSubstitute = Substitute.For<HttpResponseData>(contextSubstitute);
+        var bodyStream = new MemoryStream();
+
+        responseSubstitute.Body.Returns(bodyStream);
+        responseSubstitute.Headers.Returns(new HttpHeadersCollection());
+
+        var requestSubstitute = Substitute.For<HttpRequestData>(contextSubstitute);
+        requestSubstitute.CreateResponse().Returns(responseSubstitute);
+
+        var sut = new HelloWorldFunction();
+
+        // Act
+        var response = await sut.HelloWorld(requestSubstitute);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        bodyStream.Position = 0;
+        using var reader = new StreamReader(bodyStream);
+        var responseBody = await reader.ReadToEndAsync();
+
+        Assert.Equal("\"Hello World\"", responseBody);
+    }
+}

--- a/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Function.Tests/SUI.GetAnIdentifier.Function.Tests.csproj
+++ b/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Function.Tests/SUI.GetAnIdentifier.Function.Tests.csproj
@@ -9,11 +9,16 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SUI.GetAnIdentifier.Function\SUI.GetAnIdentifier.Function.csproj" />
   </ItemGroup>
 </Project>

--- a/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Function.Tests/TestHelloWorldFunction.cs
+++ b/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Function.Tests/TestHelloWorldFunction.cs
@@ -1,7 +1,0 @@
-﻿namespace SUI.GetAnIdentifier.Function.Tests;
-
-public class TestHelloWorldFunction
-{
-    [Fact]
-    public void Test1() { }
-}

--- a/terraform/get-an-identifier/main.tf
+++ b/terraform/get-an-identifier/main.tf
@@ -1,0 +1,161 @@
+locals {
+  state_rg        = format("%s%srg-%s-tfstate", var.subscription_prefix, var.environment_id, var.region_short)
+  state_storage   = format("%s%ssttfstate01", var.subscription_prefix, var.environment_id)
+  state_container = "tfstate"
+
+  core_state_key    = format("%s/terraform.tfstate", var.environment_id)
+  service_state_key = format("%s/getanidentifier.tfstate", var.environment_id)
+
+  function_descriptor = "getanid01"
+  function_app_name = format(
+    "%s%sfunc-%s-%s",
+    var.subscription_prefix,
+    var.environment_id,
+    var.region_short,
+    local.function_descriptor
+  )
+
+  # Storage account name for Function App (must be globally unique, 3-24 lowercase letters/numbers)
+  function_storage_account_name = lower(
+    format("%s%sstfunc%s", var.subscription_prefix, var.environment_id, local.function_descriptor)
+  )
+
+  otel_resource_attributes = join(",", [
+    "deployment.environment=${var.environment_tag}",
+    "service.namespace=${var.product}",
+    "cloud.region=${var.location}",
+  ])
+
+  # Key Vault name
+  key_vault_descriptor = "getanidkv01"
+  key_vault_name = format(
+    "%s%skv-%s-%s",
+    var.subscription_prefix,
+    var.environment_id,
+    var.region_short,
+    local.key_vault_descriptor
+  )
+}
+
+data "azurerm_client_config" "current" {}
+
+data "terraform_remote_state" "core" {
+  backend = "azurerm"
+
+  config = {
+    resource_group_name  = local.state_rg
+    storage_account_name = local.state_storage
+    container_name       = local.state_container
+    key                  = local.core_state_key
+  }
+}
+
+module "key_vault" {
+  source = "../modules/key_vault"
+
+  name                = local.key_vault_name
+  resource_group_name = data.terraform_remote_state.core.outputs.resource_group_name
+  location            = data.terraform_remote_state.core.outputs.resource_group_location
+
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  rbac_authorization_enabled = var.key_vault_use_rbac
+
+  environment_tag  = var.environment_tag
+  product          = var.product
+  service_offering = var.service_offering
+
+  tags = var.tags
+}
+
+module "rbac_assignments_terraform_operator" {
+  source = "../modules/rbac_assignments"
+  scope  = module.key_vault.id
+
+  assignments = var.key_vault_use_rbac ? {
+    terraform_operator_secrets = {
+      principal_id = data.azurerm_client_config.current.object_id
+      role_name    = "Key Vault Secrets Officer"
+    }
+  } : {}
+}
+
+# Access policy fallback for environments that cannot create RBAC role assignments.
+resource "azurerm_key_vault_access_policy" "terraform_operator" {
+  count = var.key_vault_use_rbac ? 0 : 1
+
+  key_vault_id = module.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Get",
+  ]
+
+  secret_permissions = [
+    "Get",
+    "Set",
+    "Delete",
+    "List",
+  ]
+
+  storage_permissions = [
+    "Get",
+  ]
+}
+
+module "function_app" {
+  source = "../modules/linux_function_app"
+
+  name                = local.function_app_name
+  resource_group_name = data.terraform_remote_state.core.outputs.resource_group_name
+  location            = data.terraform_remote_state.core.outputs.resource_group_location
+  service_plan_id     = data.terraform_remote_state.core.outputs.app_service_plan_id
+
+  storage_account_name              = local.function_storage_account_name
+  app_service_integration_subnet_id = data.terraform_remote_state.core.outputs.function_app_integration_subnet_id
+  log_analytics_workspace_id        = data.terraform_remote_state.core.outputs.log_analytics_workspace_id
+
+  environment_tag  = var.environment_tag
+  product          = var.product
+  service_offering = var.service_offering
+
+  dotnet_version = var.function_dotnet_version
+
+  app_settings = merge(
+    {
+      FUNCTIONS_WORKER_RUNTIME = "dotnet-isolated"
+      WEBSITE_RUN_FROM_PACKAGE = "1"
+      OTEL_RESOURCE_ATTRIBUTES = local.otel_resource_attributes
+    },
+    var.getanidentifier_app_settings
+  )
+
+  application_insights_connection_string = data.terraform_remote_state.core.outputs.app_insights_connection_string
+
+  tags = var.tags
+}
+
+module "rbac_assignments_function_app" {
+  source = "../modules/rbac_assignments"
+  scope  = module.key_vault.id
+
+  assignments = var.key_vault_use_rbac ? {
+    function_app_secrets = {
+      principal_id = module.function_app.principal_id
+      role_name    = "Key Vault Secrets User"
+    }
+  } : {}
+}
+
+resource "azurerm_key_vault_access_policy" "function_app" {
+  count = var.key_vault_use_rbac ? 0 : 1
+
+  key_vault_id = module.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.function_app.principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}

--- a/terraform/get-an-identifier/outputs.tf
+++ b/terraform/get-an-identifier/outputs.tf
@@ -1,0 +1,29 @@
+output "service_state_key" {
+  value       = local.service_state_key
+  description = "State key for the GetAnIdentifier service."
+}
+
+output "function_app_name" {
+  value       = module.function_app.name
+  description = "Name of the GetAnIdentifier function app."
+}
+
+output "function_app_id" {
+  value       = module.function_app.id
+  description = "ID of the GetAnIdentifier function app."
+}
+
+output "function_app_default_hostname" {
+  value       = module.function_app.default_hostname
+  description = "Default hostname of the GetAnIdentifier function app."
+}
+
+output "key_vault_name" {
+  value       = module.key_vault.name
+  description = "Name of the Key Vault."
+}
+
+output "key_vault_id" {
+  value       = module.key_vault.id
+  description = "ID of the Key Vault."
+}

--- a/terraform/get-an-identifier/variables.tf
+++ b/terraform/get-an-identifier/variables.tf
@@ -1,0 +1,81 @@
+variable "subscription_prefix" {
+  description = "Prefix that identifies the subscription (for example s270)."
+  type        = string
+}
+
+variable "environment_id" {
+  description = "Short identifier for the environment (for example d01)."
+  type        = string
+}
+
+variable "environment_tag" {
+  description = "Environment tag value (for example Dev or Test)."
+  type        = string
+}
+
+variable "region_short" {
+  description = "Short name for the Azure region (for example uks for UK South)."
+  type        = string
+}
+
+variable "descriptor" {
+  description = "Default component descriptor used for resource naming when a more specific descriptor variable is not provided."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure location for the function app (for example uksouth)."
+  type        = string
+}
+
+variable "product" {
+  description = "Product tag value."
+  type        = string
+}
+
+variable "service_offering" {
+  description = "Service Offering tag value."
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the function app."
+  type        = map(string)
+  default     = {}
+}
+
+variable "getanidentifier_app_settings" {
+  description = "Additional app settings to apply to the GetAnIdentifier function app."
+  type        = map(string)
+  default     = {}
+}
+
+variable "function_dotnet_version" {
+  description = "Dotnet version for the function app stack."
+  type        = string
+  default     = "10.0"
+}
+
+variable "app_service_plan_sku" {
+  description = "SKU name for the shared App Service plan (present to support shared tfvars files)."
+  type        = string
+  default     = null
+}
+
+variable "app_service_plan_os_type" {
+  description = "OS type for the App Service plan (present to support shared tfvars files)."
+  type        = string
+  default     = null
+}
+
+variable "app_service_plan_worker_count" {
+  description = "Number of workers for the App Service plan (present to support shared tfvars files)."
+  type        = number
+  default     = null
+}
+
+variable "key_vault_use_rbac" {
+  description = "Set to true to enable Key Vault RBAC authorization and role assignments; false uses access policies."
+  type        = bool
+  default     = false
+}

--- a/terraform/get-an-identifier/versions.tf
+++ b/terraform/get-an-identifier/versions.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.58.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.12.0"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}


### PR DESCRIPTION
## Summary

Add workflows and IaC to the GetAnIdentifier solution so that coverage and unit test checks can be run via the pipeline and future deployments can be assisted with.

## Changes

- Add build, test and deploy Get An Identifier workflow
- Add test coverage check script
- Add test run settings
- Update tests
- Add new terraform workflows and code

## Validation

- Successful pipeline runs