### PR TITLE
feat(getAnIdentifier): SUI-1876 - Implement error handling and fallback behaviour for PDS matching failures

### DIFF
--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/Functions/GetAnIdentifierFunction.cs
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/Functions/GetAnIdentifierFunction.cs
@@ -62,6 +62,12 @@ public class GetAnIdentifierFunction(
         Description = "The requested demographic information did not confidently match an individual person"
     )]
     [OpenApiResponseWithBody(
+        HttpStatusCode.BadGateway,
+        "application/json",
+        typeof(Problem),
+        Description = "The upstream PDS matching service encountered an error or timed out"
+    )]
+    [OpenApiResponseWithBody(
         HttpStatusCode.InternalServerError,
         "application/json",
         typeof(Problem),
@@ -130,39 +136,54 @@ public class GetAnIdentifierFunction(
             );
         }
 
-        var personMatch = await getAnIdentifierService.MatchPersonAsync(
-            request.PersonSpecification,
-            cancellationToken
-        );
+        try
+        {
+            var personMatch = await getAnIdentifierService.MatchPersonAsync(
+                request.PersonSpecification,
+                cancellationToken
+            );
 
-        return await personMatch.Match(
-            async id =>
-                await HttpResponseUtility.OkResponse(
-                    req,
-                    new PersonMatch(id.Value),
-                    cancellationToken
-                ),
-            async dataValidationResult =>
-                await HttpResponseUtility.BadRequestResponse(
-                    req,
-                    context.InvocationId,
-                    JsonSerializer.Serialize(dataValidationResult),
-                    "Validation error",
-                    cancellationToken
-                ),
-            async notFound =>
-                await HttpResponseUtility.NotFoundResponse(
-                    req,
-                    context.InvocationId,
-                    cancellationToken
-                ),
-            async error =>
-                await HttpResponseUtility.InternalServerErrorResponse(
-                    req,
-                    context.InvocationId,
-                    cancellationToken
-                )
-        );
+            return await personMatch.Match(
+                async id =>
+                    await HttpResponseUtility.OkResponse(
+                        req,
+                        new PersonMatch(id.Value),
+                        cancellationToken
+                    ),
+                async dataValidationResult =>
+                    await HttpResponseUtility.BadRequestResponse(
+                        req,
+                        context.InvocationId,
+                        JsonSerializer.Serialize(dataValidationResult),
+                        "Validation error",
+                        cancellationToken
+                    ),
+                async notFound =>
+                    await HttpResponseUtility.NotFoundResponse(
+                        req,
+                        context.InvocationId,
+                        cancellationToken
+                    ),
+                async error =>
+                    await HttpResponseUtility.ProblemResponse(
+                        req,
+                        HttpStatusCode.BadGateway,
+                        "Downstream API Error",
+                        "The upstream PDS matching service encountered an error or timed out. Matching cannot be completed at this time.",
+                        context.InvocationId,
+                        cancellationToken
+                    )
+            );
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unhandled exception during GetAnIdentifier execution");
+            return await HttpResponseUtility.InternalServerErrorResponse(
+                req,
+                context.InvocationId,
+                cancellationToken
+            );
+        }
     }
 
     private bool TryGetMatchResponseRequestModel(

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.Infrastructure/Services/FhirService.cs
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.Infrastructure/Services/FhirService.cs
@@ -1,4 +1,5 @@
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
 using Microsoft.Extensions.Logging;
 using SUI.GetAnIdentifier.Application.Interfaces;
 using SUI.GetAnIdentifier.Application.Models;
@@ -30,10 +31,12 @@ public class FhirService(ILogger<FhirService> logger, IFhirClientFactory fhirCli
                 var isMultiMatch =
                     client.LastBodyAsResource is OperationOutcome outcome
                     && outcome.Issue.Any(i => i.Code == OperationOutcome.IssueType.MultipleMatches);
+
                 logger.LogInformation(
                     "Handling null bundle from FHIR API, isMultiMatch: {IsMultiMatch}",
                     isMultiMatch
                 );
+
                 return isMultiMatch
                     ? Result<SearchResult>.Ok(SearchResult.MultiMatched())
                     : Result<SearchResult>.Fail("FHIR API returned null bundle");
@@ -51,8 +54,51 @@ public class FhirService(ILogger<FhirService> logger, IFhirClientFactory fhirCli
                 _ => Result<SearchResult>.Fail("Unexpected multiple entries"),
             };
         }
+        catch (FhirOperationException ex)
+        {
+            // Handle NHS Digital Non-Success Responses (e.g. 400, 500)
+            if (ex.Outcome != null && ex.Outcome.Issue.Any())
+            {
+                var issues = string.Join(
+                    " | ",
+                    ex.Outcome.Issue.Select(i =>
+                        $"Severity: {i.Severity}, Code: {i.Code}, Diagnostics: {i.Diagnostics}"
+                    )
+                );
+
+                logger.LogError(
+                    ex,
+                    "PDS API returned an OperationOutcome error. Status: {StatusCode}, Issues: {Issues}",
+                    ex.Status,
+                    issues
+                );
+            }
+            else
+            {
+                logger.LogError(
+                    ex,
+                    "PDS API returned a non-success response. Status: {StatusCode}",
+                    ex.Status
+                );
+            }
+
+            return Result<SearchResult>.Fail($"PDS API Error: {ex.Status}");
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            // Handle Downstream Timeouts
+            logger.LogError(ex, "Request to PDS API timed out.");
+            return Result<SearchResult>.Fail("PDS API Timeout");
+        }
+        catch (HttpRequestException ex)
+        {
+            // Handle DNS/Network level failures
+            logger.LogError(ex, "Network error while connecting to PDS API.");
+            return Result<SearchResult>.Fail("PDS API Network Error");
+        }
         catch (Exception ex)
         {
+            // Catch-all
             logger.LogError(ex, "Error occurred while performing FHIR search");
             return Result<SearchResult>.Fail(ex.Message);
         }

--- a/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.Infrastructure/Services/FhirService.cs
+++ b/Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.Infrastructure/Services/FhirService.cs
@@ -57,7 +57,7 @@ public class FhirService(ILogger<FhirService> logger, IFhirClientFactory fhirCli
         catch (FhirOperationException ex)
         {
             // Handle NHS Digital Non-Success Responses (e.g. 400, 500)
-            if (ex.Outcome != null && ex.Outcome.Issue.Any())
+            if (ex.Outcome != null && ex.Outcome.Issue.Count != 0)
             {
                 var issues = string.Join(
                     " | ",

--- a/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.API.UnitTests/FunctionTests/GetAnIdentifierTests.cs
+++ b/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.API.UnitTests/FunctionTests/GetAnIdentifierTests.cs
@@ -5,14 +5,15 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using OneOf.Types;
-using SUI.GetAnIdentifier.Application.Enum;
-using SUI.GetAnIdentifier.Application.Interfaces;
-using SUI.GetAnIdentifier.Application.Models;
 using SUI.GetAnIdentifier.API.Configuration;
 using SUI.GetAnIdentifier.API.Functions;
 using SUI.GetAnIdentifier.API.Models;
 using SUI.GetAnIdentifier.API.UnitTests.Mocks;
+using SUI.GetAnIdentifier.Application.Enum;
+using SUI.GetAnIdentifier.Application.Interfaces;
+using SUI.GetAnIdentifier.Application.Models;
 
 namespace SUI.GetAnIdentifier.API.UnitTests.FunctionTests;
 
@@ -90,6 +91,7 @@ public class GetAnIdentifierTests
         var headers = CreateHeadersWithApiKey();
         var req = MockHttpRequestData.CreateJson(validRequest, headers: headers);
         var personId = "9876543210";
+
         _getAnIdentifierService
             .MatchPersonAsync(Arg.Any<PersonSpecification>(), Arg.Any<CancellationToken>())
             .Returns(NhsPersonId.Create(personId).Value!);
@@ -114,6 +116,7 @@ public class GetAnIdentifierTests
         var validRequest = CreateMatchRequest();
         var headers = CreateHeadersWithApiKey();
         var req = MockHttpRequestData.CreateJson(validRequest, headers: headers);
+
         _getAnIdentifierService
             .MatchPersonAsync(Arg.Any<PersonSpecification>(), Arg.Any<CancellationToken>())
             .Returns(new NotFound());
@@ -126,7 +129,7 @@ public class GetAnIdentifierTests
     }
 
     [Fact]
-    public async Task ShouldProblem_WhenErrorOccurs()
+    public async Task ShouldReturnBadGateway_WhenDownstreamErrorOccurs()
     {
         // Arrange
         var function = CreateFunction();
@@ -134,9 +137,31 @@ public class GetAnIdentifierTests
         var validRequest = CreateMatchRequest();
         var headers = CreateHeadersWithApiKey();
         var req = MockHttpRequestData.CreateJson(validRequest, headers: headers);
+
         _getAnIdentifierService
             .MatchPersonAsync(Arg.Any<PersonSpecification>(), Arg.Any<CancellationToken>())
-            .Returns(new Error());
+            .Returns(new Error()); // Simulate the failure from the FHIR service
+
+        // Act
+        var response = await function.GetAnIdentifier(req, context, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ShouldReturnInternalServerError_WhenUnhandledExceptionOccurs()
+    {
+        // Arrange
+        var function = CreateFunction();
+        var context = CreateContextWithAuth();
+        var validRequest = CreateMatchRequest();
+        var headers = CreateHeadersWithApiKey();
+        var req = MockHttpRequestData.CreateJson(validRequest, headers: headers);
+
+        _getAnIdentifierService
+            .MatchPersonAsync(Arg.Any<PersonSpecification>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Unexpected system crash")); // Simulate an unhandled code crash
 
         // Act
         var response = await function.GetAnIdentifier(req, context, CancellationToken.None);
@@ -241,8 +266,6 @@ public class GetAnIdentifierTests
     [Fact]
     public async Task ShouldReturnBadRequest_WhenRequestIsMissingBody()
     {
-        // Edge case test for null body
-
         // Arrange
         var service = Substitute.For<IGetAnIdentifierService>();
         var logger = Substitute.For<ILogger<GetAnIdentifierFunction>>();

--- a/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Infrastructure.UnitTests/Services/BaseFhirClientTests.cs
+++ b/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Infrastructure.UnitTests/Services/BaseFhirClientTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Microsoft.Extensions.Logging;
@@ -197,5 +198,73 @@ public class TestFhirClientEntryComponentSearchNull : FhirClient
         };
 
         return await Task.FromResult<Bundle?>(bundle);
+    }
+}
+
+public class TestFhirClientOperationOutcomeError : FhirClient
+{
+    public TestFhirClientOperationOutcomeError(
+        string endpoint = "https://example.com/fhir",
+        FhirClientSettings settings = null!,
+        HttpMessageHandler messageHandler = null!
+    )
+        : base(endpoint, settings, messageHandler) { }
+
+    public override Task<Bundle?> SearchAsync<TResource>(
+        SearchParams q,
+        CancellationToken? ct = null
+    )
+    {
+        var operationOutcome = new OperationOutcome();
+        operationOutcome.Issue.Add(
+            new OperationOutcome.IssueComponent
+            {
+                Severity = OperationOutcome.IssueSeverity.Error,
+                Code = OperationOutcome.IssueType.Value,
+                Diagnostics = "Invalid NHS number format",
+            }
+        );
+
+        throw new FhirOperationException(
+            "Bad Request",
+            HttpStatusCode.BadRequest,
+            operationOutcome
+        );
+    }
+}
+
+public class TestFhirClientTimeout : FhirClient
+{
+    public TestFhirClientTimeout(
+        string endpoint = "https://example.com/fhir",
+        FhirClientSettings settings = null!,
+        HttpMessageHandler messageHandler = null!
+    )
+        : base(endpoint, settings, messageHandler) { }
+
+    public override Task<Bundle?> SearchAsync<TResource>(
+        SearchParams q,
+        CancellationToken? ct = null
+    )
+    {
+        throw new TaskCanceledException("The operation was canceled.");
+    }
+}
+
+public class TestFhirClientNetworkError : FhirClient
+{
+    public TestFhirClientNetworkError(
+        string endpoint = "https://example.com/fhir",
+        FhirClientSettings settings = null!,
+        HttpMessageHandler messageHandler = null!
+    )
+        : base(endpoint, settings, messageHandler) { }
+
+    public override Task<Bundle?> SearchAsync<TResource>(
+        SearchParams q,
+        CancellationToken? ct = null
+    )
+    {
+        throw new HttpRequestException("Name resolution failure");
     }
 }

--- a/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Infrastructure.UnitTests/Services/FhirServiceTest.cs
+++ b/Apps/GetAnIdentifier/tests/SUI.GetAnIdentifier.Infrastructure.UnitTests/Services/FhirServiceTest.cs
@@ -30,6 +30,54 @@ public class FhirServiceTests : BaseFhirClientTests
     }
 
     [Fact]
+    public async Task ShouldReturnFail_WhenFhirOperationExceptionIsThrown()
+    {
+        // Arrange
+        var searchQuery = new SearchQuery();
+
+        // Act
+        var testFhirClient = new TestFhirClientOperationOutcomeError(); // Assumes this mocks a FhirOperationException throw
+        FhirClientFactoryMock.CreateFhirClientAsync().Returns(testFhirClient);
+        var result = await _fhirService.PerformSearchAsync(searchQuery, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("PDS API Error", result.Error);
+    }
+
+    [Fact]
+    public async Task ShouldReturnFail_WhenTaskCanceledExceptionIsThrown()
+    {
+        // Arrange
+        var searchQuery = new SearchQuery();
+
+        // Act
+        var testFhirClient = new TestFhirClientTimeout(); // Assumes this mocks a TaskCanceledException throw
+        FhirClientFactoryMock.CreateFhirClientAsync().Returns(testFhirClient);
+        var result = await _fhirService.PerformSearchAsync(searchQuery, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("PDS API Timeout", result.Error);
+    }
+
+    [Fact]
+    public async Task ShouldReturnFail_WhenHttpRequestExceptionIsThrown()
+    {
+        // Arrange
+        var searchQuery = new SearchQuery();
+
+        // Act
+        var testFhirClient = new TestFhirClientNetworkError(); // Assumes this mocks an HttpRequestException throw
+        FhirClientFactoryMock.CreateFhirClientAsync().Returns(testFhirClient);
+        var result = await _fhirService.PerformSearchAsync(searchQuery, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("PDS API Network Error", result.Error);
+    }
+
+    [Fact]
     public async Task ShouldReturnUnmatched_IfNoEntriesFound()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Ensure the endpoint handles downstream timeouts, non-success responses, and validation issues consistently, returning appropriate API errors and messages where matching cannot be completed.

## Changes

- Mapped downstream PDS failures to a standard 502 Bad Gateway response in the function endpoint.
- Updated FhirService to explicitly catch, handle, and log network errors, timeouts, and FHIR operation exceptions.
- Added endpoint unit tests to verify the new 502 Bad Gateway and 500 Internal Server Error fallback mappings.
- Added dedicated mock classes and service tests to validate the new upstream PDS error handling logic.

## Validation

- Successful build and deploy workflows
- Successful unit test runs
