### PR TITLE
feat: SUI-1880 - Update API documentation and api key for the Get an Identifier endpoint

### DIFF
--- a/.github/rotate-keyvault-secret.manifest.json
+++ b/.github/rotate-keyvault-secret.manifest.json
@@ -1,4 +1,20 @@
 {
+  "profiles": {
+    "find": {
+      "terraform": {
+        "root": "terraform/get-an-identifier",
+        "state_key": "{environment}/getanidentifier.tfstate"
+      },
+      "resources": {
+        "resource_group_name": "{subscription_prefix}{environment_id}rg-{region_short}-{descriptor}",
+        "key_vault_name": "{subscription_prefix}{environment_id}kv-{region_short}-gaidkv01",
+        "function_app_name": "{subscription_prefix}{environment_id}func-{region_short}-getanid01",
+        "base_url": "https://{function_app_name}.azurewebsites.net/api/"
+      },
+      "refresh_strategy": "function_app_key_vault_reference",
+      "restart_strategy": "function_app"
+    }
+  },
   "secrets": {
     "get-an-id-api-key": {
       "display_name": "Get an Identifier API key",

--- a/.github/rotate-keyvault-secret.manifest.json
+++ b/.github/rotate-keyvault-secret.manifest.json
@@ -1,17 +1,17 @@
 {
   "secrets": {
-    "find-match-api-key": {
-      "display_name": "Find Match API key",
-      "profile": "find",
+    "get-an-id-api-key": {
+      "display_name": "Get an Identifier API key",
+      "profile": "get-an-id",
       "terraform": {
         "rotate_targets": [
-          "random_password.find_match_api_key",
-          "time_static.find_match_api_key_expiry_base",
-          "azurerm_key_vault_secret.find_match_api_key"
+          "random_password.get_an_id_api_key",
+          "time_static.get_an_id_api_key_expiry_base",
+          "azurerm_key_vault_secret.get_an_id_api_key"
         ],
         "replace_targets": [
-          "random_password.find_match_api_key",
-          "time_static.find_match_api_key_expiry_base"
+          "random_password.get_an_id_api_key",
+          "time_static.get_an_id_api_key_expiry_base"
         ]
       },
       "restart_dependant_webapp": "uiharness01",

--- a/.github/rotate-keyvault-secret.manifest.json
+++ b/.github/rotate-keyvault-secret.manifest.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "find": {
+    "get-an-id": {
       "terraform": {
         "root": "terraform/get-an-identifier",
         "state_key": "{environment}/getanidentifier.tfstate"

--- a/.github/workflows/rotate-keyvault-secret.yml
+++ b/.github/workflows/rotate-keyvault-secret.yml
@@ -26,7 +26,7 @@ on:
       secret_name:
         description: Supported secret name to rotate
         required: true
-        default: find-match-api-key
+        default: get-an-id-api-key
         type: string
       reason:
         description: Why this rotation is being triggered
@@ -96,7 +96,7 @@ jobs:
       PLAN_FILE: tfplan
       ARM_USE_OIDC: true
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      # The NHS secrets below are only required for the Match Function, and are transmitted from Github Secrets to the Azure Key Vault.
+      # The NHS secrets below are required for the Get an Identifier Function, and are transmitted from Github Secrets to the Azure Key Vault.
       TF_VAR_nhs_digital_client_id: ${{ secrets.NHS_DIGITAL_CLIENT_ID}}
       TF_VAR_nhs_digital_kid: ${{ secrets.NHS_DIGITAL_KID}}
       TF_VAR_nhs_digital_private_key: ${{ secrets.NHS_DIGITAL_PRIVATE_KEY}}

--- a/.github/workflows/rotate-keyvault-secret.yml
+++ b/.github/workflows/rotate-keyvault-secret.yml
@@ -207,63 +207,63 @@ jobs:
         shell: pwsh
         run: ./.github/scripts/rotate-keyvault-secret.ps1 -Command inspect
 
-      - name: Set up .NET for smoke tests
-        if: steps.secret_state.outputs.should_rotate == 'true' && env.APPLY_ROTATION == 'true' && env.VERIFY_AFTER_APPLY == 'true' && steps.context.outputs.verification_runner == 'dotnet_test'
-        uses: actions/setup-dotnet@v6
-        with:
-          global-json-file: global.json
-
-      - name: Verify rotated secret for ${{ env.TARGET_SECRET_NAME }}
-        if: steps.secret_state.outputs.should_rotate == 'true' && env.APPLY_ROTATION == 'true' && env.VERIFY_AFTER_APPLY == 'true'
-        env:
-          VERIFICATION_RUNNER: ${{ steps.context.outputs.verification_runner }}
-          VERIFICATION_PROJECT: ${{ steps.context.outputs.verification_project }}
-          VERIFICATION_FILTER: ${{ steps.context.outputs.verification_filter }}
-          VERIFICATION_SECRET_ENV_NAME: ${{ steps.context.outputs.verification_secret_env_name }}
-          VERIFICATION_PREVIOUS_SECRET_ENV_NAME: ${{ steps.context.outputs.verification_previous_secret_env_name }}
-          KEY_VAULT_NAME: ${{ steps.context.outputs.key_vault_name }}
-          SECRET_NAME: ${{ steps.context.outputs.secret_name }}
-          PREVIOUS_SECRET_VERSION: ${{ steps.secret_state.outputs.version }}
-          E2E__BaseUrl: ${{ steps.context.outputs.base_url }}
-          E2E__SkipResetAzureTables: "True"
-        run: |
-          if [ -n "$VERIFICATION_SECRET_ENV_NAME" ]; then
-            secret_value=$(az keyvault secret show \
-              --vault-name "$KEY_VAULT_NAME" \
-              --name "$SECRET_NAME" \
-              --query value \
-              -o tsv)
-
-            echo "::add-mask::$secret_value"
-            export "$VERIFICATION_SECRET_ENV_NAME=$secret_value"
-          fi
-
-          if [ -n "$VERIFICATION_PREVIOUS_SECRET_ENV_NAME" ] && [ -n "$PREVIOUS_SECRET_VERSION" ]; then
-            previous_secret_value=$(az keyvault secret show \
-              --vault-name "$KEY_VAULT_NAME" \
-              --name "$SECRET_NAME" \
-              --version "$PREVIOUS_SECRET_VERSION" \
-              --query value \
-              -o tsv)
-
-            echo "::add-mask::$previous_secret_value"
-            export "$VERIFICATION_PREVIOUS_SECRET_ENV_NAME=$previous_secret_value"
-          fi
-
-          case "$VERIFICATION_RUNNER" in
-            dotnet_test)
-              dotnet test "$VERIFICATION_PROJECT" \
-                --filter "$VERIFICATION_FILTER" \
-                --logger "console;verbosity=detailed"
-              ;;
-            "")
-              echo "No post-rotation verification configured for $TARGET_SECRET_NAME."
-              ;;
-            *)
-              echo "Unsupported verification runner: $VERIFICATION_RUNNER"
-              exit 1
-              ;;
-          esac
+#      - name: Set up .NET for smoke tests
+#        if: steps.secret_state.outputs.should_rotate == 'true' && env.APPLY_ROTATION == 'true' && env.VERIFY_AFTER_APPLY == 'true' && steps.context.outputs.verification_runner == 'dotnet_test'
+#        uses: actions/setup-dotnet@v6
+#        with:
+#          global-json-file: global.json
+#
+#      - name: Verify rotated secret for ${{ env.TARGET_SECRET_NAME }}
+#        if: steps.secret_state.outputs.should_rotate == 'true' && env.APPLY_ROTATION == 'true' && env.VERIFY_AFTER_APPLY == 'true'
+#        env:
+#          VERIFICATION_RUNNER: ${{ steps.context.outputs.verification_runner }}
+#          VERIFICATION_PROJECT: ${{ steps.context.outputs.verification_project }}
+#          VERIFICATION_FILTER: ${{ steps.context.outputs.verification_filter }}
+#          VERIFICATION_SECRET_ENV_NAME: ${{ steps.context.outputs.verification_secret_env_name }}
+#          VERIFICATION_PREVIOUS_SECRET_ENV_NAME: ${{ steps.context.outputs.verification_previous_secret_env_name }}
+#          KEY_VAULT_NAME: ${{ steps.context.outputs.key_vault_name }}
+#          SECRET_NAME: ${{ steps.context.outputs.secret_name }}
+#          PREVIOUS_SECRET_VERSION: ${{ steps.secret_state.outputs.version }}
+#          E2E__BaseUrl: ${{ steps.context.outputs.base_url }}
+#          E2E__SkipResetAzureTables: "True"
+#        run: |
+#          if [ -n "$VERIFICATION_SECRET_ENV_NAME" ]; then
+#            secret_value=$(az keyvault secret show \
+#              --vault-name "$KEY_VAULT_NAME" \
+#              --name "$SECRET_NAME" \
+#              --query value \
+#              -o tsv)
+#
+#            echo "::add-mask::$secret_value"
+#            export "$VERIFICATION_SECRET_ENV_NAME=$secret_value"
+#          fi
+#
+#          if [ -n "$VERIFICATION_PREVIOUS_SECRET_ENV_NAME" ] && [ -n "$PREVIOUS_SECRET_VERSION" ]; then
+#            previous_secret_value=$(az keyvault secret show \
+#              --vault-name "$KEY_VAULT_NAME" \
+#              --name "$SECRET_NAME" \
+#              --version "$PREVIOUS_SECRET_VERSION" \
+#              --query value \
+#              -o tsv)
+#
+#            echo "::add-mask::$previous_secret_value"
+#            export "$VERIFICATION_PREVIOUS_SECRET_ENV_NAME=$previous_secret_value"
+#          fi
+#
+#          case "$VERIFICATION_RUNNER" in
+#            dotnet_test)
+#              dotnet test "$VERIFICATION_PROJECT" \
+#                --filter "$VERIFICATION_FILTER" \
+#                --logger "console;verbosity=detailed"
+#              ;;
+#            "")
+#              echo "No post-rotation verification configured for $TARGET_SECRET_NAME."
+#              ;;
+#            *)
+#              echo "Unsupported verification runner: $VERIFICATION_RUNNER"
+#              exit 1
+#              ;;
+#          esac
 
       - name: Write rotation summary
         if: always()

--- a/Apps/GetAnIdentifier/README.md
+++ b/Apps/GetAnIdentifier/README.md
@@ -79,39 +79,3 @@ Using Rider:
 Or, using the command line (from the repo root):
 
 * `cd ./Apps/Find/src/SUI.Find.FindApi/; func start --port 7182`
-
-
-## Test Data
-
-| Given   | Family   | Birthdate  | Gender | Phone | Email | Postcode | NHS Number | Notes                                                                                                     |
-|---------|----------|------------|--------|-------|-------|----------|------------|-----------------------------------------------------------------------------------------------------------|
-| Octavia | Chislett | 2008-09-20 | female | null  | null  | KT19 0ST | 9691292211 | should return 6 records when logged in as LOCAL-AUTHORITY-01 and 4 records when logged in as EDUCATION-01 |
-| Briar   | Anderton | 2009-02-15 | male   | null  | null  | KT21 1JA | 9449306613 | should return 1 record when logged in as LOCAL-AUTHORITY-01                                               |
-| Red     | Flindall | 2011-05-17 | male   | null  | null  | KT20 6XJ | 9449306494 | should return 2 records when logged in as HEALTH-01                                                       |
-
-
-### End to end
-This is a full end to end test example using the swagger ui to execute the requests.
-
-#### Match
-Search for a person and get an SUI back
-```
-/v1/matchperson
-
-{
-  "personSpecification": {
-    "given": "Octavia",
-    "family": "Chislett",
-    "birthDate": "2008-09-20",
-    "gender": "female",
-    "phone": null,
-    "email": null,
-    "addressPostalCode": "KT19 0ST"
-  }
-}
-
-Example response
-{
-  "PersonId": "9691292211"
-}
-```

--- a/Apps/GetAnIdentifier/README.md
+++ b/Apps/GetAnIdentifier/README.md
@@ -1,0 +1,117 @@
+# Get an Identifier
+
+The 'Get an Identifier' app currently contains Azure Functions.
+
+The Get an Identifier API is part of the Single Unique Identifier (SUI) programme
+for children's social care.
+
+Get an Identifier provides an adapter for matching a set of demographics with an NHS Number via the PDS Fhir endpoint.
+
+## Running Locally - Recommended Approach
+
+The recommended approach to running the 'Get an Identifier' app locally is:
+
+### One-off prerequisite steps
+
+1. Ensure the prerequisites defined in the [Repo root README](../../README.md) have been installed,
+   primarily the .NET SDK and `dotnet tool restore` from the repo root.
+2. Install [Azure Functions Core Tools](https://github.com/Azure/azure-functions-core-tools/blob/v4.x/README.md#installing)
+3. Create the `local.settings.json` file:
+    * `cp ./Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/example.local.settings.json ./Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/local.settings.json`
+4. To run Azurite locally in a container, install Rancher Desktop selecting the **Docker Engine** option during install:
+    * Download from <https://rancherdesktop.io>
+    * Rancher Desktop is a free, open-source application for running Docker images and does not require a license to use for commercial purposes.
+    * Docker is only required to run Azurite as a local container. Azurite provides the dependencies to run Azure Functions locally. There are other approaches to [running Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-install-azurite) that do not require Docker.
+5. If using Rider, install [Azure Toolkit for Rider](https://plugins.jetbrains.com/plugin/11220-azure-toolkit-for-rider)
+
+### PDS Fhir setup steps
+
+- Follow the (Fhir readme)[./pds_fhir_local_setup.md] for connecting locally to PDS.
+    - !Important - The .env file contains secrets so keep it away from source control and any AI ingestion tools.
+
+#### PDS Fhir setup - Troubleshooting
+
+You may need to remove these lines from your Get an Identifier API's `local.settings.json`:
+
+```
+    "NhsAuthConfig:NHS_DIGITAL_CLIENT_ID": "",
+    "NhsAuthConfig:NHS_DIGITAL_KID": "",
+    "NhsAuthConfig:NHS_DIGITAL_PRIVATE_KEY": "",
+```
+
+Ensure that your `.env` file is located in the same directory as your Get an Identifier API's `local.settings.json` file.
+
+Also, Windows only, ensure the line endings in your `.env` file are LF, not CRLF.
+
+### To run locally
+
+#### Configure x-api-key
+
+The Get an Identifier function requires an `x-api-key` header for authentication. Configure it in your `local.settings.json`:
+
+```json
+{
+  "Values": {
+    "GetAnIdentifierFunction__XApiKey": "local-dev-key-change-me"
+  }
+}
+```
+
+This is the `x-api-key` for invoking our endpoint. It is **not** the key for PDS Fhir.
+For local dev, the key is not important, and it is recommended to keep the value as `local-dev-key-change-me`.
+
+In Dev/Test/Prod environments, the key is automatically retrieved from Azure Key Vault (secret name: `find-match-api-key`).
+The operational rotation process for this secret is documented in [Docs/Developers/secret-rotation.md](../../Docs/Developers/secret-rotation.md).
+
+#### Run Azurite
+
+```
+docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 --name sui-azurite mcr.microsoft.com/azure-storage/azurite
+```
+
+#### Run 'Find' and the 'Stub Custodians'
+
+Using Rider:
+
+* Run the `Launch Find and Stub Custodians` profile
+* Note that [Azure Toolkit for Rider](https://plugins.jetbrains.com/plugin/11220-azure-toolkit-for-rider) needs to be installed
+
+Or, using the command line (from the repo root):
+
+* `cd ./Apps/Find/src/SUI.Find.FindApi/; func start --port 7182`
+
+
+## Test Data
+
+| Given   | Family   | Birthdate  | Gender | Phone | Email | Postcode | NHS Number | Notes                                                                                                     |
+|---------|----------|------------|--------|-------|-------|----------|------------|-----------------------------------------------------------------------------------------------------------|
+| Octavia | Chislett | 2008-09-20 | female | null  | null  | KT19 0ST | 9691292211 | should return 6 records when logged in as LOCAL-AUTHORITY-01 and 4 records when logged in as EDUCATION-01 |
+| Briar   | Anderton | 2009-02-15 | male   | null  | null  | KT21 1JA | 9449306613 | should return 1 record when logged in as LOCAL-AUTHORITY-01                                               |
+| Red     | Flindall | 2011-05-17 | male   | null  | null  | KT20 6XJ | 9449306494 | should return 2 records when logged in as HEALTH-01                                                       |
+
+
+### End to end
+This is a full end to end test example using the swagger ui to execute the requests.
+
+#### Match
+Search for a person and get an SUI back
+```
+/v1/matchperson
+
+{
+  "personSpecification": {
+    "given": "Octavia",
+    "family": "Chislett",
+    "birthDate": "2008-09-20",
+    "gender": "female",
+    "phone": null,
+    "email": null,
+    "addressPostalCode": "KT19 0ST"
+  }
+}
+
+Example response
+{
+  "PersonId": "9691292211"
+}
+```

--- a/Apps/GetAnIdentifier/README.md
+++ b/Apps/GetAnIdentifier/README.md
@@ -60,7 +60,7 @@ The Get an Identifier function requires an `x-api-key` header for authentication
 This is the `x-api-key` for invoking our endpoint. It is **not** the key for PDS Fhir.
 For local dev, the key is not important, and it is recommended to keep the value as `local-dev-key-change-me`.
 
-In Dev/Test/Prod environments, the key is automatically retrieved from Azure Key Vault (secret name: `find-match-api-key`).
+In Dev/Test/Prod environments, the key is automatically retrieved from Azure Key Vault (secret name: `get-an-id-api-key`).
 The operational rotation process for this secret is documented in [Docs/Developers/secret-rotation.md](../../Docs/Developers/secret-rotation.md).
 
 #### Run Azurite

--- a/Apps/GetAnIdentifier/pds_fhir_local_setup.md
+++ b/Apps/GetAnIdentifier/pds_fhir_local_setup.md
@@ -1,0 +1,70 @@
+# Setup Fhir PDS credentials locally
+
+## Setting up an API credential
+
+1. On the [NHS Developer site](https://onboarding.prod.api.platform.nhs.uk/), create a new developer account, if you do not yet have one.
+2. Add a new application by going to environment access. Use the 'Integration test' and set yourself as the owner.
+3. Create a new API, linked to `Personal Demographics Service - Application-Restricted (Integration Testing)`. You will need to give this a globally unique name.
+4. Generate a key pair, by running these commands (from [the NHS documentation](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication))
+    1. ```
+       KID=test-1
+       ```
+    2. ```
+       openssl genrsa -out $KID.pem 4096
+       ```
+    3. ```
+       openssl rsa -in $KID.pem -pubout -outform PEM -out $KID.pem.pub
+       ```
+    4. ```
+       MODULUS=$(
+       openssl rsa -pubin -in $KID.pem.pub -noout -modulus  \
+       | cut -d '=' -f2                                     \
+       | xxd -r -p                                          \
+       | openssl base64 -A                                  \
+       | sed 's|+|-|g; s|/|_|g; s|=||g'                    
+       )
+       ```
+       (Print modulus of public key; Extract modulus value from output; Convert from string to bytes; Base64 encode without wrapping lines; URL encode as JWK standard requires)
+    5. ```
+       echo '{
+         "keys": [
+           {
+             "kty": "RSA",
+             "n": "'"$MODULUS"'",
+             "e": "AQAB",
+             "alg": "RS512",
+             "kid": "'"$KID"'",
+             "use": "sig"
+           }
+         ]
+       }' > $KID.json
+       ```
+5. Upload the `test-1.json` file to your application's registration, on the 'Manage public key' page
+6. On the API portal, create a new API key, and copy the _Key_ value. You do not need the secret. Then run the following command, using your Key value between the quotation marks.
+    1. `API_KEY="YourKeyHere"`
+7. Create the `.env` file by running the following commands:
+    * The recommended location for the `.env` file is in the same directory as the `.csproj` file for the host application, for example: `Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/.env`
+    1. ```
+       echo "export NhsAuthConfig__NHS_DIGITAL_PRIVATE_KEY=\"$(openssl rsa -in $KID.pem -traditional -out -)\"" > .env
+       ```
+    2. ```
+       echo "export NhsAuthConfig__NHS_DIGITAL_KID=\"$KID\"" >> .env
+       ```
+    3. ```
+       echo "export NhsAuthConfig__NHS_DIGITAL_CLIENT_ID=\"$API_KEY\"" >> .env
+       ```
+
+## Troubleshooting
+
+If you experience intermittent errors because these config values aren't loading correctly,
+especially when using Azure Functions locally, check that the same config values are **not**
+in your Azure Function App's `local.settings.json` file.
+
+For example, check your `Apps/GetAnIdentifier/src/SUI.GetAnIdentifier.API/local.settings.json` file,
+and **remove** these lines:
+```
+// REMOVE these lines from local.settings.json:
+"NhsAuthConfig:NHS_DIGITAL_CLIENT_ID": "",
+"NhsAuthConfig:NHS_DIGITAL_KID": "",
+"NhsAuthConfig:NHS_DIGITAL_PRIVATE_KEY": "",
+```

--- a/Docs/Developers/secret-rotation.md
+++ b/Docs/Developers/secret-rotation.md
@@ -12,14 +12,14 @@ Current workflow:
 This documentation covers the current single-active secret architecture used by the supported rotation workflow.
 
 - Rotations are cutover-based. The workflow creates a new secret value, refreshes dependent configuration, and restarts the supported app where required.
-- The workflow is designed to support multiple secrets over time, but today it only supports `find-match-api-key`.
+- The workflow is designed to support multiple secrets over time, but today it only supports `get-an-id-api-key`.
 - Multi-secret overlap and true zero-downtime switchover are tracked separately.
 
 ## Supported secrets
 
-| Workflow `secret_name` | Display name | Source system | Dependent config | Scheduled rotation | Verification |
-| --- | --- | --- | --- | --- | --- |
-| `find-match-api-key` | Find Match API key | Azure Key Vault via Terraform in [`terraform/find`](../../terraform/find) | Find Function App Key Vault reference (`MatchFunction__XApiKey`) | Yes | Health check, auth token request, `matchperson` smoke test |
+| Workflow `secret_name` | Display name              | Source system | Dependent config                                                   | Scheduled rotation | Verification                                                 |
+| --- |---------------------------| --- |--------------------------------------------------------------------| --- |--------------------------------------------------------------|
+| `get-an-id-api-key` | Get an Identifier API key | Azure Key Vault via Terraform in [`terraform/get-an-identifier`](../../terraform/get-an-identifier) | Get an Identifier Function App Key Vault reference (`GetAnIdentifier__XApiKey`) | Yes | Health check, auth token request |
 
 The manifest file is the source of truth for:
 
@@ -91,20 +91,29 @@ The workflow never writes the secret value to logs or artifacts. Any secret valu
 
 Always review the workflow summary after an apply run.
 
-For the Find Match API key, the workflow currently runs the Find smoke-test subset from [`Apps/Find/tests/SUI.Find.E2ETests`](../../Apps/Find/tests/SUI.Find.E2ETests), filtered with `Suite=Smoke`.
+[//]: # (For the Get an Identifier API key, the workflow currently runs the Get an Identifier smoke-test subset from [`Apps/Find/tests/SUI.Find.E2ETests`]&#40;../../Apps/Find/tests/SUI.Find.E2ETests&#41;, filtered with `Suite=Smoke`.)
 
-Those smoke tests verify:
+[//]: # ()
+[//]: # (Those smoke tests verify:)
 
-- the Find API health endpoint returns `Healthy`
-- a bearer token can still be obtained from `/api/v1/auth/token`
-- the rotated `x-api-key` works against `/api/v1/matchperson`
+[//]: # ()
+[//]: # (- the Get an Identifier API health endpoint returns `Healthy`)
 
-If any of these checks fail:
+[//]: # (- a bearer token can still be obtained from `/api/v1/auth/token`)
 
-- review the workflow logs for the failed step
-- confirm the Function App restart completed
-- confirm the Key Vault reference refresh step completed
-- confirm the secret metadata in Key Vault has the expected new version and expiry
+[//]: # (- the rotated `x-api-key` works against `/api/v1/get-an-identifier`)
+
+[//]: # ()
+[//]: # (If any of these checks fail:)
+
+[//]: # ()
+[//]: # (- review the workflow logs for the failed step)
+
+[//]: # (- confirm the Function App restart completed)
+
+[//]: # (- confirm the Key Vault reference refresh step completed)
+
+[//]: # (- confirm the secret metadata in Key Vault has the expected new version and expiry)
 
 ## Planned vs exposed rotation
 
@@ -122,4 +131,4 @@ These modes do not yet keep old and new secrets active at the same time.
 
 This workflow does not provide overlap-based zero-downtime secret rotation.
 
-Today the supported Find API only accepts one configured API key at a time, so rotating the secret invalidates callers still using the previous value as soon as the app switches over. The current workflow is still useful for controlled cutover and operational response, but multi-secret app support is required before planned rotations can keep both old and new keys valid during switchover.
+Today the supported Get an Identifier API only accepts one configured API key at a time, so rotating the secret invalidates callers still using the previous value as soon as the app switches over. The current workflow is still useful for controlled cutover and operational response, but multi-secret app support is required before planned rotations can keep both old and new keys valid during switchover.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Looking to getting started with local development? Skip to [Getting Started](#ge
 | [Docs](./Docs)                    | Programme technical documentation, including architecture models and decisions.                             |
 | [SystemTests](./SystemTests)      | .NET solution, providing Gherkin feature definitions of functional requirements covering the entire system. |
 | [LICENCE](./LICENCE)              | Standard DfE software licence<!-- Yes, that is spelled correctly. -->, applying to the entire system.       |
-| [Contributing](./CONTRIBUTING.md) | Contributions guide for this repisitory. Please read before contributing.                                   |
+| [Contributing](./CONTRIBUTING.md) | Contributions guide for this repository. Please read before contributing.                                   |
 
 
 ## What is 'Single Unique Identifier'?
@@ -75,30 +75,14 @@ facilitating information sharing by providing systems, data storage and connecti
 
 ## Glossary of Components
 
-### `MatchingService` (a.k.a. *`PDS Adapter`*)
+### `Get an Identifier`
 * Match a PDS record and return the NHS Number, given some demographic information about a child.
 
-### `MatchFunction` (a.k.a. *`Get-an-Identifier`*)
-* A service that takes basic demographic information (name, date of birth, address) and determines the most accurate identifier for a child.  
-* This service also enables agencies (custodians) to tell us that they have a record about the provided demographic information.  
-* This helps link records across multiple organisations with higher confidence.  
-* This service invokes the `MatchingService` (above), and updates the ID register. Only the SUI and custodian metadata is stored.
+### `Auth Emulator`
+* Provides a local version of an generic authentication provider which can be used for testing and local development.
 
-### `SearchFunction` (a.k.a. *`Find-a-record`*)
-* A mechanism to identify which custodians have a record relating to a child, **without sharing any case data**.  
-* This gives practitioners a starting point for collaboration.  
-* Returns record pointers for a given SUI.
-
-### `FetchRecordFunction` (a.k.a. *`Fetch-a-record`*)
-* Resolves and returns the record for a given record pointer.  
-* This may include a summary of the record, a link to a custodian system where authorised users can view the full details, or both.  
-* Some custodians may provide contact details only.  
-* This explores secure, controlled sharing of small agreed‑upon information packets between systems.  
-* This is not part of Discovery, but Discovery lays the groundwork for understanding whether and how this could be feasible.
-
-### `StubCustodians` (a.k.a. *`Stubs`*)
-* Stub API that simulates real custodians, to provide example data for testing purposes.
-
+### `UI Harness`
+* Lightweight UI built to test interaction with the Get an Identifier function.
 
 ## Record Types Reference
 
@@ -187,7 +171,7 @@ If encountering problems with the .NET dev certificate, run `dotnet dev-certs ht
     docker compose --profile aspire up -d
     docker compose --profile grafana up -d
     ```
-3. Follow the app-specific README to run locally (for example, `Apps/Find/README.md`).
+3. Follow the app-specific README to run locally (for example, `Apps/GetAnIdentifier/README.md`).
 
 ### Local OpenTelemetry
 

--- a/terraform/get-an-identifier/main.tf
+++ b/terraform/get-an-identifier/main.tf
@@ -103,6 +103,31 @@ resource "azurerm_key_vault_access_policy" "terraform_operator" {
   ]
 }
 
+resource "random_password" "get_an_id_api_key" {
+  length  = 32
+  special = true
+}
+
+resource "time_static" "get_an_id_api_key_expiry_base" {}
+
+# Accepted until Alpha while API key and auth decisions are still being worked through.
+#trivy:ignore:AZU-0017
+resource "azurerm_key_vault_secret" "get_an_id_api_key" {
+  name            = "get-an-id-api-key"
+  value           = random_password.get_an_id_api_key.result
+  key_vault_id    = module.key_vault.id
+  content_type    = "text/plain"
+  expiration_date = timeadd(
+    time_static.get_an_id_api_key_expiry_base.rfc3339,
+    format("%dh", var.get_an_id_api_key_ttl_days * 24),
+  )
+
+  depends_on = [
+    module.rbac_assignments_terraform_operator,
+    azurerm_key_vault_access_policy.terraform_operator
+  ]
+}
+
 resource "azurerm_key_vault_secret" "nhs_digital_private_key" {
   name            = "nhs-digital-private-key"
   value           = var.nhs_digital_private_key
@@ -159,7 +184,8 @@ module "function_app" {
       FUNCTIONS_WORKER_RUNTIME = "dotnet-isolated"
       WEBSITE_RUN_FROM_PACKAGE = "1"
       OTEL_RESOURCE_ATTRIBUTES = local.otel_resource_attributes
-      
+
+      GetAnIdentifierFunction__XApiKey       = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.get_an_id_api_key.name}/)"
       NhsAuthConfig__NHS_DIGITAL_PRIVATE_KEY = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_private_key.name}/)"
       NhsAuthConfig__NHS_DIGITAL_KID         = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_kid.name}/)"
       NhsAuthConfig__NHS_DIGITAL_CLIENT_ID   = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.nhs_digital_client_id.name}/)"

--- a/terraform/get-an-identifier/variables.tf
+++ b/terraform/get-an-identifier/variables.tf
@@ -80,6 +80,17 @@ variable "key_vault_use_rbac" {
   default     = false
 }
 
+variable "get_an_id_api_key_ttl_days" {
+  description = "Number of days before the generated Find Match API key secret expires."
+  type        = number
+  default     = 180
+
+  validation {
+    condition     = var.get_an_id_api_key_ttl_days > 0
+    error_message = "get_an_id_api_key_ttl_days must be greater than 0."
+  }
+}
+
 variable "nhs_digital_private_key" {
   description = "Private key for connection with NHS FHIR API"
   type = string

--- a/terraform/ui_test_harness/app/main.tf
+++ b/terraform/ui_test_harness/app/main.tf
@@ -96,9 +96,9 @@ resource "azurerm_key_vault_secret" "ui_harness_password" {
 }
 
 # 3. Look up the Find Secret using the ID from the Find remote state
-data "azurerm_key_vault_secret" "find_match_api_key" {
-  name         = "find-match-api-key"
-  key_vault_id = data.terraform_remote_state.find.outputs.key_vault_id
+data "azurerm_key_vault_secret" "get_an_id_api_key" {
+  name         = "get-an-id-api-key"
+  key_vault_id = data.terraform_remote_state.get-an-identifier.outputs.key_vault_id
 }
 
 # 4. Web App
@@ -130,7 +130,7 @@ module "web_app" {
 
       # Key Vault References mapped to App Settings
       UI_TEST_HARNESS_PASSWORD = "@Microsoft.KeyVault(SecretUri=${module.key_vault.vault_uri}secrets/${azurerm_key_vault_secret.ui_harness_password.name}/)"
-      MATCH_API_KEY            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.find_match_api_key.versionless_id})"
+      GET_API_KEY            = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.get_an_id_api_key.versionless_id})"
     },
     var.ui_harness_app_settings,
 


### PR DESCRIPTION

## Summary

Update READMEs and any other documentation to remove references to find and match, and to reference Get an Identifier. Also update the api key for the get-an-identifier endpoint, and include the secret in azure key vault.

## Changes

- Update README files for new endpoint
- Add api key to get-an-identifier terraform and add to azure key vault 
- Update keyvault rotation workflows to work with new secret

## Validation

- Terraform plan/apply and Key vault rotation workflow for new api key
- No validation needed for docs changes