### PR TITLE
fix: SUI-1938 - clean up post project rename leftovers and update workflow files

### DIFF
--- a/.github/workflows/get-an-identifier-build-and-deploy.yml
+++ b/.github/workflows/get-an-identifier-build-and-deploy.yml
@@ -68,7 +68,7 @@ jobs:
       actions: write
     with:
       directory_name: Apps/GetAnIdentifier
-      project_names: '["SUI.GetAnIdentifier.Function"]'
+      project_names: '["SUI.GetAnIdentifier.API"]'
       requires_azurite: true
       upload_artifacts: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.deploy == 'true' || github.event.inputs.upload_artifacts == 'true')) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       artifact_store: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.artifact_store || vars.ARTIFACT_STORE || 'azure' }}

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/Properties/launchSettings.json
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "SUI.GetAnIdentifier.Function": {
+    "SUI.GetAnIdentifier.API": {
       "commandName": "Project",
       "commandLineArgs": "--port 7120"
     }

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/SUI.GetAnIdentifier.API.csproj
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/SUI.GetAnIdentifier.API.csproj
@@ -38,7 +38,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
-    <None Remove="local.settings.json" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\..\Data\auth-clients-inbound.json">

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/SUI.GetAnIdentifier.API.csproj
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/SUI.GetAnIdentifier.API.csproj
@@ -30,14 +30,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="SUI.GetAnIdentifier.Function\local.settings.json">
+    <None Update="SUI.GetAnIdentifier.API\local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
-    <None Update="SUI.GetAnIdentifier.Function\host.json">
+    <None Update="SUI.GetAnIdentifier.API\host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
+    <None Remove="local.settings.json" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\..\Data\auth-clients-inbound.json">

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/SUI.GetAnIdentifier.API.csproj
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/SUI.GetAnIdentifier.API.csproj
@@ -47,7 +47,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SUI.GetAnIdentifier.Application\SUI.GetAnIdentifier.Application.csproj" />
     <ProjectReference Include="..\SUI.GetAnIdentifier.Infrastructure\SUI.GetAnIdentifier.Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/FullSystem.slnx
+++ b/FullSystem.slnx
@@ -9,10 +9,10 @@
   </Folder>
   <Folder Name="/Apps/GetAnIdentifier/" />
   <Folder Name="/Apps/GetAnIdentifier/src/">
-    <Project Path="Apps\GetAnIdentifier\src\SUI.GetAnIdentifier.Function\SUI.GetAnIdentifier.Function.csproj" Type="Classic C#" />
+    <Project Path="Apps\GetAnIdentifier\src\SUI.GetAnIdentifier.API\SUI.GetAnIdentifier.API.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/Apps/GetAnIdentifier/tests/">
-    <Project Path="Apps\GetAnIdentifier\tests\SUI.GetAnIdentifier.Function.Tests\SUI.GetAnIdentifier.Function.Tests.csproj" />
+    <Project Path="Apps\GetAnIdentifier\tests\SUI.GetAnIdentifier.API.UnitTests\SUI.GetAnIdentifier.API.UnitTests.csproj" />
   </Folder>
   <Folder Name="/Apps/UIHarness/" />
   <Folder Name="/Apps/UIHarness/src/">


### PR DESCRIPTION
## Summary

The reincorporation of code into GetAnIdentifier required some further older references to be renamed.

## Changes

- Updated broken workflows
- Updated broken launch settings
- Updated solution files

## Validation

- Successful build and test pipeline runs
