### PR TITLE
feat: SUI-1877 - Configure PDS connectivity for FHIR API

### DIFF
--- a/.github/workflows/terraform-plan-and-apply.yml
+++ b/.github/workflows/terraform-plan-and-apply.yml
@@ -25,7 +25,7 @@ on:
         required: true
       AZURE_SUBSCRIPTION_ID:
         required: true
-      # The NHS secrets below are only required for the Match Function.
+      # The NHS secrets below are required for the Get an Identifier Function.
       NHS_DIGITAL_CLIENT_ID:
         required: true
       NHS_DIGITAL_KID:
@@ -68,7 +68,7 @@ jobs:
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
       ARM_USE_OIDC: true
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      # The NHS secrets below are only required for the Match Function, and are transmitted from Github Secrets to the Azure Key Vault.
+      # The NHS secrets below are required for the Get an Identifier Function, and are transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_nhs_digital_client_id: ${{ secrets.NHS_DIGITAL_CLIENT_ID}}
       TF_VAR_nhs_digital_kid: ${{ secrets.NHS_DIGITAL_KID}}
       TF_VAR_nhs_digital_private_key: ${{ secrets.NHS_DIGITAL_PRIVATE_KEY}}

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/example.local.settings.json
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/example.local.settings.json
@@ -1,0 +1,17 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "NhsAuthConfig:NHS_DIGITAL_TOKEN_URL": "https://int.api.service.nhs.uk/oauth2/token",
+    "NhsAuthConfig:NHS_DIGITAL_FHIR_ENDPOINT": "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/",
+    "NhsAuthConfig:NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES": 5,
+    "GetAnIdentifierFunction:XApiKey": "local-dev-key-change-me",
+    "StorageRetentionDays": 1,
+    "AuthSettings__Issuer": "https://sandbox.api.example.gov.uk/sui-find-a-record/auth",
+    "AuthSettings__Audience": "sui-find-a-record-api",
+    "AuthSettings__OidcDiscoveryUrl": "https://localhost:7250/api/v1/.well-known/openid-configuration",
+    "AuthSettings__AccessTokenUrl": "https://localhost:7250/api/v1/auth/token",
+    "AuthSettings__UseAuthStoreForAuthorisation": false
+  }
+}

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.Infrastructure/Services/FhirAuthTokenService.cs
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.Infrastructure/Services/FhirAuthTokenService.cs
@@ -169,14 +169,8 @@ public sealed class FhirAuthTokenService(
     private static SigningCredentials CreateSigningCredentials(string privateKey, string kid)
     {
         var rsa = RSA.Create();
+        rsa.ImportFromPem(privateKey.ToCharArray());
 
-        var keyContents = privateKey
-            .Replace("-----BEGIN RSA PRIVATE KEY-----", "")
-            .Replace("-----END RSA PRIVATE KEY-----", "")
-            .ReplaceLineEndings("")
-            .Trim();
-
-        rsa.ImportRSAPrivateKey(Convert.FromBase64String(keyContents), out _);
         var securityKey = new RsaSecurityKey(rsa) { KeyId = kid };
 
         return new SigningCredentials(securityKey, SecurityAlgorithms.RsaSha512)

--- a/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Infrastructure.UnitTests/Services/FhirAuthTokenServiceTests.cs
+++ b/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Infrastructure.UnitTests/Services/FhirAuthTokenServiceTests.cs
@@ -49,7 +49,7 @@ public class FhirAuthTokenServiceTests
     private static string GenerateDummyPrivateKey()
     {
         using var rsa = System.Security.Cryptography.RSA.Create(2048);
-        return Convert.ToBase64String(rsa.ExportRSAPrivateKey());
+        return rsa.ExportRSAPrivateKeyPem();
     }
 
     private FhirAuthTokenService CreateService()

--- a/FullSystem.slnx
+++ b/FullSystem.slnx
@@ -10,9 +10,13 @@
   <Folder Name="/Apps/GetAnIdentifier/" />
   <Folder Name="/Apps/GetAnIdentifier/src/">
     <Project Path="Apps\GetAnIdentifier\src\SUI.GetAnIdentifier.API\SUI.GetAnIdentifier.API.csproj" Type="Classic C#" />
+    <Project Path="Apps\GetAnIdentifier\src\SUI.GetAnIdentifier.Application\SUI.GetAnIdentifier.Application.csproj" Type="Classic C#" />
+    <Project Path="Apps\GetAnIdentifier\src\SUI.GetAnIdentifier.Infrastructure\SUI.GetAnIdentifier.Infrastructure.csproj" Type="Classic C#" />
   </Folder>
   <Folder Name="/Apps/GetAnIdentifier/tests/">
     <Project Path="Apps\GetAnIdentifier\tests\SUI.GetAnIdentifier.API.UnitTests\SUI.GetAnIdentifier.API.UnitTests.csproj" />
+    <Project Path="Apps\GetAnIdentifier\tests\SUI.GetAnIdentifier.Application.UnitTests\SUI.GetAnIdentifier.Application.UnitTests.csproj" />
+    <Project Path="Apps\GetAnIdentifier\tests\SUI.GetAnIdentifier.Infrastructure.UnitTests\SUI.GetAnIdentifier.Infrastructure.UnitTests.csproj" />
   </Folder>
   <Folder Name="/Apps/UIHarness/" />
   <Folder Name="/Apps/UIHarness/src/">

--- a/terraform/environments/d01.tfvars
+++ b/terraform/environments/d01.tfvars
@@ -19,6 +19,12 @@ auxiliary_app_service_plan_os_type      = "Linux"
 auxiliary_app_service_plan_worker_count = 1
 key_vault_use_rbac            = false
 
+getanidentifier_app_settings = {
+  NhsAuthConfig__NHS_DIGITAL_TOKEN_URL                       = "https://int.api.service.nhs.uk/oauth2/token"
+  NhsAuthConfig__NHS_DIGITAL_FHIR_ENDPOINT                   = "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/"
+  NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
+}
+
 tags = {
   # Additional tags can be added here
   # Environment, Product, and Service Offering will be added by default

--- a/terraform/environments/d02.tfvars
+++ b/terraform/environments/d02.tfvars
@@ -19,6 +19,12 @@ auxiliary_app_service_plan_os_type      = "Linux"
 auxiliary_app_service_plan_worker_count = 1
 key_vault_use_rbac            = false
 
+getanidentifier_app_settings = {
+  NhsAuthConfig__NHS_DIGITAL_TOKEN_URL                       = "https://int.api.service.nhs.uk/oauth2/token"
+  NhsAuthConfig__NHS_DIGITAL_FHIR_ENDPOINT                   = "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/"
+  NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
+}
+
 ui_harness_app_settings = {
   ArchitectureOptionHidden = true
 }

--- a/terraform/environments/d03.tfvars
+++ b/terraform/environments/d03.tfvars
@@ -19,6 +19,13 @@ auxiliary_app_service_plan_os_type      = "Linux"
 auxiliary_app_service_plan_worker_count = 1
 key_vault_use_rbac            = false
 
+getanidentifier_app_settings = {
+  NhsAuthConfig__NHS_DIGITAL_TOKEN_URL                       = "https://int.api.service.nhs.uk/oauth2/token"
+  NhsAuthConfig__NHS_DIGITAL_FHIR_ENDPOINT                   = "https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/"
+  NhsAuthConfig__NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5
+  AuthSettings__UseAuthStoreForAuthorisation = true
+}
+
 tags = {
   # Additional tags can be added here
   # Environment, Product, and Service Offering will be added by default

--- a/terraform/get-an-identifier/main.tf
+++ b/terraform/get-an-identifier/main.tf
@@ -27,7 +27,7 @@ locals {
   ])
 
   # Key Vault name
-  key_vault_descriptor = "getanidkv01"
+  key_vault_descriptor = "gaidkv01"
   key_vault_name = format(
     "%s%skv-%s-%s",
     var.subscription_prefix,

--- a/terraform/get-an-identifier/main.tf
+++ b/terraform/get-an-identifier/main.tf
@@ -103,6 +103,39 @@ resource "azurerm_key_vault_access_policy" "terraform_operator" {
   ]
 }
 
+resource "azurerm_key_vault_secret" "nhs_digital_private_key" {
+  name            = "nhs-digital-private-key"
+  value           = var.nhs_digital_private_key
+  key_vault_id    = module.key_vault.id
+  content_type    = "text/plain"
+  depends_on = [
+    module.rbac_assignments_terraform_operator,
+    azurerm_key_vault_access_policy.terraform_operator
+  ]
+}
+
+resource "azurerm_key_vault_secret" "nhs_digital_kid" {
+  name            = "nhs-digital-kid"
+  value           = var.nhs_digital_kid
+  key_vault_id    = module.key_vault.id
+  content_type    = "text/plain"
+  depends_on = [
+    module.rbac_assignments_terraform_operator,
+    azurerm_key_vault_access_policy.terraform_operator
+  ]
+}
+
+resource "azurerm_key_vault_secret" "nhs_digital_client_id" {
+  name            = "nhs-digital-client-id"
+  value           = var.nhs_digital_client_id
+  key_vault_id    = module.key_vault.id
+  content_type    = "text/plain"
+  depends_on = [
+    module.rbac_assignments_terraform_operator,
+    azurerm_key_vault_access_policy.terraform_operator
+  ]
+}
+
 module "function_app" {
   source = "../modules/linux_function_app"
 

--- a/terraform/get-an-identifier/main.tf
+++ b/terraform/get-an-identifier/main.tf
@@ -126,6 +126,10 @@ module "function_app" {
       FUNCTIONS_WORKER_RUNTIME = "dotnet-isolated"
       WEBSITE_RUN_FROM_PACKAGE = "1"
       OTEL_RESOURCE_ATTRIBUTES = local.otel_resource_attributes
+      
+      NhsAuthConfig__NHS_DIGITAL_PRIVATE_KEY = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_private_key.name}/)"
+      NhsAuthConfig__NHS_DIGITAL_KID         = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_kid.name}/)"
+      NhsAuthConfig__NHS_DIGITAL_CLIENT_ID   = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_client_id.name}/)"
     },
     var.getanidentifier_app_settings
   )

--- a/terraform/get-an-identifier/variables.tf
+++ b/terraform/get-an-identifier/variables.tf
@@ -79,3 +79,21 @@ variable "key_vault_use_rbac" {
   type        = bool
   default     = false
 }
+
+variable "nhs_digital_private_key" {
+  description = "Private key for connection with NHS FHIR API"
+  type = string
+  sensitive = true
+}
+
+variable "nhs_digital_kid" {
+  description = "KID for connection with NHS FHIR API"
+  type = string
+  sensitive = true
+}
+
+variable "nhs_digital_client_id" {
+  description = "Client ID for connection with NHS FHIR API"
+  type = string
+  sensitive = true
+}


### PR DESCRIPTION
## Summary

Add NHS Digital secrets and variables via terraform, change RSA parsing to match pilot codebase, and other tidying of project files.

## Changes

- Add NHS Digital settings to Terraform variables
- Import NHS Digital secrets via GitHub actions to Key Vault via terraform
- Add example local settings file
- Change RSA parsing to handle PEM format natively
- Add missing project references to FullSystem solution
- Shorten Key Vault name to fix broken terraform in main

## Validation

- Unit tests succeeding
- Pipeline runs succeeding
- Terraform plan succeeding in d01
